### PR TITLE
Satisfy template: rename to haskell-mobile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,5 @@
-# Change log for template project
+# Change log for haskell-mobile
 
-## Version 0.0.0 
+## Version 1.0.0
 
-import [template](https://github.com/jappeace/template).
-
+Initial release of haskell-mobile.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Jappie Klooster
+Copyright (c) 2026 Jappie Klooster
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -1,72 +1,8 @@
-[![https://jappieklooster.nl](https://img.shields.io/badge/blog-jappieklooster.nl-lightgrey)](https://jappieklooster.nl/tag/haskell.html)
-[![Github actions build status](https://img.shields.io/github/actions/workflow/status/jappeace/haskell-template-project/nix.yaml?branch=master)](https://github.com/jappeace/haskell-template-project/actions)
-[![Jappiejappie](https://img.shields.io/badge/discord-jappiejappie-black?logo=discord)](https://discord.gg/Hp4agqy)
-[![Hackage version](https://img.shields.io/hackage/v/template.svg?label=Hackage)](https://hackage.haskell.org/package/template) 
+[![Github actions build status](https://img.shields.io/github/actions/workflow/status/jappeace/haskell-mobile/nix.yaml?branch=master)](https://github.com/jappeace/haskell-mobile/actions)
 
-> The eye that looks ahead to the safe course is closed forever.
+> The future belongs to those who believe in the beauty of their dreams.
 
-Haskell project template.
-
-Set up cabal within a nix shell.
-If you like nix this is a good way of doing haskell development.
-
-similar to: https://github.com/monadfix/nix-cabal
-except this has a makefile and ghcid.
-We also make aggressive use of [pinning](https://wiki.nixos.org/wiki/FAQ/Pinning_Nixpkgs)
-ensuring project builds for ever (theoretically).
-
-Comes with:
-+ [GHCID](https://jappieklooster.nl/ghcid-for-multi-package-projects.html)
-+ a nix shell, meaning somewhat platform independence.
-  + which is pinned by default
-+ A couple of handy make commands.
-+ Starting haskell files, assuming we put practically all code in library
-+ Working test suite.
-+ functioining CI (pick your favorite or keep both)
-  + for various platforms with cabal
-
-## Usage
-
-### Modifying for your project
-Assuming the name of your new project is `new-project`.
-
-```
-git clone git@github.com:jappeace/haskell-template-project.git new-project
-cd new-project
-```
-
-+ [ ] Edit template.cabal,
-    + [ ] find and replace template with `new-project`
-    + [ ] Update copyright
-    + [ ] Update github
-+ [ ] rename template.cabal to new-project.cabal
-+ [ ] Edit Changelog.md
-  + [ ] replace template with `new-project`
-  + [ ] Also describe your version 1.0.0 release.
-+ [x] Edit default.nix and shell.nix, replace template with `new-project`.
-+ [ ] Edit copyright in LICENSE
-+ [ ] For automatic bound bumping: In “Settings” → “Actions” → “General” → “Workflow permissions” tick “Allow GitHub Actions to create and approve pull requests”
-
-#### Reconfigure remotes
-```
-git remote add template git@github.com:jappeace/haskell-template-project.git
-git remote set-url origin git@github.com:YOUR-ORG-OR-USER-NAME/new-project.git
-```
-
-We can get template updates like this if we want to by doing `git pull template`.
-There will be a large amount of conflicts, but the merge commit should solve them permanently.
-
-#### Readme
-
-+ [ ] Select desired badges. 
-  + [ ] Point build badges to right project
-+ [ ] Give short project description.
-+ [ ] Add new quote suited for the project.
-  For example for [fakedata-quickcheck](https://github.com/fakedata-haskell/fakedata-quickcheck#readme)
-  I used Kant because
-  he dealt with the question "what is truth" a lot.
-+ [ ] Truncate this checklist
-+ [ ] Truncate motivation for using  this template
+Haskell mobile project.
 
 ### Tools
 Enter the nix shell.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,7 @@
 
 module Main where
 
-import qualified Template
+import qualified HaskellMobile
 
 main :: IO ()
-main = Template.main
+main = HaskellMobile.main

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
 { hpkgs ? import ./nix/hpkgs.nix {}
 ,
 }:
-hpkgs.template-project
+hpkgs.haskell-mobile-project

--- a/haskell-mobile.cabal
+++ b/haskell-mobile.cabal
@@ -1,12 +1,12 @@
 cabal-version:      3.0
 
-name:           template
+name:           haskell-mobile
 version:        1.0.0
-homepage:       https://github.com/jappeace/template#readme
-bug-reports:    https://github.com/jappeace/template/issues
+homepage:       https://github.com/jappeace/haskell-mobile#readme
+bug-reports:    https://github.com/jappeace/haskell-mobile/issues
 author:         Jappie Klooster
 maintainer:     hi@jappie.me
-copyright:      2025 Jappie Klooster
+copyright:      2026 Jappie Klooster
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
@@ -18,7 +18,7 @@ extra-doc-files:
 
 source-repository head
   type: git
-  location: https://github.com/jappeace/template
+  location: https://github.com/jappeace/haskell-mobile
 
 common common-options
   default-extensions: 
@@ -61,9 +61,9 @@ common common-options
 library
   import: common-options
   exposed-modules:
-      Template
+      HaskellMobile
   other-modules:
-      Paths_template
+      Paths_haskell_mobile
   hs-source-dirs:
       src
 
@@ -73,7 +73,7 @@ executable exe
   hs-source-dirs:
       app
   build-depends:
-      template
+      haskell-mobile
   ghc-options: -Wno-unused-packages
 
 test-suite unit
@@ -82,11 +82,11 @@ test-suite unit
   main-is: Test.hs
   ghc-options: -Wno-unused-packages
   other-modules:
-      Paths_template
+      Paths_haskell_mobile
   hs-source-dirs:
       test
   build-depends:
       tasty,
       tasty-hunit,
       tasty-quickcheck,
-      template
+      haskell-mobile

--- a/nix/hpkgs.nix
+++ b/nix/hpkgs.nix
@@ -8,6 +8,6 @@ pkgs.haskellPackages.override {
   overrides = hnew: hold: {
     # NB this is a bit silly because nix files are now considered for the build
     # bigger projects should consider putting haskell stuff in a subfolder
-    template-project = hnew.callCabal2nix "template-project" ../. { };
+    haskell-mobile-project = hnew.callCabal2nix "haskell-mobile" ../. { };
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
   pkgs ? import ./nix/pkgs.nix {},
 }:
 hpkgs.shellFor {
-  packages = ps: [ ps."template-project" ];
+  packages = ps: [ ps."haskell-mobile-project" ];
   withHoogle = false;
 
   buildInputs = [

--- a/src/HaskellMobile.hs
+++ b/src/HaskellMobile.hs
@@ -1,4 +1,4 @@
-module Template
+module HaskellMobile
   ( main
   )
 where

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -5,7 +5,7 @@ import Test.Tasty.QuickCheck as QC
 import Test.Tasty.HUnit
 
 import Data.List(sort)
-import qualified Template
+import qualified HaskellMobile
 
 main :: IO ()
 main = defaultMain tests
@@ -36,5 +36,5 @@ unitTests = testGroup "Unit tests"
   , testCase "List comparison (same length)" $
       oneTwoThree `compare` [1,2,3] @?= EQ
   , testCase "run main" $ do
-      Template.main
+      HaskellMobile.main
   ]


### PR DESCRIPTION
## Summary
- Renamed `template.cabal` → `haskell-mobile.cabal` with all internal references updated
- Renamed `Template` module → `HaskellMobile` (source file + imports)
- Updated nix files (`default.nix`, `shell.nix`, `nix/hpkgs.nix`) to use `haskell-mobile-project`
- Updated `Changelog.md` for v1.0.0, `LICENSE` copyright year, and `Readme.md` badges

## Test plan
- [x] `cabal build` passes on GHC 9.10.3
- [x] `cabal test` — all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)