### PR TITLE
Add iOS IPA build to CI with XcodeGen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
 
   ios:
     runs-on: macos-latest
+    env:
+      HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' && 'true' || 'false' }}
     steps:
     - uses: actions/checkout@v4
     - name: Local cache
@@ -95,6 +97,103 @@ jobs:
         path: |
           result/lib/libHaskellMobile.a
           result/include/HaskellMobile.h
+
+    # --- IPA build (requires Apple signing secrets) ---
+    - name: Stage Haskell library for Xcode
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      run: |
+        mkdir -p ios/lib ios/include
+        cp result/lib/libHaskellMobile.a ios/lib/
+        cp result/include/HaskellMobile.h ios/include/
+
+    - name: Generate Xcode project
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      run: nix-shell -p xcodegen --run "cd ios && xcodegen generate"
+
+    - name: Import signing certificate
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      env:
+        APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      run: |
+        CERT_PATH=$RUNNER_TEMP/certificate.p12
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+        KEYCHAIN_PASSWORD=$(openssl rand -hex 20)
+
+        echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+          -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+        security set-key-partition-list -S apple-tool:,apple: \
+          -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+    - name: Install provisioning profile
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      env:
+        APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+      run: |
+        PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+        echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/
+
+    - name: Build archive
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      env:
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        xcodebuild archive \
+          -project ios/HaskellMobile.xcodeproj \
+          -scheme HaskellMobile \
+          -sdk iphoneos \
+          -archivePath $RUNNER_TEMP/HaskellMobile.xcarchive \
+          CODE_SIGN_STYLE=Manual \
+          DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+          CODE_SIGN_IDENTITY="Apple Distribution" \
+          -allowProvisioningUpdates
+
+    - name: Export IPA
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      env:
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        cat > $RUNNER_TEMP/ExportOptions.plist << PLIST
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>method</key>
+            <string>app-store-connect</string>
+            <key>teamID</key>
+            <string>${APPLE_TEAM_ID}</string>
+            <key>destination</key>
+            <string>export</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+        </dict>
+        </plist>
+        PLIST
+
+        xcodebuild -exportArchive \
+          -archivePath $RUNNER_TEMP/HaskellMobile.xcarchive \
+          -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+          -exportPath $RUNNER_TEMP/ipa-output
+
+    - name: Upload IPA
+      if: env.HAS_SIGNING == 'true' && github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v4
+      with:
+        name: haskell-mobile-ios-ipa
+        path: ${{ runner.temp }}/ipa-output/*.ipa
+
+    - name: Cleanup keychain
+      if: always() && env.HAS_SIGNING == 'true'
+      run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+
     - name: Cancel workflow on failure
       if: failure()
       continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,16 @@ network-uri-lenses.cabal
 dist*
 .#*
 result
+result-*
 TAGS
 
 *.hi
 *.o
 .envrc
+
+# Generated Xcode project (recreated via xcodegen)
+ios/HaskellMobile.xcodeproj/
+
+# Staging dirs populated from nix build output
+ios/lib/
+ios/include/

--- a/Readme.md
+++ b/Readme.md
@@ -1,25 +1,100 @@
-[![Github actions build status](https://img.shields.io/github/actions/workflow/status/jappeace/haskell-mobile/nix.yaml?branch=master)](https://github.com/jappeace/haskell-mobile/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/jappeace/haskell-mobile/ci.yaml?branch=master)](https://github.com/jappeace/haskell-mobile/actions)
 
-> The future belongs to those who believe in the beauty of their dreams.
+# Haskell Mobile
 
-Haskell mobile project.
+Write mobile apps in Haskell.
+This project cross-compiles a Haskell library to Android (APK) and iOS (static library / IPA),
+with a thin platform-native UI layer (Kotlin for Android, Swift for iOS).
 
-### Tools
-Enter the nix shell.
-```
+## Building
+
+### Native (desktop)
+
+Enter the Nix shell and use cabal:
+
+```bash
 nix-shell
-```
-You can checkout the makefile to see what's available:
-```
-cat makefile
+cabal build all
+cabal test all
 ```
 
-### Running
-```
-make run
+Or use the makefile shortcuts (`make build`, `make test`, `make ghcid`).
+
+### Android APK
+
+```bash
+nix-build nix/android.nix   # cross-compiled Haskell library
+nix-build nix/apk.nix       # full APK
 ```
 
-### Fast filewatch which runs tests
+The APK is written to `result/haskell-mobile.apk`.
+
+### iOS static library
+
+Requires macOS (same ISA as iOS aarch64):
+
+```bash
+nix-build nix/ios.nix
 ```
-make ghcid
+
+Produces `result/lib/libHaskellMobile.a` and `result/include/HaskellMobile.h`.
+
+### iOS app (local dev)
+
+After building the static library, generate an Xcode project with [XcodeGen](https://github.com/yonaskolb/XcodeGen):
+
+```bash
+# Stage the Haskell library where the Xcode project expects it
+mkdir -p ios/lib ios/include
+cp result/lib/libHaskellMobile.a ios/lib/
+cp result/include/HaskellMobile.h ios/include/
+
+# Generate and open
+nix-shell -p xcodegen --run "cd ios && xcodegen generate"
+open ios/HaskellMobile.xcodeproj
+```
+
+Configure signing in Xcode (team, bundle ID, provisioning profile), then build and run.
+
+## Installing
+
+### Android
+
+```bash
+adb install result/haskell-mobile.apk
+```
+
+### iOS
+
+Use Xcode to deploy to a connected device, or download the IPA artifact from the
+[CI Actions page](https://github.com/jappeace/haskell-mobile/actions) (master builds only, when signing secrets are configured).
+
+## CI
+
+The GitHub Actions workflow runs four jobs:
+
+| Job | Platform | What it does |
+|-----|----------|--------------|
+| `nix` | Linux | `nix-build` + `nix-shell` smoke test |
+| `android` | Linux | Cross-compile to Android, build APK (master) |
+| `ios` | macOS | Cross-compile to iOS static lib, build IPA if signing secrets are set (master) |
+| `cabal` | Linux/macOS/Windows | GHC 9.6 / 9.8 / 9.10 / 9.12 matrix build + tests |
+
+### iOS signing secrets
+
+The IPA build is conditional: without secrets, CI only builds the static library.
+To enable IPA builds, add these repository secrets:
+
+| Secret | Description |
+|--------|-------------|
+| `APPLE_CERTIFICATE_BASE64` | Base64-encoded `.p12` distribution certificate |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` file |
+| `APPLE_PROVISIONING_PROFILE_BASE64` | Base64-encoded `.mobileprovision` file |
+| `APPLE_TEAM_ID` | Apple Developer Team ID |
+
+Generate the base64 values with:
+
+```bash
+base64 -i Certificates.p12 | pbcopy
+base64 -i App.mobileprovision | pbcopy
 ```

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,19 @@
+name: HaskellMobile
+options:
+  bundleIdPrefix: me.jappie
+  deploymentTarget:
+    iOS: "15.0"
+
+targets:
+  HaskellMobile:
+    type: application
+    platform: iOS
+    sources:
+      - HaskellMobile
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: me.jappie.haskellmobile
+        SWIFT_OBJC_BRIDGING_HEADER: HaskellMobile/HaskellMobile-Bridging-Header.h
+        LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
+        HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++"]


### PR DESCRIPTION
## Summary
- Add conditional IPA build pipeline to the iOS CI job using xcodegen (from nixpkgs) + system xcodebuild
- Create `ios/project.yml` XcodeGen spec linking the Haskell static lib with correct search paths and GHC RTS linker flags
- All IPA steps gated on `APPLE_CERTIFICATE_BASE64` secret + master branch — CI works unchanged without Apple credentials
- Rewrite `Readme.md` with build/install instructions for both Android and iOS, plus CI overview and signing secrets docs
- Update `.gitignore` for generated xcodeproj and staging directories

## Test plan
- [ ] CI passes without Apple signing secrets (IPA steps skipped, `.a` still built)
- [ ] `ios/project.yml` generates valid Xcode project via `xcodegen generate`
- [ ] Readme accurately describes both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)