### PR TITLE
Use weak symbol for haskellUseScrollDemo in jni_bridge.c

### DIFF
--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -24,7 +24,12 @@ extern void haskellOnLifecycle(void *ctx, int eventType);
 extern void haskellRenderUI(void *ctx);
 extern void haskellOnUIEvent(void *ctx, int callbackId);
 extern void haskellOnUITextChange(void *ctx, int callbackId, const char *text);
-extern void haskellUseScrollDemo(void);
+
+/* Weak default for apps that don't provide a scroll-demo.
+ * Apps that want useScrollDemo to do something meaningful should define
+ * haskellUseScrollDemo via 'foreign export ccall' in their Haskell source,
+ * which overrides this no-op at link time. */
+void __attribute__((weak)) haskellUseScrollDemo(void) {}
 
 /* Android UI bridge (from ui_bridge_android.c) */
 extern void setup_android_ui_bridge(JNIEnv *env, jobject activity, void *haskellCtx);


### PR DESCRIPTION
## Summary

- `haskellUseScrollDemo` was declared `extern` in `jni_bridge.c`, which forced every app using haskell-mobile as a library to export that symbol from Haskell
- Apps that replace `HaskellMobile/App.hs` via `extraModuleCopy` (e.g. `prrrrrrrrr`) and don't provide a scroll demo would get an `UnsatisfiedLinkError` at startup when Android's dynamic linker tried to load the `.so`
- Fix: define `haskellUseScrollDemo` with `__attribute__((weak))` as a no-op fallback; apps that export it from Haskell override it, apps that don't need it link cleanly

## Test plan

- [ ] Existing haskell-mobile CI (emulator scroll test) should still pass — `App.hs` exports `haskellUseScrollDemo` which overrides the weak default
- [ ] Apps that replace `App.hs` and do not export `haskellUseScrollDemo` now link without error (verified by prrrrrrrrr#7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)