### PR TITLE
Add retry mechanism to emulator/simulator tests

### DIFF
--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -240,15 +240,38 @@ export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK PACKAGE ACTIVITY WORK_DIR
 PHASE1_EXIT=0
 PHASE2_EXIT=0
 
+# run_with_retry LABEL COMMAND [ARGS...]
+# Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
+run_with_retry() {
+    local label="$1"; shift
+    local max_attempts=10
+    local attempt=1
+    while [ $attempt -le $max_attempts ]; do
+        echo "[$label] attempt $attempt/$max_attempts"
+        if "$@"; then
+            echo "[$label] PASSED on attempt $attempt"
+            return 0
+        fi
+        echo "[$label] attempt $attempt FAILED"
+        attempt=$((attempt + 1))
+        if [ $attempt -le $max_attempts ]; then
+            echo "[$label] retrying in 5s..."
+            sleep 5
+        fi
+    done
+    echo "[$label] FAILED after $max_attempts attempts"
+    return 1
+}
+
 echo ""
 echo "--- lifecycle ---"
-bash "$TEST_SCRIPTS/android/lifecycle.sh" || PHASE1_EXIT=1
+run_with_retry "lifecycle" bash "$TEST_SCRIPTS/android/lifecycle.sh" || PHASE1_EXIT=1
 echo "--- ui ---"
-bash "$TEST_SCRIPTS/android/ui.sh"        || PHASE1_EXIT=1
+run_with_retry "ui"        bash "$TEST_SCRIPTS/android/ui.sh"        || PHASE1_EXIT=1
 echo "--- buttons ---"
-bash "$TEST_SCRIPTS/android/buttons.sh"   || PHASE1_EXIT=1
+run_with_retry "buttons"   bash "$TEST_SCRIPTS/android/buttons.sh"   || PHASE1_EXIT=1
 echo "--- scroll ---"
-bash "$TEST_SCRIPTS/android/scroll.sh"    || PHASE2_EXIT=1
+run_with_retry "scroll"    bash "$TEST_SCRIPTS/android/scroll.sh"    || PHASE2_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -224,15 +224,38 @@ export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP WORK_DIR
 PHASE1_EXIT=0
 PHASE2_EXIT=0
 
+# run_with_retry LABEL COMMAND [ARGS...]
+# Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
+run_with_retry() {
+    local label="$1"; shift
+    local max_attempts=10
+    local attempt=1
+    while [ $attempt -le $max_attempts ]; do
+        echo "[$label] attempt $attempt/$max_attempts"
+        if "$@"; then
+            echo "[$label] PASSED on attempt $attempt"
+            return 0
+        fi
+        echo "[$label] attempt $attempt FAILED"
+        attempt=$((attempt + 1))
+        if [ $attempt -le $max_attempts ]; then
+            echo "[$label] retrying in 5s..."
+            sleep 5
+        fi
+    done
+    echo "[$label] FAILED after $max_attempts attempts"
+    return 1
+}
+
 echo ""
 echo "--- lifecycle ---"
-bash "$TEST_SCRIPTS/ios/lifecycle.sh" || PHASE1_EXIT=1
+run_with_retry "lifecycle" bash "$TEST_SCRIPTS/ios/lifecycle.sh" || PHASE1_EXIT=1
 echo "--- ui ---"
-bash "$TEST_SCRIPTS/ios/ui.sh"        || PHASE1_EXIT=1
+run_with_retry "ui"        bash "$TEST_SCRIPTS/ios/ui.sh"        || PHASE1_EXIT=1
 echo "--- buttons ---"
-bash "$TEST_SCRIPTS/ios/buttons.sh"   || PHASE1_EXIT=1
+run_with_retry "buttons"   bash "$TEST_SCRIPTS/ios/buttons.sh"   || PHASE1_EXIT=1
 echo "--- scroll ---"
-bash "$TEST_SCRIPTS/ios/scroll.sh"    || PHASE2_EXIT=1
+run_with_retry "scroll"    bash "$TEST_SCRIPTS/ios/scroll.sh"    || PHASE2_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Adds `run_with_retry` shell function to both `nix/emulator-all.nix` and `nix/simulator-all.nix`
- Each test script (lifecycle, ui, buttons, scroll) retries up to 10 times before failing
- 5s delay between retries for emulator/simulator stabilization
- Prevents flaky CI failures (e.g. "setRoot not found after 120s") from blocking merges

## Test plan
- [ ] `nix-build nix/ci.nix` builds successfully
- [ ] CI emulator tests pass on GitHub Actions
- [ ] CI simulator tests pass on GitHub Actions
- [ ] Verify retry logging appears in CI output on first-pass success (`[lifecycle] PASSED on attempt 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)