### PR TITLE
Split CI: separate nix builds from emulator runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+        df -h
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  nix-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          extra-substituters = https://nix-cache.jappie.me
+          extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+    - name: Nix store cache
+      uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-build-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
+        restore-prefixes-first-match: nix-build-
+        gc-max-store-size-linux: 8G
+    - name: Build all nix targets (excludes emulator/simulator runners)
+      run: nix-build nix/ci.nix -A all-builds
+    - name: Cancel workflow on failure
+      if: failure()
+      continue-on-error: true
+      run: gh run cancel ${{ github.run_id }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+
   android:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -29,7 +55,6 @@ jobs:
         primary-key: nix-android-aarch64-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
         restore-prefixes-first-match: nix-android-aarch64-
         gc-max-store-size-linux: 8G
-    - run: nix-build nix/ci.nix
     - name: Run combined emulator test (lifecycle + UI + buttons + scroll)
       run: nix-build nix/ci.nix -A emulator-all -o result-emulator-all && ./result-emulator-all/bin/test-all
     - name: Cancel workflow on failure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+        df -h
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
       with:
@@ -69,6 +73,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+        df -h
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
       with:

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -2,26 +2,46 @@
 let
   isDarwin = builtins.currentSystem == "aarch64-darwin"
           || builtins.currentSystem == "x86_64-darwin";
-in {
-  # Build artifacts
-  native = import ../default.nix {};
-  android-aarch64 = import ./android.nix { inherit sources; };
-  android-armv7a = import ./android.nix { inherit sources; androidArch = "armv7a"; };
-  apk = import ./apk.nix { inherit sources; };
-  consumer-link-test = import ./test-link-consumer.nix { inherit sources; };
-  consumer-deps-test = import ./test-consumer-deps.nix { inherit sources; };
+  pkgs = import sources.nixpkgs {};
 
-  # Android combined test script (boot + run via CI: nix-build ... -o out && ./out/bin/test-all)
-  emulator-all = import ./emulator-all.nix { inherit sources; };
-  # armv7a (armeabi-v7a) emulator test — covers Wear OS watches (32-bit ARM)
-  emulator-armv7a = import ./emulator-all.nix { inherit sources; androidArch = "armv7a"; };
-} // (if isDarwin then {
-  # iOS library for artifact upload
-  ios-lib = import ./ios.nix { inherit sources; };
-  # iOS combined test script (boot + run via CI: nix-build ... -o out && ./out/bin/test-all-ios)
-  simulator-all = import ./simulator-all.nix { inherit sources; };
-  # watchOS library for artifact upload
-  watchos-lib = import ./watchos.nix { inherit sources; };
-  # watchOS combined test script (boot + run via CI)
-  watchos-simulator-all = import ./watchos-simulator-all.nix { inherit sources; };
-} else {})
+  # Compilation and link-test targets.
+  # New targets added here are automatically picked up by `all-builds`.
+  buildTargets = {
+    native = import ../default.nix {};
+    android-aarch64 = import ./android.nix { inherit sources; };
+    android-armv7a = import ./android.nix { inherit sources; androidArch = "armv7a"; };
+    apk = import ./apk.nix { inherit sources; };
+    consumer-link-test = import ./test-link-consumer.nix { inherit sources; };
+    consumer-deps-test = import ./test-consumer-deps.nix { inherit sources; };
+  } // (if isDarwin then {
+    ios-lib = import ./ios.nix { inherit sources; };
+    watchos-lib = import ./watchos.nix { inherit sources; };
+  } else {});
+
+  # Emulator/simulator test runners — heavy (include system images),
+  # need dedicated CI jobs with enough disk space.
+  testRunners = {
+    emulator-all = import ./emulator-all.nix { inherit sources; };
+    emulator-armv7a = import ./emulator-all.nix {
+      inherit sources; androidArch = "armv7a";
+    };
+  } // (if isDarwin then {
+    simulator-all = import ./simulator-all.nix { inherit sources; };
+    watchos-simulator-all = import ./watchos-simulator-all.nix {
+      inherit sources;
+    };
+  } else {});
+
+in
+  buildTargets // testRunners // {
+    # Meta-target: builds every compilation/link-test target.
+    # Excludes emulator/simulator runners (they have dedicated CI jobs).
+    # Adding a new attr to buildTargets automatically includes it here.
+    all-builds = pkgs.runCommand "ci-all-builds" {} ''
+      mkdir -p $out
+      ${builtins.concatStringsSep "\n" (
+        builtins.map (name: "ln -s ${buildTargets.${name}} $out/${name}")
+          (builtins.attrNames buildTargets)
+      )}
+    '';
+  }


### PR DESCRIPTION
## Summary
- Splits the `android` CI job into a new `nix-build` job (all compilation/link targets) and emulator-only `android` job
- Adds `all-builds` meta-target in `nix/ci.nix` that auto-includes new build attributes via symlinks
- Fixes disk exhaustion from PR #114 by not building emulator system images (~2-3 GB each) alongside all cross-compiled targets

## Test plan
- [x] `nix-instantiate nix/ci.nix -A all-builds` evaluates without error
- [x] `nix-instantiate nix/ci.nix -A emulator-all` still works
- [x] `nix-instantiate nix/ci.nix -A native` individual attrs still work
- [ ] CI `nix-build` job passes without disk exhaustion
- [ ] CI `android` emulator job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)