### PR TITLE
Add WebView widget (#76)

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="34" />
 
+    <!-- WebView requires internet access -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <!-- Runtime permissions (requested at runtime via Permission API) -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/android/java/me/jappie/haskellmobile/HaskellMobileActivity.java
+++ b/android/java/me/jappie/haskellmobile/HaskellMobileActivity.java
@@ -19,6 +19,8 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.EditText;
 
 /**
@@ -358,6 +360,20 @@ public class HaskellMobileActivity extends Activity implements View.OnClickListe
     @Override
     public void onClick(View v) {
         onButtonClick(v);
+    }
+
+    /**
+     * Register a WebViewClient on a WebView. Called from native code
+     * when a WebView widget has an EventClick (page-load) handler.
+     * The client fires onButtonClick when a page finishes loading.
+     */
+    public void registerWebViewClient(final WebView webView) {
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                onButtonClick(view);
+            }
+        });
     }
 
     /**

--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -54,6 +54,7 @@ static jclass   g_class_EditText;
 static jclass   g_class_LinearLayout;
 static jclass   g_class_ScrollView;
 static jclass   g_class_ImageView;
+static jclass   g_class_WebView;
 static jclass   g_class_BitmapFactory;
 static jclass   g_class_ViewGroup;
 static jclass   g_class_ViewGroup_LayoutParams;
@@ -65,6 +66,7 @@ static jmethodID g_ctor_EditText;
 static jmethodID g_ctor_LinearLayout;
 static jmethodID g_ctor_ScrollView;
 static jmethodID g_ctor_ImageView;
+static jmethodID g_ctor_WebView;
 static jmethodID g_ctor_ViewGroup_LayoutParams;
 static jmethodID g_ctor_Integer;
 
@@ -92,6 +94,10 @@ static jmethodID g_method_setImageBitmap;
 static jmethodID g_method_setScaleType;
 static jmethodID g_method_decodeByteArray;
 static jmethodID g_method_decodeFile;
+static jmethodID g_method_loadUrl;
+static jmethodID g_method_getSettings;
+static jmethodID g_method_setJavaScriptEnabled;
+static jmethodID g_method_registerWebViewClient;
 
 /* LinearLayout orientation constants */
 static jint ORIENTATION_VERTICAL   = 1;
@@ -152,6 +158,10 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     if (!cls) return -1;
     g_class_ImageView = (*env)->NewGlobalRef(env, cls);
 
+    cls = (*env)->FindClass(env, "android/webkit/WebView");
+    if (!cls) return -1;
+    g_class_WebView = (*env)->NewGlobalRef(env, cls);
+
     cls = (*env)->FindClass(env, "android/graphics/BitmapFactory");
     if (!cls) return -1;
     g_class_BitmapFactory = (*env)->NewGlobalRef(env, cls);
@@ -180,6 +190,8 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     g_ctor_ScrollView = (*env)->GetMethodID(env, g_class_ScrollView,
         "<init>", "(Landroid/content/Context;)V");
     g_ctor_ImageView = (*env)->GetMethodID(env, g_class_ImageView,
+        "<init>", "(Landroid/content/Context;)V");
+    g_ctor_WebView = (*env)->GetMethodID(env, g_class_WebView,
         "<init>", "(Landroid/content/Context;)V");
     g_ctor_ViewGroup_LayoutParams = (*env)->GetMethodID(env,
         g_class_ViewGroup_LayoutParams, "<init>", "(II)V");
@@ -275,6 +287,32 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     /* BitmapFactory.decodeFile(String) -> Bitmap */
     g_method_decodeFile = (*env)->GetStaticMethodID(env, g_class_BitmapFactory,
         "decodeFile", "(Ljava/lang/String;)Landroid/graphics/Bitmap;");
+
+    /* WebView.loadUrl(String) */
+    g_method_loadUrl = (*env)->GetMethodID(env, g_class_WebView,
+        "loadUrl", "(Ljava/lang/String;)V");
+
+    /* WebView.getSettings() -> WebSettings */
+    g_method_getSettings = (*env)->GetMethodID(env, g_class_WebView,
+        "getSettings", "()Landroid/webkit/WebSettings;");
+
+    /* WebSettings.setJavaScriptEnabled(boolean) */
+    {
+        jclass webSettingsClass = (*env)->FindClass(env, "android/webkit/WebSettings");
+        if (webSettingsClass) {
+            g_method_setJavaScriptEnabled = (*env)->GetMethodID(env, webSettingsClass,
+                "setJavaScriptEnabled", "(Z)V");
+            (*env)->DeleteLocalRef(env, webSettingsClass);
+        }
+    }
+
+    /* Activity.registerWebViewClient(WebView) — our custom Java method */
+    g_method_registerWebViewClient = (*env)->GetMethodID(env, actClass,
+        "registerWebViewClient", "(Landroid/webkit/WebView;)V");
+    if (!g_method_registerWebViewClient) {
+        LOGE("registerWebViewClient not found — webview page-load events disabled");
+        (*env)->ExceptionClear(env);
+    }
 
     /* Clear any pending exception from optional method lookups above */
     if ((*env)->ExceptionCheck(env)) {
@@ -394,6 +432,17 @@ static int32_t android_create_node(int32_t nodeType)
     case UI_NODE_IMAGE:
         view = (*env)->NewObject(env, g_class_ImageView, g_ctor_ImageView, g_activity);
         break;
+    case UI_NODE_WEBVIEW: {
+        view = (*env)->NewObject(env, g_class_WebView, g_ctor_WebView, g_activity);
+        if (view && g_method_getSettings && g_method_setJavaScriptEnabled) {
+            jobject settings = (*env)->CallObjectMethod(env, view, g_method_getSettings);
+            if (settings) {
+                (*env)->CallVoidMethod(env, settings, g_method_setJavaScriptEnabled, JNI_TRUE);
+                (*env)->DeleteLocalRef(env, settings);
+            }
+        }
+        break;
+    }
     default:
         LOGE("Unknown node type: %d", nodeType);
         return 0;
@@ -496,6 +545,15 @@ static void android_set_str_prop(int32_t nodeId, int32_t propId, const char *val
                 LOGE("Failed to decode file: %s", value);
             }
             (*env)->DeleteLocalRef(env, jpath);
+        }
+        break;
+    }
+    case UI_PROP_WEBVIEW_URL: {
+        LOGI("setStrProp(node=%d, webviewUrl=\"%s\")", nodeId, value);
+        if ((*env)->IsInstanceOf(env, view, g_class_WebView)) {
+            jstring jurl = (*env)->NewStringUTF(env, value);
+            (*env)->CallVoidMethod(env, view, g_method_loadUrl, jurl);
+            (*env)->DeleteLocalRef(env, jurl);
         }
         break;
     }
@@ -634,8 +692,18 @@ static void android_set_handler(int32_t nodeId, int32_t eventType, int32_t callb
 
     switch (eventType) {
     case UI_EVENT_CLICK:
-        /* Register the Activity (which implements OnClickListener) as handler */
-        (*env)->CallVoidMethod(env, view, g_method_setOnClickListener, g_activity);
+        if ((*env)->IsInstanceOf(env, view, g_class_WebView)) {
+            /* Register a WebViewClient via our Java helper for page-load callbacks */
+            if (g_method_registerWebViewClient) {
+                (*env)->CallVoidMethod(env, g_activity, g_method_registerWebViewClient, view);
+                LOGI("setHandler(node=%d, webview-pageload, callback=%d)", nodeId, callbackId);
+            } else {
+                LOGE("setHandler: registerWebViewClient unavailable, skipping node=%d", nodeId);
+            }
+        } else {
+            /* Register the Activity (which implements OnClickListener) as handler */
+            (*env)->CallVoidMethod(env, view, g_method_setOnClickListener, g_activity);
+        }
         LOGI("setHandler(node=%d, click, callback=%d)", nodeId, callbackId);
         break;
     case UI_EVENT_TEXT_CHANGE:

--- a/include/UIBridge.h
+++ b/include/UIBridge.h
@@ -11,6 +11,7 @@
 #define UI_NODE_TEXT_INPUT  4
 #define UI_NODE_SCROLL_VIEW 5
 #define UI_NODE_IMAGE       6
+#define UI_NODE_WEBVIEW     8
 
 /* Property IDs for string properties */
 #define UI_PROP_TEXT            0
@@ -19,6 +20,7 @@
 #define UI_PROP_BG_COLOR        3
 #define UI_PROP_IMAGE_RESOURCE  4
 #define UI_PROP_IMAGE_FILE      5
+#define UI_PROP_WEBVIEW_URL     6
 
 /* Property IDs for numeric properties */
 #define UI_PROP_FONT_SIZE   0

--- a/ios/HaskellMobile/UIBridgeIOS.m
+++ b/ios/HaskellMobile/UIBridgeIOS.m
@@ -9,7 +9,9 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 #import <os/log.h>
+#import <objc/runtime.h>
 #include <stdlib.h>
 #include <string.h>
 #include "UIBridge.h"
@@ -84,6 +86,20 @@ static UIViewController *g_viewController = nil;
     NSString *text = sender.text ?: @"";
     LOGI("TextChange dispatched: callbackId=%d text=\"%{public}s\"", callbackId, [text UTF8String]);
     haskellOnUITextChange(self.haskellCtx, callbackId, [text UTF8String]);
+}
+
+@end
+
+/* ---- WKWebView navigation delegate for page-load callbacks ---- */
+@interface HMWebViewDelegate : NSObject <WKNavigationDelegate>
+@property (nonatomic, assign) int32_t callbackId;
+@end
+
+@implementation HMWebViewDelegate
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    LOGI("WebView page loaded: callbackId=%d", self.callbackId);
+    haskellOnUIEvent([IOSBridgeHandler shared].haskellCtx, self.callbackId);
 }
 
 @end
@@ -273,6 +289,13 @@ static int32_t ios_create_node(int32_t nodeType)
         view = imageView;
         break;
     }
+    case UI_NODE_WEBVIEW: {
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
+        webView.translatesAutoresizingMaskIntoConstraints = NO;
+        view = webView;
+        break;
+    }
     case UI_NODE_SCROLL_VIEW: {
         UIScrollView *scrollView = [[UIScrollView alloc] init];
         scrollView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -392,6 +415,19 @@ static void ios_set_str_prop(int32_t nodeId, int32_t propId, const char *value)
             } else {
                 LOGE("Failed to load image file: %{public}s", value);
                 ios_set_image_placeholder((UIImageView *)view, "Image not found");
+            }
+        }
+        break;
+    }
+    case UI_PROP_WEBVIEW_URL: {
+        LOGI("setStrProp(node=%d, webviewUrl=\"%{public}s\")", nodeId, value);
+        if ([view isKindOfClass:[WKWebView class]]) {
+            NSURL *url = [NSURL URLWithString:str];
+            if (url) {
+                NSURLRequest *request = [NSURLRequest requestWithURL:url];
+                [(WKWebView *)view loadRequest:request];
+            } else {
+                LOGE("Invalid URL: %{public}s", value);
             }
         }
         break;
@@ -518,7 +554,17 @@ static void ios_set_handler(int32_t nodeId, int32_t eventType, int32_t callbackI
     switch (eventType) {
     case UI_EVENT_CLICK:
         view.tag = callbackId;
-        LOGI("setHandler(node=%d, click, callback=%d)", nodeId, callbackId);
+        if ([view isKindOfClass:[WKWebView class]]) {
+            HMWebViewDelegate *delegate = [[HMWebViewDelegate alloc] init];
+            delegate.callbackId = callbackId;
+            ((WKWebView *)view).navigationDelegate = delegate;
+            /* Prevent ARC from deallocating the delegate by associating it with the view */
+            objc_setAssociatedObject(view, "HMWebViewDelegate", delegate,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            LOGI("setHandler(node=%d, webview-pageload, callback=%d)", nodeId, callbackId);
+        } else {
+            LOGI("setHandler(node=%d, click, callback=%d)", nodeId, callbackId);
+        }
         break;
     case UI_EVENT_TEXT_CHANGE:
         view.tag = callbackId;

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,4 +30,4 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: HaskellMobile/HaskellMobile-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit"]

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -138,6 +138,17 @@ let
     name = "haskell-mobile-location-apk";
   };
 
+  webviewAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/WebViewDemoMain.hs;
+  };
+  webviewApk = lib.mkApk {
+    sharedLibs = [{ lib = webviewAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "haskell-mobile-webview.apk";
+    name = "haskell-mobile-webview-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -186,6 +197,7 @@ NODEPOOL_APK="${nodepoolApk}/haskell-mobile-nodepool.apk"
 BLE_APK="${bleApk}/haskell-mobile-ble.apk"
 DIALOG_APK="${dialogApk}/haskell-mobile-dialog.apk"
 LOCATION_APK="${locationApk}/haskell-mobile-location.apk"
+WEBVIEW_APK="${webviewApk}/haskell-mobile-webview.apk"
 PACKAGE="me.jappie.haskellmobile"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -205,7 +217,8 @@ for so_path in \
     "${imageAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${nodepoolAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${bleAndroid}/lib/${abiDir}/libhaskellmobile.so" \
-    "${dialogAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
+    "${dialogAndroid}/lib/${abiDir}/libhaskellmobile.so" \
+    "${webviewAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -267,6 +280,7 @@ PHASE5_OK=0
 PHASE6_OK=0
 PHASE7_OK=0
 PHASE8_OK=0
+PHASE9_OK=0
 
 cleanup() {
     echo ""
@@ -383,7 +397,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -393,6 +407,7 @@ PHASE5_EXIT=0
 PHASE6_EXIT=0
 PHASE7_EXIT=0
 PHASE8_EXIT=0
+PHASE9_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -453,6 +468,8 @@ echo "--- dialog ---"
 run_with_retry "dialog" bash "$TEST_SCRIPTS/android/dialog.sh" || PHASE8_EXIT=1
 echo "--- location ---"
 run_with_retry "location" bash "$TEST_SCRIPTS/android/location.sh" || PHASE7_EXIT=1
+echo "--- webview ---"
+run_with_retry "webview" bash "$TEST_SCRIPTS/android/webview.sh" || PHASE9_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -533,6 +550,16 @@ else
     echo "PHASE 8 FAILED"
 fi
 
+if [ $PHASE9_EXIT -eq 0 ]; then
+    PHASE9_OK=1
+    echo ""
+    echo "PHASE 9 PASSED"
+else
+    PHASE9_OK=0
+    echo ""
+    echo "PHASE 9 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -596,6 +623,13 @@ if [ $PHASE8_OK -eq 1 ]; then
     echo "PASS  Phase 8 — Dialog demo app"
 else
     echo "FAIL  Phase 8 — Dialog demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE9_OK -eq 1 ]; then
+    echo "PASS  Phase 9 — WebView demo app"
+else
+    echo "FAIL  Phase 9 — WebView demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -122,6 +122,17 @@ let
     name = "haskell-mobile-location-simulator-app";
   };
 
+  webviewIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/WebViewDemoMain.hs;
+    simulator = true;
+  };
+  webviewSimApp = lib.mkSimulatorApp {
+    iosLib = webviewIos;
+    iosSrc = ../ios;
+    name = "haskell-mobile-webview-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -152,6 +163,7 @@ NODEPOOL_SHARE_DIR="${nodepoolSimApp}/share/ios"
 BLE_SHARE_DIR="${bleSimApp}/share/ios"
 DIALOG_SHARE_DIR="${dialogSimApp}/share/ios"
 LOCATION_SHARE_DIR="${locationSimApp}/share/ios"
+WEBVIEW_SHARE_DIR="${webviewSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -167,6 +179,7 @@ PHASE5_OK=0
 PHASE6_OK=0
 PHASE7_OK=0
 PHASE8_OK=0
+PHASE9_OK=0
 
 cleanup() {
     echo ""
@@ -616,6 +629,45 @@ if [ -z "$LOCATION_APP" ]; then
 fi
 echo "Location app: $LOCATION_APP"
 
+# --- Stage and build webview demo app ---
+echo "=== Staging webview demo app ==="
+mkdir -p "$WORK_DIR/webview/lib" "$WORK_DIR/webview/include"
+cp "$WEBVIEW_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/webview/lib/"
+cp "$WEBVIEW_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/webview/include/"
+cp -r "$WEBVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/webview/"
+cp "$WEBVIEW_SHARE_DIR/project.yml" "$WORK_DIR/webview/"
+chmod -R u+w "$WORK_DIR/webview"
+
+echo "=== Generating webview Xcode project ==="
+cd "$WORK_DIR/webview"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building webview demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/webview-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+WEBVIEW_APP=$(find "$WORK_DIR/webview-build" -name "*.app" -type d | head -1)
+if [ -z "$WEBVIEW_APP" ]; then
+    echo "ERROR: Could not find webview .app bundle"
+    exit 1
+fi
+echo "WebView app: $WEBVIEW_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -677,7 +729,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -687,6 +739,7 @@ PHASE5_EXIT=0
 PHASE6_EXIT=0
 PHASE7_EXIT=0
 PHASE8_EXIT=0
+PHASE9_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -747,6 +800,8 @@ echo "--- dialog ---"
 run_with_retry "dialog" bash "$TEST_SCRIPTS/ios/dialog.sh" || PHASE8_EXIT=1
 echo "--- location ---"
 run_with_retry "location" bash "$TEST_SCRIPTS/ios/location.sh" || PHASE7_EXIT=1
+echo "--- webview ---"
+run_with_retry "webview" bash "$TEST_SCRIPTS/ios/webview.sh" || PHASE9_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -827,6 +882,16 @@ else
     echo "PHASE 8 FAILED"
 fi
 
+if [ $PHASE9_EXIT -eq 0 ]; then
+    PHASE9_OK=1
+    echo ""
+    echo "PHASE 9 PASSED"
+else
+    PHASE9_OK=0
+    echo ""
+    echo "PHASE 9 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -890,6 +955,13 @@ if [ $PHASE8_OK -eq 1 ]; then
     echo "PASS  Phase 8 — Dialog demo app"
 else
     echo "FAIL  Phase 8 — Dialog demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE9_OK -eq 1 ]; then
+    echo "PASS  Phase 9 — WebView demo app"
+else
+    echo "FAIL  Phase 9 — WebView demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -112,6 +112,17 @@ let
     name = "haskell-mobile-watchos-location-simulator-app";
   };
 
+  webviewWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/WebViewDemoMain.hs;
+    simulator = true;
+  };
+  webviewSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = webviewWatchos;
+    watchosSrc = ../watchos;
+    name = "haskell-mobile-watchos-webview-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -141,6 +152,7 @@ NODEPOOL_SHARE_DIR="${nodepoolSimApp}/share/watchos"
 BLE_SHARE_DIR="${bleSimApp}/share/watchos"
 DIALOG_SHARE_DIR="${dialogSimApp}/share/watchos"
 LOCATION_SHARE_DIR="${locationSimApp}/share/watchos"
+WEBVIEW_SHARE_DIR="${webviewSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -155,6 +167,7 @@ PHASE4_OK=0
 PHASE5_OK=0
 PHASE6_OK=0
 PHASE7_OK=0
+PHASE8_OK=0
 
 cleanup() {
     echo ""
@@ -562,6 +575,45 @@ if [ -z "$LOCATION_APP" ]; then
 fi
 echo "Location app: $LOCATION_APP"
 
+# --- Stage and build webview demo app ---
+echo "=== Staging webview demo app ==="
+mkdir -p "$WORK_DIR/webview/lib" "$WORK_DIR/webview/include"
+cp "$WEBVIEW_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/webview/lib/"
+cp "$WEBVIEW_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/webview/include/"
+cp -r "$WEBVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/webview/"
+cp "$WEBVIEW_SHARE_DIR/project.yml" "$WORK_DIR/webview/"
+chmod -R u+w "$WORK_DIR/webview"
+
+echo "=== Generating webview Xcode project ==="
+cd "$WORK_DIR/webview"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building webview demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/webview-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+WEBVIEW_APP=$(find "$WORK_DIR/webview-build" -name "*.app" -type d | head -1)
+if [ -z "$WEBVIEW_APP" ]; then
+    echo "ERROR: Could not find webview .app bundle"
+    exit 1
+fi
+echo "WebView app: $WEBVIEW_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -625,7 +677,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.haskellmobile"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -634,6 +686,7 @@ PHASE4_EXIT=0
 PHASE5_EXIT=0
 PHASE6_EXIT=0
 PHASE7_EXIT=0
+PHASE8_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -685,6 +738,8 @@ echo "--- dialog ---"
 run_with_retry "dialog" bash "$TEST_SCRIPTS/watchos/dialog.sh" || PHASE7_EXIT=1
 echo "--- location ---"
 run_with_retry "location" bash "$TEST_SCRIPTS/watchos/location.sh" || PHASE6_EXIT=1
+echo "--- webview ---"
+run_with_retry "webview" bash "$TEST_SCRIPTS/watchos/webview.sh" || PHASE8_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -755,6 +810,16 @@ else
     echo "PHASE 7 FAILED"
 fi
 
+if [ $PHASE8_EXIT -eq 0 ]; then
+    PHASE8_OK=1
+    echo ""
+    echo "PHASE 8 PASSED"
+else
+    PHASE8_OK=0
+    echo ""
+    echo "PHASE 8 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -811,6 +876,13 @@ if [ $PHASE7_OK -eq 1 ]; then
     echo "PASS  Phase 7 — Dialog demo app"
 else
     echo "FAIL  Phase 7 — Dialog demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE8_OK -eq 1 ]; then
+    echo "PASS  Phase 8 — WebView demo app"
+else
+    echo "FAIL  Phase 8 — WebView demo app"
     FINAL_EXIT=1
 fi
 

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -19,7 +19,7 @@ import Data.Int (Int32)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Text (Text, pack)
-import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), Widget(..), WidgetStyle(..), colorToHex)
+import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
@@ -122,6 +122,15 @@ renderNode _rs (Image config) = do
     ImageData bytes                   -> Bridge.setImageData nodeId bytes
     ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
   Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
+  pure nodeId
+renderNode rs (WebView config) = do
+  nodeId <- Bridge.createNode Bridge.NodeWebView
+  Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
+  case wvOnPageLoad config of
+    Just action -> do
+      callbackId <- registerCallback rs action
+      Bridge.setHandler nodeId Bridge.EventClick callbackId
+    Nothing -> pure ()
   pure nodeId
 renderNode rs (Styled style child) = do
   nodeId <- renderNode rs child

--- a/src/HaskellMobile/UIBridge.hs
+++ b/src/HaskellMobile/UIBridge.hs
@@ -41,6 +41,7 @@ data NodeType
   | NodeTextInput
   | NodeScrollView
   | NodeImage
+  | NodeWebView
   deriving (Show, Eq, Enum, Bounded)
 
 -- | Map a 'NodeType' to its C integer code.
@@ -52,6 +53,7 @@ nodeTypeToInt NodeRow        = 3
 nodeTypeToInt NodeTextInput  = 4
 nodeTypeToInt NodeScrollView = 5
 nodeTypeToInt NodeImage      = 6
+nodeTypeToInt NodeWebView    = 8
 
 -- | Property identifiers for 'setStrProp' and 'setNumProp'.
 data PropId
@@ -66,6 +68,7 @@ data PropId
   | PropImageResource
   | PropImageFile
   | PropScaleType
+  | PropWebViewUrl
   deriving (Show, Eq, Enum, Bounded)
 
 -- | Map a 'PropId' to its C integer code.
@@ -81,6 +84,7 @@ propIdToInt PropPadding       = 1
 propIdToInt PropInputType     = 2
 propIdToInt PropGravity       = 3
 propIdToInt PropScaleType     = 4
+propIdToInt PropWebViewUrl   = 6
 
 -- | Event types corresponding to @UI_EVENT_*@ in @UIBridge.h@.
 data EventType

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -14,6 +14,7 @@ module HaskellMobile.Widget
   , ResourceName(..)
   , ImageSource(..)
   , ImageConfig(..)
+  , WebViewConfig(..)
   , Widget(..)
   , WidgetStyle(..)
   , TextAlignment(..)
@@ -173,6 +174,14 @@ data ImageConfig = ImageConfig
     -- ^ How the image is scaled.
   } deriving (Show, Eq)
 
+-- | Configuration for an embedded web view.
+data WebViewConfig = WebViewConfig
+  { wvUrl        :: Text
+    -- ^ URL to load in the web view.
+  , wvOnPageLoad :: Maybe (IO ())
+    -- ^ Optional callback fired when a page finishes loading.
+  }
+
 -- | A declarative description of a UI element.
 data Widget
   = Text TextConfig
@@ -189,5 +198,7 @@ data Widget
     -- ^ A vertically scrollable container.
   | Image ImageConfig
     -- ^ An image widget displaying resource, file, or raw data.
+  | WebView WebViewConfig
+    -- ^ An embedded web view loading a URL.
   | Styled WidgetStyle Widget
     -- ^ Apply visual style overrides to a child widget.

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -50,7 +50,7 @@ import HaskellMobile.Lifecycle
   , lifecycleToInt
   , loggingMobileContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), Widget(..), WidgetStyle(..), colorFromText, colorToHex, defaultStyle)
+import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorFromText, colorToHex, defaultStyle)
 import HaskellMobile.Permission
   ( Permission(..)
   , PermissionStatus(..)
@@ -113,7 +113,7 @@ main = do
   defaultMain (tests (acPermissionState ffiAppCtx) (acSecureStorageState ffiAppCtx) (acDialogState ffiAppCtx))
 
 tests :: PermissionState -> SecureStorageState -> DialogState -> TestTree
-tests ffiPermState ffiSecureStorageState ffiDialogState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, appContextTests, exceptionHandlerTests]
+tests ffiPermState ffiSecureStorageState ffiDialogState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, appContextTests, exceptionHandlerTests]
 
 qcProps :: TestTree
 qcProps = testGroup "(checked by QuickCheck)"
@@ -309,6 +309,7 @@ uiTests = testGroup "UI"
         Button _        -> assertFailure "expected Column, got Button"
         TextInput _     -> assertFailure "expected Column, got TextInput"
         Image _         -> assertFailure "expected Column, got Image"
+        WebView _       -> assertFailure "expected Column, got WebView"
         Row _           -> assertFailure "expected Column, got Row"
         ScrollView _    -> assertFailure "expected Column, got ScrollView"
         Styled _ _      -> assertFailure "expected Column, got Styled"
@@ -522,6 +523,48 @@ imageTests = testGroup "Image"
       rs <- newRenderState
       renderWidget rs $ Image ImageConfig
         { icSource = ImageResource (ResourceName "none_test"), icScaleType = ScaleNone }
+  ]
+
+-- | Tests for the WebView widget.
+webViewTests :: TestTree
+webViewTests = testGroup "WebView"
+  [ testCase "WebView renders without error" $ do
+      rs <- newRenderState
+      renderWidget rs $ WebView WebViewConfig
+        { wvUrl = "https://example.com", wvOnPageLoad = Nothing }
+
+  , testCase "WebView with callback registers handler and fires" $ do
+      ref <- newIORef (0 :: Int)
+      rs <- newRenderState
+      renderWidget rs $ WebView WebViewConfig
+        { wvUrl = "https://example.com"
+        , wvOnPageLoad = Just (modifyIORef' ref (+ 1))
+        }
+      -- Callback 0 is registered for the page-load event
+      dispatchEvent rs 0
+      count <- readIORef ref
+      count @?= 1
+
+  , testCase "WebView without callback does not register handler" $ do
+      rs <- newRenderState
+      renderWidget rs $ WebView WebViewConfig
+        { wvUrl = "https://example.com", wvOnPageLoad = Nothing }
+      -- No callbacks registered, dispatching should log error but not crash
+      dispatchEvent rs 0
+
+  , testCase "WebView inside Column renders" $ do
+      rs <- newRenderState
+      renderWidget rs $ Column
+        [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
+        , WebView WebViewConfig
+            { wvUrl = "https://example.com", wvOnPageLoad = Nothing }
+        ]
+
+  , testCase "Styled WebView renders without error" $ do
+      rs <- newRenderState
+      renderWidget rs $ Styled defaultStyle
+        (WebView WebViewConfig
+          { wvUrl = "https://example.com", wvOnPageLoad = Nothing })
   ]
 
 -- | Tests for the Styled widget wrapper.
@@ -1323,6 +1366,7 @@ viewIsErrorWidget ctxPtr = do
     Button _                 -> pure False
     TextInput _              -> pure False
     Image _                  -> pure False
+    WebView _                -> pure False
     Row _                    -> pure False
     ScrollView _             -> pure False
     Styled _ _               -> pure False

--- a/test/WebViewDemoMain.hs
+++ b/test/WebViewDemoMain.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Mobile entry point for the webview-demo test app.
+--
+-- Used by the emulator and simulator WebView integration tests.
+-- Starts directly in webview-demo mode so no runtime switching is needed.
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Text (pack)
+import Foreign.Ptr (Ptr)
+import HaskellMobile
+  ( MobileApp(..)
+  , UserState(..)
+  , startMobileApp
+  , platformLog
+  , loggingMobileContext
+  , AppContext
+  )
+import HaskellMobile.Widget
+  ( ButtonConfig(..)
+  , TextConfig(..)
+  , WebViewConfig(..)
+  , Widget(..)
+  )
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "WebView demo app registered"
+  urlRef <- newIORef ("https://example.com" :: String)
+  startMobileApp (webViewDemoApp urlRef)
+
+-- | WebView demo: loads a URL and logs when page finishes loading.
+-- A button switches to a second URL to test navigation.
+webViewDemoApp :: IORef String -> MobileApp
+webViewDemoApp urlRef = MobileApp
+  { maContext = loggingMobileContext
+  , maView    = webViewDemoView urlRef
+  }
+
+-- | Builds a Column with a WebView, a status label, and a URL-switch button.
+webViewDemoView :: IORef String -> UserState -> IO Widget
+webViewDemoView urlRef _userState = do
+  currentUrl <- readIORef urlRef
+  pure $ Column
+    [ Text TextConfig { tcLabel = "WebView Demo", tcFontConfig = Nothing }
+    , WebView WebViewConfig
+        { wvUrl = pack currentUrl
+        , wvOnPageLoad = Just (platformLog ("WebView page loaded: " <> pack currentUrl))
+        }
+    , Button ButtonConfig
+        { bcLabel = "Load example.org"
+        , bcAction = writeIORef urlRef "https://example.org"
+        , bcFontConfig = Nothing
+        }
+    ]

--- a/test/android/webview.sh
+++ b/test/android/webview.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Android webview test: install webview APK, assert WebView renders and page-load fires.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, WEBVIEW_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+install_apk "$WEBVIEW_APK" || { echo "FAIL: install_apk"; exit 1; }
+
+"$ADB" -s "$EMULATOR_SERIAL" logcat -c
+"$ADB" -s "$EMULATOR_SERIAL" shell am start -n "$PACKAGE/$ACTIVITY"
+
+wait_for_logcat "setRoot" 120
+WAIT_RC=$?
+if [ $WAIT_RC -eq 2 ]; then
+    dump_logcat "webview"
+    echo "FATAL: Native library failed to load — aborting"
+    exit 1
+fi
+sleep 5
+
+LOGCAT_FILE="$WORK_DIR/webview_logcat.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_FILE" 2>&1 || true
+
+# WebView node created (type=8)
+assert_logcat "$LOGCAT_FILE" "createNode.*type=8" "createNode(type=8) WebView node"
+
+# URL property set
+assert_logcat "$LOGCAT_FILE" "setStrProp.*webviewUrl.*example.com" "WebView URL set to example.com"
+
+# Page-load callback registered
+assert_logcat "$LOGCAT_FILE" "setHandler.*callback=" "setHandler registered for page-load"
+
+# setRoot called
+assert_logcat "$LOGCAT_FILE" "setRoot" "setRoot called"
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/webview.sh
+++ b/test/ios/webview.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# iOS webview test: install webview app, launch, assert WebView renders and page-load fires.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, WEBVIEW_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+xcrun simctl install "$SIM_UDID" "$WEBVIEW_APP"
+echo "WebView app installed."
+
+WEBVIEW_START=$(date "+%Y-%m-%d %H:%M:%S")
+
+STREAM_LOG="$WORK_DIR/webview_stream.txt"
+> "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$BUNDLE_ID\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
+sleep 5
+
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID"
+
+render_done=0
+wait_for_log "$STREAM_LOG" "setRoot" 60
+WAIT_RC=$?
+if [ $WAIT_RC -eq 2 ]; then
+    dump_ios_log "$STREAM_LOG" "webview"
+    echo "FATAL: Native library failed to load — aborting"
+    exit 1
+fi
+if [ $WAIT_RC -eq 0 ]; then
+    render_done=1
+fi
+
+if [ $render_done -eq 0 ]; then
+    echo "WARNING: setRoot not found — retrying with relaunch"
+    xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+    sleep 3
+    > "$STREAM_LOG"
+    xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID"
+    wait_for_log "$STREAM_LOG" "setRoot" 60 || true
+fi
+
+sleep 5
+
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+FULL_LOG="$WORK_DIR/webview_full.txt"
+get_full_log "$WEBVIEW_START" "$FULL_LOG"
+
+if ! grep -q "setRoot" "$FULL_LOG" 2>/dev/null; then
+    echo "  'log show' empty/incomplete, using stream log"
+    FULL_LOG="$STREAM_LOG"
+fi
+
+# WebView node created (type=8)
+assert_log "$FULL_LOG" "createNode\(type=8\)" "createNode(type=8) — WKWebView created"
+
+# URL property set
+assert_log "$FULL_LOG" "setStrProp.*webviewUrl.*example.com" "WebView URL set to example.com"
+
+# Page-load callback registered
+assert_log "$FULL_LOG" "setHandler.*callback=" "setHandler registered for page-load"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/watchos/webview.sh
+++ b/test/watchos/webview.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# watchOS webview test: install webview app, launch, assert placeholder renders.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, WEBVIEW_APP, WORK_DIR, LOG_SUBSYSTEM
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+xcrun simctl install "$SIM_UDID" "$WEBVIEW_APP"
+echo "WebView app installed."
+
+WEBVIEW_START=$(date "+%Y-%m-%d %H:%M:%S")
+
+STREAM_LOG="$WORK_DIR/webview_stream.txt"
+> "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$LOG_SUBSYSTEM\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
+sleep 5
+
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID"
+
+render_done=0
+wait_for_log "$STREAM_LOG" "setRoot" 60 && render_done=1 || true
+
+if [ $render_done -eq 0 ]; then
+    echo "WARNING: setRoot not found — retrying with relaunch"
+    xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+    sleep 3
+    > "$STREAM_LOG"
+    xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID"
+    wait_for_log "$STREAM_LOG" "setRoot" 60 || true
+fi
+
+sleep 5
+
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+FULL_LOG="$WORK_DIR/webview_full.txt"
+get_full_log "$WEBVIEW_START" "$FULL_LOG"
+
+if ! grep -q "setRoot" "$FULL_LOG" 2>/dev/null; then
+    echo "  'log show' empty/incomplete, using stream log"
+    FULL_LOG="$STREAM_LOG"
+fi
+
+# WebView node created (type=8)
+assert_log "$FULL_LOG" "createNode\(type=8\)" "createNode(type=8) — WebView node created"
+
+# URL property set (stored as text on watchOS)
+assert_log "$FULL_LOG" "setStrProp.*webviewUrl.*example.com" "WebView URL set"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/watchos/HaskellMobile/ContentView.swift
+++ b/watchos/HaskellMobile/ContentView.swift
@@ -54,6 +54,9 @@ struct NodeView: View {
             }
         case 6: // UI_NODE_IMAGE
             ImageNodeView(node: node)
+        case 8: // UI_NODE_WEBVIEW
+            Text("WebView not available")
+                .foregroundColor(.secondary)
         default:
             EmptyView()
         }

--- a/watchos/HaskellMobile/WatchUIBridgeState.swift
+++ b/watchos/HaskellMobile/WatchUIBridgeState.swift
@@ -45,6 +45,9 @@ class WatchUIBridgeState: ObservableObject {
         case 5: // UI_PROP_IMAGE_FILE
             os_log("setStrProp(node=%d, imageFile=\"%{public}s\")", log: bridgeLog, type: .info, nodeId, value)
             node.imageFile = value
+        case 6: // UI_PROP_WEBVIEW_URL
+            os_log("setStrProp(node=%d, webviewUrl=\"%{public}s\")", log: bridgeLog, type: .info, nodeId, value)
+            node.text = value
         default:
             os_log("setStrProp: unknown propId %d", log: bridgeLog, type: .info, propId)
         }


### PR DESCRIPTION
## Summary
- Adds `WebView` widget constructor to the declarative UI tree with `WebViewConfig` (URL + optional page-load callback)
- Android: `android.webkit.WebView` with JS enabled, `WebViewClient.onPageFinished` callback, `INTERNET` permission
- iOS: `WKWebView` with `WKNavigationDelegate` for `didFinishNavigation`, WebKit framework linked
- watchOS: Placeholder text ("WebView not available") since WKWebView isn't available for third-party apps
- UIBridge-only: reuses existing `setStrProp` (prop 6) and `setHandler`/`EventClick` (code 0) — no new C bridge files
- 5 new unit tests, integration test scripts for all 3 platforms, demo app (`test/WebViewDemoMain.hs`)
- Nix harnesses updated with Phase 9 (Android/iOS) and Phase 8 (watchOS) for webview tests

Closes #76

## Test plan
- [x] `cabal build` — zero warnings
- [x] `cabal test` — all 134 tests pass (including 5 new WebView tests)
- [ ] CI: android job passes
- [ ] CI: android-armv7a-emulator job passes
- [ ] CI: ios job passes
- [ ] CI: watchos job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)