### PR TITLE
Add Template Haskell cross-compilation support for aarch64

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -13,6 +13,7 @@ let
     apk = import ./apk.nix { inherit sources; };
     consumer-link-test = import ./test-link-consumer.nix { inherit sources; };
     consumer-deps-test = import ./test-consumer-deps.nix { inherit sources; };
+    th-test = import ./test-th.nix { inherit sources; };
   } // (if isDarwin then {
     ios-lib = import ./ios.nix { inherit sources; };
     watchos-lib = import ./watchos.nix { inherit sources; };

--- a/nix/cross-deps.nix
+++ b/nix/cross-deps.nix
@@ -5,6 +5,11 @@
 #   $out/lib/*.a       — static archives
 #   $out/pkgdb/        — GHC package database (.conf + cache)
 #
+# On aarch64, includes Template Haskell cross-compilation support:
+# static iserv-proxy, native libdl, mmap wrapper, QEMU guest_base
+# overlay, and package DB patching.  These are no-ops when TH isn't
+# used, so they're always enabled for aarch64.
+#
 # Consumers supply their own dependencies via consumerCabalFile (IFD),
 # consumerCabal2Nix (pre-generated), or hpkgs overrides.
 { sources
@@ -27,20 +32,155 @@ let
     inherit androidArch;
   };
 
-  pkgs = import nixpkgsSrc {
+  # QEMU overlay for aarch64 TH cross-compilation.
+  # Without -B, QEMU uses guest_base=0: guest addresses map directly to
+  # host addresses.  The guest binary loads at ~0x200000 where QEMU's own
+  # code resides, so mmap hints from GHC's RTS linker are ignored.
+  # Loaded .o code lands far from the binary's symbols, exceeding the
+  # +-4 GiB range of aarch64 ADRP relocations.
+  # -B 0x4000000000 shifts the guest address space by 256 GiB.
+  qemuOverlay = final: prev: {
+    qemu-user = prev.symlinkJoin {
+      name = "qemu-user-with-guest-base";
+      paths = [ prev.qemu-user ];
+      postBuild = ''
+        rm $out/bin/qemu-aarch64
+        cat > $out/bin/qemu-aarch64 <<'WRAPPER'
+#!/bin/sh
+exec ${prev.qemu-user}/bin/qemu-aarch64 -B 0x4000000000 "$@"
+WRAPPER
+        chmod +x $out/bin/qemu-aarch64
+      '';
+    };
+  };
+
+  pkgs = import nixpkgsSrc ({
     config.allowUnfree = true;
     config.android_sdk.accept_license = true;
-  };
+  } // (if androidArch == "aarch64"
+        then { overlays = [ qemuOverlay ]; }
+        else {}));
 
   # Cross-compilation toolchain
   androidPkgs = pkgs.pkgsCross.${archConfig.crossAttr};
 
-  # Default overrides needed for cross-compilation:
-  # - vector: test suite uses GHC plugins (inspection-testing), incompatible
-  #   with cross-compilation's external interpreter.
-  defaultOverrides = self: super: {
+  # --- aarch64 TH support: static C libraries ---
+  # Static versions of C libraries so iserv-proxy-interpreter can be
+  # linked statically.  A static binary does not need /system/bin/linker64,
+  # which lets QEMU run it on the build host during TH evaluation.
+  gmpStatic = androidPkgs.gmp.overrideAttrs (old: {
+    dontDisableStatic = true;
+  });
+  libffiStatic = androidPkgs.libffi.overrideAttrs (old: {
+    dontDisableStatic = true;
+  });
+  numactlStatic = androidPkgs.numactl.overrideAttrs (old: {
+    dontDisableStatic = true;
+  });
+
+  # Android NDK ships libdl.a as LLVM bitcode with stub implementations
+  # where dlerror() returns "libdl.a is a stub --- use libdl.so instead".
+  # GHC's RTS linker can't parse LLVM bitcode as ELF.
+  #
+  # Fix: provide a native-ELF libdl.a that implements dlopen/dlsym by
+  # searching the process's own dynamic symbol table.  Combined with
+  # --export-dynamic on iserv-proxy-interpreter, this lets the RTS
+  # linker resolve symbols (strlen, ghc-prim, etc.) from the static binary.
+  libdlNative = pkgs.runCommand "libdl-native-android" {
+    nativeBuildInputs = [ androidPkgs.stdenv.cc ];
+  } ''
+    ${androidPkgs.stdenv.cc.targetPrefix}clang -c -fPIC -o dl_impl.o ${./th-support/dl_impl.c}
+    ${androidPkgs.stdenv.cc.targetPrefix}clang -c -fPIC -o mmap_wrapper.o ${./th-support/mmap_wrapper.c}
+    mkdir -p $out/lib
+    ${androidPkgs.stdenv.cc.targetPrefix}ar rcs $out/lib/libdl.a dl_impl.o
+    ${androidPkgs.stdenv.cc.targetPrefix}ar rcs $out/lib/libmmap_wrapper.a mmap_wrapper.o
+  '';
+
+  # --- Haskell package overrides ---
+
+  # vector: test suite uses GHC plugins (inspection-testing), incompatible
+  # with cross-compilation's external interpreter.
+  vectorOverride = self: super: {
     vector = pkgs.haskell.lib.dontBenchmark (pkgs.haskell.lib.dontCheck super.vector);
   };
+
+  # Template Haskell cross-compilation overrides (aarch64 only).
+  #
+  # Overrides mkDerivation to fix TH evaluation: copies GHC's global
+  # package DB entries into the local DB, resolves ${pkgroot} to absolute
+  # paths, and clears dynamic-library-dirs to force LoadArchive.
+  #
+  # Builds iserv-proxy as a static binary with --export-dynamic so our
+  # dlsym can find symbols, --hash-style=sysv for DT_HASH, and
+  # --wrap=mmap to intercept NULL-hint mmaps from GHC's RTS linker.
+  thOverrides = self: super: {
+    mkDerivation = args:
+      let isIservProxy = (args.pname or "") == "iserv-proxy";
+      in super.mkDerivation (args // {
+        preConfigure = (args.preConfigure or "") +
+          (if isIservProxy then "" else ''
+            # --- TH cross-compilation fix ---
+            # Copy GHC's global package DB entries (rts, base, ghc-prim,
+            # etc.) into the local package DB so we can patch them.
+            # The local DB shadows the global one.
+            _ghcLibDir=$(${self.ghc}/bin/${self.ghc.targetPrefix}ghc --print-libdir)
+            _globalConfDir="$_ghcLibDir/package.conf.d"
+            if [ -d "$_globalConfDir" ] && [ -d "$packageConfDir" ]; then
+              echo "TH-fix: copying global package DB from $_globalConfDir"
+              for _conf in "$_globalConfDir"/*.conf; do
+                _name=$(basename "$_conf")
+                if [ ! -e "$packageConfDir/$_name" ]; then
+                  cp "$_conf" "$packageConfDir/$_name"
+                fi
+              done
+              # Patch ALL conf files:
+              # 1. Resolve ''${pkgroot} to absolute paths (relative refs
+              #    break when boot packages are copied to the local DB)
+              # 2. Clear dynamic-library-dirs (forces LoadArchive over
+              #    LoadDLL for Haskell .a files)
+              # extra-libraries are kept: our dlsym resolves C symbols
+              # from the static iserv-proxy-interpreter binary.
+              for _conf in "$packageConfDir"/*.conf; do
+                ${pkgs.gawk}/bin/awk -v pkgroot="$_ghcLibDir" '
+                  { gsub(/\$\{pkgroot\}/, pkgroot) }
+                  /^dynamic-library-dirs:/ { print "dynamic-library-dirs:"; skip=1; next }
+                  skip && /^[[:space:]]/ { next }
+                  { skip=0; print }
+                ' "$_conf" > "$_conf.tmp" && mv "$_conf.tmp" "$_conf"
+              done
+              echo "TH-fix: patched package DB, recaching"
+              ${self.ghc}/bin/${self.ghc.targetPrefix}ghc-pkg --package-db="$packageConfDir" recache
+              echo "TH-fix: rts include-dirs after patch:"
+              grep -A3 "include-dirs" "$packageConfDir"/rts-*.conf || true
+            fi
+          '');
+      });
+    # Build iserv-proxy-interpreter as a static binary so QEMU can
+    # run it without Android's /system/bin/linker64.
+    # --export-dynamic populates .dynsym so our dlsym can find symbols.
+    # --hash-style=sysv provides DT_HASH (needed by our dlsym impl).
+    # --wrap=mmap intercepts NULL-hint mmaps from GHC's RTS linker
+    # (which uses mmap(NULL,...) on aarch64 due to linkerAlwaysPic=true)
+    # and provides hints near the binary so allocations stay within
+    # the +-4 GiB ADRP relocation range.
+    iserv-proxy = pkgs.haskell.lib.appendConfigureFlags super.iserv-proxy [
+      "--ghc-option=-optl-static"
+      "--ghc-option=-optl-pie"
+      "--ghc-option=-optl-Wl,--export-dynamic"
+      "--ghc-option=-optl-Wl,--hash-style=sysv"
+      "--ghc-option=-optl-Wl,--wrap=mmap"
+      "--ghc-option=-optl-lmmap_wrapper"
+      "--extra-lib-dirs=${gmpStatic}/lib"
+      "--extra-lib-dirs=${libffiStatic}/lib"
+      "--extra-lib-dirs=${numactlStatic}/lib"
+      "--extra-lib-dirs=${libdlNative}/lib"
+    ];
+  };
+
+  defaultOverrides =
+    if androidArch == "aarch64"
+    then pkgs.lib.composeExtensions vectorOverride thOverrides
+    else vectorOverride;
 
   # armv7a: disable profiling — LLVM ARM backend crashes in
   # ARMAsmPrinter::emitXXStructor when compiling profiled libraries.

--- a/nix/test-th.nix
+++ b/nix/test-th.nix
@@ -1,0 +1,22 @@
+# Integration test: build an Android library with a TH-using dependency.
+#
+# th-consumer is a minimal Haskell package containing a single TH splice.
+# If this builds for aarch64-android, TH cross-compilation works:
+# iserv-proxy-interpreter runs under QEMU, evaluates TH splices,
+# and sends results back to the cross-GHC.
+{ sources ? import ../npins }:
+import ./android.nix {
+  inherit sources;
+  mainModule = ../test/THDemoMain.hs;
+  hpkgs = self: super: {
+    th-consumer = self.callCabal2nix "th-consumer" ../test/th-consumer {};
+  };
+  consumerCabal2Nix =
+    { mkDerivation, base, lib, th-consumer }:
+    mkDerivation {
+      pname = "th-test";
+      version = "0.1.0.0";
+      libraryHaskellDepends = [ base th-consumer ];
+      license = lib.licenses.mit;
+    };
+}

--- a/nix/th-support/dl_impl.c
+++ b/nix/th-support/dl_impl.c
@@ -1,0 +1,79 @@
+#include <stddef.h>
+#include <string.h>
+#include <elf.h>
+#include <stdint.h>
+
+/*
+ * Minimal dlopen/dlsym for a statically linked aarch64 binary.
+ *
+ * dlopen: returns a fake non-NULL handle (the binary itself).
+ * dlsym:  walks the .dynsym table (populated by --export-dynamic
+ *         and --hash-style=sysv) to find symbols by name.
+ *
+ * Requires: -Wl,--export-dynamic -Wl,--hash-style=sysv at link time.
+ */
+
+/* _DYNAMIC is provided by the linker when --export-dynamic is used. */
+extern Elf64_Dyn _DYNAMIC[] __attribute__((weak));
+
+static Elf64_Sym  *g_symtab  = NULL;
+static const char *g_strtab  = NULL;
+static uint32_t    g_nsyms   = 0;
+static int         g_inited  = 0;
+
+static void init_symtab(void) {
+    Elf64_Dyn *d;
+    g_inited = 1;
+    if (!_DYNAMIC) return;
+    for (d = _DYNAMIC; d->d_tag != DT_NULL; d++) {
+        switch (d->d_tag) {
+        case DT_SYMTAB:
+            g_symtab = (Elf64_Sym *)(uintptr_t)d->d_un.d_ptr;
+            break;
+        case DT_STRTAB:
+            g_strtab = (const char *)(uintptr_t)d->d_un.d_ptr;
+            break;
+        case DT_HASH: {
+            /* SysV hash table: uint32_t nbuckets, nchain.
+             * nchain == total number of symbols in .dynsym. */
+            uint32_t *h = (uint32_t *)(uintptr_t)d->d_un.d_ptr;
+            g_nsyms = h[1];
+            break;
+        }
+        }
+    }
+}
+
+void *dlopen(const char *filename, int flags) {
+    (void)filename; (void)flags;
+    return (void *)(uintptr_t)1;  /* fake non-NULL handle */
+}
+
+char *dlerror(void) { return NULL; }
+
+void *dlsym(void *handle, const char *symbol) {
+    uint32_t i;
+    (void)handle;
+    if (!g_inited) init_symtab();
+    if (!g_symtab || !g_strtab || g_nsyms == 0) return NULL;
+    for (i = 0; i < g_nsyms; i++) {
+        if (g_symtab[i].st_shndx != SHN_UNDEF &&
+            g_symtab[i].st_name  != 0 &&
+            strcmp(g_strtab + g_symtab[i].st_name, symbol) == 0) {
+            return (void *)(uintptr_t)g_symtab[i].st_value;
+        }
+    }
+    return NULL;
+}
+
+int dlclose(void *handle) { (void)handle; return 0; }
+
+void *dlvsym(void *handle, const char *s, const char *v) {
+    (void)v;
+    return dlsym(handle, s);
+}
+
+int dladdr(const void *addr, void *info) {
+    (void)addr; (void)info;
+    return 0;
+}

--- a/nix/th-support/mmap_wrapper.c
+++ b/nix/th-support/mmap_wrapper.c
@@ -1,0 +1,58 @@
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * mmap wrapper for iserv-proxy-interpreter under QEMU user-mode.
+ *
+ * GHC's RTS linker on aarch64 sets linkerAlwaysPic=true, which
+ * causes mmapForLinker to call mmap(NULL,...) without any address
+ * hint.  Under QEMU user-mode, NULL-hint mmaps land at very high
+ * guest addresses (0x7fb...), far from the static binary at
+ * 0x200000.  When the RTS linker processes ADRP relocations
+ * between loaded code and its GOT, the +-4 GiB range is exceeded.
+ *
+ * This wrapper intercepts mmap(NULL,...) calls and provides a
+ * hint address just above the binary.  QEMU honours the hint if
+ * the guest address is free, keeping all allocations within the
+ * +-4 GiB ADRP range.
+ *
+ * Linked with -Wl,--wrap=mmap so __wrap_mmap replaces mmap and
+ * __real_mmap calls the original.
+ */
+
+/* Flags from linux/mman.h -- same on all architectures */
+#define _MAP_ANONYMOUS 0x20
+#define _MAP_FIXED     0x10
+
+void *__real_mmap(void *addr, unsigned long length, int prot,
+                  int flags, int fd, long offset);
+
+/* _end is provided by the linker: end of BSS = end of binary */
+extern char _end;
+
+static void *_mmap_next_hint = 0;
+
+void *__wrap_mmap(void *addr, unsigned long length, int prot,
+                  int flags, int fd, long offset) {
+    /* Only intercept NULL-hint anonymous mappings */
+    if (addr == 0 && (flags & _MAP_ANONYMOUS)
+                  && !(flags & _MAP_FIXED)) {
+        if (_mmap_next_hint == 0) {
+            /* First call: start 2 MiB above end of binary */
+            uintptr_t binary_end = ((uintptr_t)&_end + 0xfff)
+                                   & ~(uintptr_t)0xfff;
+            _mmap_next_hint = (void *)(binary_end + 0x200000);
+        }
+        void *result = __real_mmap(_mmap_next_hint, length, prot,
+                                   flags, fd, offset);
+        if (result != (void *)(intptr_t)-1) {
+            /* Advance hint past this allocation (page-aligned) */
+            uintptr_t next = ((uintptr_t)result + length + 0xfff)
+                             & ~(uintptr_t)0xfff;
+            _mmap_next_hint = (void *)next;
+            return result;
+        }
+        /* Hint rejected (region occupied): fall through */
+    }
+    return __real_mmap(addr, length, prot, flags, fd, offset);
+}

--- a/test/THDemoMain.hs
+++ b/test/THDemoMain.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Entry point for the TH cross-compilation test.
+--
+-- Imports from th-consumer, a dependency package that uses a TH splice.
+-- The splice runs during cross-compilation of th-consumer (via the Nix
+-- haskellPackages infrastructure), not in this main module.
+-- If this builds for aarch64-android, TH cross-compilation works.
+module Main where
+
+import Data.Text (pack)
+import Foreign.Ptr (Ptr)
+import THConsumer (thGreeting)
+import HaskellMobile (startMobileApp, platformLog, AppContext)
+import HaskellMobile.App (mobileApp)
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog ("TH test app: " <> pack thGreeting)
+  startMobileApp mobileApp

--- a/test/th-consumer/src/THConsumer.hs
+++ b/test/th-consumer/src/THConsumer.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
+-- | Minimal module that forces a Template Haskell splice at compile time.
+-- If this compiles during aarch64-android cross-compilation, TH works.
+module THConsumer (thGreeting) where
+
+import Language.Haskell.TH.Syntax (lift)
+
+-- | Compile-time evaluated splice — forces iserv-proxy TH evaluation.
+thGreeting :: String
+thGreeting = $(lift ("Hello from Template Haskell" :: String))

--- a/test/th-consumer/th-consumer.cabal
+++ b/test/th-consumer/th-consumer.cabal
@@ -1,0 +1,11 @@
+cabal-version: 2.4
+name:          th-consumer
+version:       0.1.0.0
+synopsis:      Minimal package that exercises a Template Haskell splice
+license:       MIT
+
+library
+  exposed-modules: THConsumer
+  hs-source-dirs:  src
+  build-depends:   base, template-haskell
+  default-language: Haskell2010


### PR DESCRIPTION
## Summary

- Moves generic TH cross-compilation infrastructure from consumer (prrrrrrrrr) into haskell-mobile
- Any consumer using TH-dependent libraries (servant, aeson, lens, etc.) gets cross-compilation support for free
- Guarded with `androidArch == "aarch64"` — no-op for armv7a

## Changes

**New files:**
- `nix/th-support/dl_impl.c` — Native ELF dlsym replacing Android NDK's LLVM bitcode stub
- `nix/th-support/mmap_wrapper.c` — Intercepts NULL-hint mmap calls to keep allocations within ADRP range

**Modified `nix/cross-deps.nix`:**
- QEMU overlay (`-B 0x4000000000`) shifts guest address space
- Static lib derivations (gmp, libffi, numactl) for static iserv-proxy
- TH overrides: package DB patching + iserv-proxy static build

## Test plan

- [x] `nix-build nix/ci.nix -A android-aarch64` succeeds locally
- [x] `nix-build nix/ci.nix -A android-armv7a` dry-run evaluates (TH skipped)
- [x] Nix syntax validation passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)