### PR TITLE
Add BottomSheet bridge for action menus (#94)

### DIFF
--- a/android/java/me/jappie/haskellmobile/HaskellMobileActivity.java
+++ b/android/java/me/jappie/haskellmobile/HaskellMobileActivity.java
@@ -76,6 +76,7 @@ public class HaskellMobileActivity extends Activity implements View.OnClickListe
                                        byte[] imageData, int width, int height);
     private native void onVideoFrame(int requestId, byte[] frameData, int width, int height);
     private native void onAudioChunk(int requestId, byte[] audioData);
+    private native void onBottomSheetResult(int requestId, int actionCode);
 
     private static final String SECURE_PREFS_NAME = "haskell_mobile_secure_storage";
 
@@ -319,6 +320,36 @@ public class HaskellMobileActivity extends Activity implements View.OnClickListe
             }
         });
 
+        builder.show();
+    }
+
+    /**
+     * Show a bottom sheet / action menu. Called from native code via JNI.
+     * requestId: opaque ID passed back in the result callback.
+     * title: bottom sheet title.
+     * items: newline-separated item labels.
+     */
+    public void showBottomSheet(final int requestId, String title, String items) {
+        final boolean[] itemSelected = {false};
+        String[] itemLabels = items.split("\n");
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(title);
+        builder.setItems(itemLabels, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                itemSelected[0] = true;
+                onBottomSheetResult(requestId, which);
+            }
+        });
+        builder.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                if (!itemSelected[0]) {
+                    onBottomSheetResult(requestId, -1); // BOTTOM_SHEET_DISMISSED
+                }
+            }
+        });
         builder.show();
     }
 

--- a/cbits/bottom_sheet_android.c
+++ b/cbits/bottom_sheet_android.c
@@ -1,0 +1,98 @@
+/*
+ * Android implementation of the bottom sheet bridge callback.
+ *
+ * Uses JNI to call Activity.showBottomSheet() which presents a BottomSheetDialog.
+ * Compiled by NDK clang, not cabal.
+ *
+ * All functions run on the main/UI thread -- the same thread that
+ * calls haskellRenderUI from Java.
+ */
+
+#include <jni.h>
+#include <android/log.h>
+#include "BottomSheetBridge.h"
+#include "JniBridge.h"
+
+#define LOG_TAG "BottomSheetBridge"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+/* Haskell FFI export (dispatches result back to Haskell callback) */
+extern void haskellOnBottomSheetResult(void *ctx, int32_t requestId, int32_t actionCode);
+
+/* ---- Global state (valid only on the UI thread) ---- */
+static JNIEnv  *g_env         = NULL;
+static jobject  g_activity     = NULL;   /* global ref to Activity */
+static void    *g_haskell_ctx  = NULL;   /* stored per-request for JNI callback */
+
+/* Cached JNI method ID */
+static jmethodID g_method_showBottomSheet;
+
+/* ---- Bottom sheet bridge implementation ---- */
+
+static void android_bottom_sheet_show(void *ctx, int32_t requestId,
+                                       const char *title, const char *items)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("bottom_sheet_show: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+
+    jstring jtitle = (*env)->NewStringUTF(env, title);
+    jstring jitems = (*env)->NewStringUTF(env, items);
+
+    LOGI("bottom_sheet_show(title=\"%s\", id=%d)", title, requestId);
+    (*env)->CallVoidMethod(env, g_activity, g_method_showBottomSheet,
+                           (jint)requestId, jtitle, jitems);
+
+    (*env)->DeleteLocalRef(env, jtitle);
+    (*env)->DeleteLocalRef(env, jitems);
+}
+
+/* ---- Public API ---- */
+
+/*
+ * Set up the Android bottom sheet bridge. Called from jni_bridge.c
+ * during renderUI (after the Activity is available).
+ * Resolves JNI method IDs and registers callback with the
+ * platform-agnostic dispatcher.
+ */
+void setup_android_bottom_sheet_bridge(JNIEnv *env, jobject activity, void *haskellCtx)
+{
+    g_env = env;
+    g_haskell_ctx = haskellCtx;
+
+    if (!g_activity) {
+        g_activity = (*env)->NewGlobalRef(env, activity);
+    }
+
+    jclass actClass = (*env)->GetObjectClass(env, activity);
+
+    g_method_showBottomSheet = (*env)->GetMethodID(env, actClass,
+        "showBottomSheet",
+        "(ILjava/lang/String;Ljava/lang/String;)V");
+
+    if (!g_method_showBottomSheet) {
+        LOGE("Failed to resolve bottom sheet JNI method ID -- bridge disabled");
+        (*env)->ExceptionClear(env);
+        return;
+    }
+
+    bottom_sheet_register_impl(android_bottom_sheet_show);
+
+    LOGI("Android bottom sheet bridge initialized");
+}
+
+/* ---- JNI callback from Java ---- */
+
+JNIEXPORT void JNICALL
+JNI_METHOD(onBottomSheetResult)(JNIEnv *env, jobject thiz,
+                                 jint requestId, jint actionCode)
+{
+    g_env = env;
+    LOGI("onBottomSheetResult(requestId=%d, actionCode=%d)", requestId, actionCode);
+    haskellOnBottomSheetResult(g_haskell_ctx, (int32_t)requestId, (int32_t)actionCode);
+}

--- a/cbits/bottom_sheet_bridge.c
+++ b/cbits/bottom_sheet_bridge.c
@@ -1,0 +1,49 @@
+/*
+ * Platform-agnostic bottom sheet bridge dispatcher.
+ *
+ * Stores a function pointer filled by the platform (Android/iOS/watchOS).
+ * bottom_sheet_show() delegates to the pointer. When no callback is registered
+ * (desktop), a stub logs to stderr and auto-selects the first item via
+ * haskellOnBottomSheetResult so that cabal test exercises the round-trip
+ * without native code.
+ *
+ * The opaque Haskell context pointer is threaded through each call
+ * rather than stored as a global, allowing multiple contexts to coexist.
+ */
+
+#include "BottomSheetBridge.h"
+#include <stdio.h>
+
+/* Haskell FFI export (called from desktop stub to dispatch result back) */
+extern void haskellOnBottomSheetResult(void *ctx, int32_t requestId, int32_t actionCode);
+
+static void (*g_show_impl)(void *, int32_t, const char *, const char *) = NULL;
+
+void bottom_sheet_register_impl(
+    void (*show_impl)(void *, int32_t, const char *, const char *))
+{
+    g_show_impl = show_impl;
+}
+
+/* ---- Desktop stub ---- */
+
+static void stub_show(void *ctx, int32_t requestId,
+                      const char *title, const char *items)
+{
+    fprintf(stderr, "[BottomSheetBridge stub] show(title=\"%s\", items=\"%s\")\n",
+            title, items);
+    /* Auto-select first item synchronously for desktop testing */
+    haskellOnBottomSheetResult(ctx, requestId, 0);
+}
+
+/* ---- Public API ---- */
+
+void bottom_sheet_show(void *ctx, int32_t requestId,
+                       const char *title, const char *items)
+{
+    if (g_show_impl) {
+        g_show_impl(ctx, requestId, title, items);
+        return;
+    }
+    stub_show(ctx, requestId, title, items);
+}

--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -20,6 +20,7 @@
 #include "LocationBridge.h"
 #include "AuthSessionBridge.h"
 #include "CameraBridge.h"
+#include "BottomSheetBridge.h"
 
 /* Runs the user's Haskell main via RTS API (cbits/run_main.c).
  * Returns the opaque AppContext pointer. */
@@ -51,6 +52,7 @@ extern void haskellOnCameraResult(void *ctx, int32_t requestId,
                                    int32_t statusCode,
                                    const uint8_t *imageData, int32_t imageDataLen,
                                    int32_t width, int32_t height);
+extern void haskellOnBottomSheetResult(void *ctx, int32_t requestId, int32_t actionCode);
 
 /* Android UI bridge (from ui_bridge_android.c) */
 extern void setup_android_ui_bridge(JNIEnv *env, jobject activity, void *haskellCtx);
@@ -77,6 +79,8 @@ extern void setup_android_auth_session_bridge(JNIEnv *env, jobject activity, voi
 
 /* Android camera bridge (from camera_bridge_android.c) */
 extern void setup_android_camera_bridge(JNIEnv *env, jobject activity, void *haskellCtx);
+/* Android bottom sheet bridge (from bottom_sheet_android.c) */
+extern void setup_android_bottom_sheet_bridge(JNIEnv *env, jobject activity, void *haskellCtx);
 
 /* Lifecycle event codes (must match HaskellMobile.h) */
 #define LIFECYCLE_CREATE     0
@@ -155,6 +159,7 @@ JNI_METHOD(renderUI)(JNIEnv *env, jobject thiz)
     setup_android_location_bridge(env, thiz, g_haskell_ctx);
     setup_android_auth_session_bridge(env, thiz, g_haskell_ctx);
     setup_android_camera_bridge(env, thiz, g_haskell_ctx);
+    setup_android_bottom_sheet_bridge(env, thiz, g_haskell_ctx);
     haskellRenderUI(g_haskell_ctx);
 }
 

--- a/haskell-mobile.cabal
+++ b/haskell-mobile.cabal
@@ -77,6 +77,7 @@ library
       HaskellMobile.Location
       HaskellMobile.AuthSession
       HaskellMobile.Camera
+      HaskellMobile.BottomSheet
   hs-source-dirs:
       src
   build-depends:
@@ -95,6 +96,7 @@ library
       cbits/location_bridge.c
       cbits/auth_session_bridge.c
       cbits/camera_bridge.c
+      cbits/bottom_sheet_bridge.c
   include-dirs:
       include
 

--- a/include/BottomSheetBridge.h
+++ b/include/BottomSheetBridge.h
@@ -1,0 +1,34 @@
+#ifndef BOTTOM_SHEET_BRIDGE_H
+#define BOTTOM_SHEET_BRIDGE_H
+
+#include <stdint.h>
+
+/* Bottom sheet action codes (must match HaskellMobile.BottomSheet) */
+#define BOTTOM_SHEET_DISMISSED -1
+/* actionCode >= 0: 0-based index of the selected item */
+
+/*
+ * Platform-agnostic bottom sheet bridge.
+ *
+ * Haskell calls bottom_sheet_show() through this wrapper.
+ * When no platform callback is registered (desktop), a stub logs to stderr
+ * and auto-selects the first item via haskellOnBottomSheetResult.
+ *
+ * On Android/iOS the platform-specific setup function fills in a real
+ * implementation via bottom_sheet_register_impl().
+ */
+
+/* Show a bottom sheet with a title and newline-separated item labels.
+ * ctx:       opaque Haskell context pointer (passed through to callback).
+ * requestId: opaque ID from Haskell (used to dispatch the result).
+ * title:     null-terminated sheet title.
+ * items:     null-terminated newline-separated item labels ("Edit\nDelete\nShare"). */
+void bottom_sheet_show(void *ctx, int32_t requestId,
+                       const char *title, const char *items);
+
+/* Register the platform-specific implementation.
+ * Called by platform setup functions (setup_android_bottom_sheet_bridge, etc). */
+void bottom_sheet_register_impl(
+    void (*show_impl)(void *, int32_t, const char *, const char *));
+
+#endif /* BOTTOM_SHEET_BRIDGE_H */

--- a/include/HaskellMobile.h
+++ b/include/HaskellMobile.h
@@ -162,5 +162,14 @@ void haskellOnVideoFrame(void *ctx, int32_t requestId,
  * ctx must be a pointer returned by haskellRunMain(). */
 void haskellOnAudioChunk(void *ctx, int32_t requestId,
                           const uint8_t *audioData, int32_t audioDataLen);
+/* Bottom sheet action codes */
+#define BOTTOM_SHEET_DISMISSED -1
+/* actionCode >= 0: 0-based index of the selected item */
+
+/* Dispatch a bottom sheet result from native code back to Haskell.
+ * requestId:  opaque ID from the original bottom_sheet_show() call.
+ * actionCode: >= 0 for item index, BOTTOM_SHEET_DISMISSED (-1) for dismiss.
+ * ctx must be a pointer returned by haskellRunMain(). */
+void haskellOnBottomSheetResult(void *ctx, int32_t requestId, int32_t actionCode);
 
 #endif /* HASKELL_MOBILE_H */

--- a/ios/HaskellMobile/BottomSheetBridgeIOS.m
+++ b/ios/HaskellMobile/BottomSheetBridgeIOS.m
@@ -1,0 +1,98 @@
+/*
+ * iOS implementation of the bottom sheet bridge callback.
+ *
+ * Uses UIAlertController with actionSheet style to present a bottom sheet
+ * with a title and selectable item buttons.  This is the standard iOS
+ * pattern for action menus from the bottom of the screen.
+ * Compiled by Xcode, not GHC.
+ *
+ * All functions run on the main thread.
+ */
+
+#import <UIKit/UIKit.h>
+#import <os/log.h>
+#include "BottomSheetBridge.h"
+
+#define LOG_TAG "BottomSheetBridge"
+static os_log_t g_log;
+
+#define LOGI(fmt, ...) os_log_info(g_log, fmt, ##__VA_ARGS__)
+#define LOGE(fmt, ...) os_log_error(g_log, fmt, ##__VA_ARGS__)
+
+/* Haskell FFI export (dispatches result back to Haskell callback) */
+extern void haskellOnBottomSheetResult(void *ctx, int32_t requestId, int32_t actionCode);
+
+/* ---- Bottom sheet implementation ---- */
+
+static void ios_bottom_sheet_show(void *ctx, int32_t requestId,
+                                   const char *title, const char *items)
+{
+    LOGI("bottom_sheet_show(title=\"%{public}s\", id=%d)", title, requestId);
+
+    /* In autotest mode, auto-select first item without presenting the sheet. */
+    NSArray<NSString *> *args = [[NSProcessInfo processInfo] arguments];
+    if ([args containsObject:@"--autotest-buttons"] || [args containsObject:@"--autotest"]) {
+        LOGI("bottom_sheet_show: autotest mode -- auto-selecting first item");
+        haskellOnBottomSheetResult(ctx, requestId, 0);
+        return;
+    }
+
+    NSString *nsTitle = [NSString stringWithUTF8String:title];
+    NSString *nsItems = [NSString stringWithUTF8String:items];
+    NSArray<NSString *> *itemLabels = [nsItems componentsSeparatedByString:@"\n"];
+
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:nsTitle
+                                                                  message:nil
+                                                           preferredStyle:UIAlertControllerStyleActionSheet];
+
+    /* Add an action for each item */
+    for (NSUInteger i = 0; i < itemLabels.count; i++) {
+        NSInteger index = (NSInteger)i;
+        [sheet addAction:[UIAlertAction actionWithTitle:itemLabels[i]
+                                                  style:UIAlertActionStyleDefault
+                                                handler:^(UIAlertAction *action) {
+            haskellOnBottomSheetResult(ctx, requestId, (int32_t)index);
+        }]];
+    }
+
+    /* Cancel action fires DISMISSED */
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                              style:UIAlertActionStyleCancel
+                                            handler:^(UIAlertAction *action) {
+        haskellOnBottomSheetResult(ctx, requestId, BOTTOM_SHEET_DISMISSED);
+    }]];
+
+    /* Present on the topmost view controller */
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIWindowScene *scene = (UIWindowScene *)[[UIApplication sharedApplication].connectedScenes anyObject];
+        UIWindow *window = scene.windows.firstObject;
+        UIViewController *rootVC = window.rootViewController;
+
+        /* Walk up presented controllers to find the topmost */
+        while (rootVC.presentedViewController) {
+            rootVC = rootVC.presentedViewController;
+        }
+
+        if (rootVC) {
+            [rootVC presentViewController:sheet animated:YES completion:nil];
+        } else {
+            LOGE("bottom_sheet_show: no root view controller to present on");
+            haskellOnBottomSheetResult(ctx, requestId, BOTTOM_SHEET_DISMISSED);
+        }
+    });
+}
+
+/* ---- Public API ---- */
+
+/*
+ * Set up the iOS bottom sheet bridge. Called from Swift during initialisation.
+ * Registers callback with the platform-agnostic dispatcher.
+ */
+void setup_ios_bottom_sheet_bridge(void *haskellCtx)
+{
+    g_log = os_log_create("me.jappie.haskellmobile", LOG_TAG);
+
+    bottom_sheet_register_impl(ios_bottom_sheet_show);
+
+    LOGI("iOS bottom sheet bridge initialized");
+}

--- a/ios/HaskellMobile/HaskellBridge.swift
+++ b/ios/HaskellMobile/HaskellBridge.swift
@@ -27,6 +27,7 @@ class HaskellBridge {
         setup_ios_location_bridge(context)
         setup_ios_auth_session_bridge(context)
         setup_ios_camera_bridge(context)
+        setup_ios_bottom_sheet_bridge(context)
     }
 
     /// Call Haskell's haskellGreet and return the result as a Swift String.

--- a/ios/HaskellMobile/HaskellMobile-Bridging-Header.h
+++ b/ios/HaskellMobile/HaskellMobile-Bridging-Header.h
@@ -7,6 +7,7 @@
 #include "LocationBridge.h"
 #include "AuthSessionBridge.h"
 #include "CameraBridge.h"
+#include "BottomSheetBridge.h"
 
 /* iOS UI bridge setup — called from Swift before haskellRenderUI */
 void setup_ios_ui_bridge(void *viewController, void *haskellCtx);
@@ -31,3 +32,5 @@ void setup_ios_auth_session_bridge(void *haskellCtx);
 
 /* iOS camera bridge setup — called from Swift during initialisation */
 void setup_ios_camera_bridge(void *haskellCtx);
+/* iOS bottom sheet bridge setup — called from Swift during initialisation */
+void setup_ios_bottom_sheet_bridge(void *haskellCtx);

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -171,6 +171,17 @@ let
     name = "haskell-mobile-camera-apk";
   };
 
+  bottomSheetAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/BottomSheetDemoMain.hs;
+  };
+  bottomSheetApk = lib.mkApk {
+    sharedLibs = [{ lib = bottomSheetAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "haskell-mobile-bottomsheet.apk";
+    name = "haskell-mobile-bottomsheet-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -222,6 +233,7 @@ LOCATION_APK="${locationApk}/haskell-mobile-location.apk"
 WEBVIEW_APK="${webviewApk}/haskell-mobile-webview.apk"
 AUTH_SESSION_APK="${authSessionApk}/haskell-mobile-authsession.apk"
 CAMERA_APK="${cameraApk}/haskell-mobile-camera.apk"
+BOTTOM_SHEET_APK="${bottomSheetApk}/haskell-mobile-bottomsheet.apk"
 PACKAGE="me.jappie.haskellmobile"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -244,7 +256,8 @@ for so_path in \
     "${dialogAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${webviewAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${authSessionAndroid}/lib/${abiDir}/libhaskellmobile.so" \
-    "${cameraAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
+    "${cameraAndroid}/lib/${abiDir}/libhaskellmobile.so" \
+    "${bottomSheetAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -308,6 +321,7 @@ PHASE7_OK=0
 PHASE8_OK=0
 PHASE9_OK=0
 PHASE10_OK=0
+PHASE11_OK=0
 
 cleanup() {
     echo ""
@@ -424,7 +438,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK CAMERA_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK CAMERA_APK BOTTOM_SHEET_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -436,6 +450,7 @@ PHASE7_EXIT=0
 PHASE8_EXIT=0
 PHASE9_EXIT=0
 PHASE10_EXIT=0
+PHASE11_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -502,6 +517,8 @@ echo "--- authsession ---"
 run_with_retry "authsession" bash "$TEST_SCRIPTS/android/authsession.sh" || PHASE10_EXIT=1
 echo "--- camera ---"
 run_with_retry "camera" bash "$TEST_SCRIPTS/android/camera.sh" || PHASE10_EXIT=1
+echo "--- bottomsheet ---"
+run_with_retry "bottomsheet" bash "$TEST_SCRIPTS/android/bottomsheet.sh" || PHASE11_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -602,6 +619,16 @@ else
     echo "PHASE 10 FAILED"
 fi
 
+if [ $PHASE11_EXIT -eq 0 ]; then
+    PHASE11_OK=1
+    echo ""
+    echo "PHASE 11 PASSED"
+else
+    PHASE11_OK=0
+    echo ""
+    echo "PHASE 11 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -679,6 +706,13 @@ if [ $PHASE10_OK -eq 1 ]; then
     echo "PASS  Phase 10 — AuthSession demo app"
 else
     echo "FAIL  Phase 10 — AuthSession demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE11_OK -eq 1 ]; then
+    echo "PASS  Phase 11 — BottomSheet demo app"
+else
+    echo "FAIL  Phase 11 — BottomSheet demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -189,6 +189,14 @@ in {
           -o camera_bridge_android.o \
           ${haskellMobileSrc}/cbits/camera_bridge_android.c
 
+        ${ndkCc} -c -fPIC \
+          -DJNI_PACKAGE=me_jappie_haskellmobile \
+          -I${sysroot}/usr/include \
+          -I$RTS_INCLUDE \
+          -I${haskellMobileSrc}/include \
+          -o bottom_sheet_android.o \
+          ${haskellMobileSrc}/cbits/bottom_sheet_android.c
+
         # Compile extra JNI bridge sources (consumer-specific JNI methods)
         ${builtins.concatStringsSep "\n" (builtins.genList (i:
           let src = builtins.elemAt extraJniBridge i;
@@ -225,6 +233,7 @@ in {
         cp ${haskellMobileSrc}/src/HaskellMobile/Location.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/AuthSession.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/Camera.hs HaskellMobile/
+        cp ${haskellMobileSrc}/src/HaskellMobile/BottomSheet.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/AppContext.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile.hs .
 
@@ -255,6 +264,7 @@ in {
         cp ${haskellMobileSrc}/cbits/location_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/auth_session_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/camera_bridge.c cbits/
+        cp ${haskellMobileSrc}/cbits/bottom_sheet_bridge.c cbits/
 
         # Step 4: Compile Haskell to shared library with cross-GHC.
         # Discover library paths dynamically — hash suffixes vary across nixpkgs.
@@ -313,6 +323,7 @@ in {
           cbits/location_bridge.c \
           cbits/auth_session_bridge.c \
           cbits/camera_bridge.c \
+          cbits/bottom_sheet_bridge.c \
           -optl-L${androidPkgs.gmp}/lib \
           -optl-L${androidPkgs.libffi}/lib \
           -optl-lffi \
@@ -327,6 +338,7 @@ in {
           -optl$(pwd)/location_bridge_android.o \
           -optl$(pwd)/auth_session_android.o \
           -optl$(pwd)/camera_bridge_android.o \
+          -optl$(pwd)/bottom_sheet_android.o \
           ${builtins.concatStringsSep " " (builtins.genList (i: "-optl$(pwd)/extra_jni_${toString i}.o") (builtins.length extraJniBridge))} \
           ${builtins.concatStringsSep " " (map (o: "-optl${o}") extraLinkObjects)} \
           -optl-Wl,-u,haskellRunMain \
@@ -344,6 +356,7 @@ in {
           -optl-Wl,-u,haskellOnCameraResult \
           -optl-Wl,-u,haskellOnVideoFrame \
           -optl-Wl,-u,haskellOnAudioChunk \
+          -optl-Wl,-u,haskellOnBottomSheetResult \
           -optl-Wl,-u,haskellLogLocale \
           -optl-Wl,--no-undefined \
           -optl-Wl,--whole-archive \
@@ -543,6 +556,7 @@ in {
         cp ${haskellMobileSrc}/src/HaskellMobile/Location.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/AuthSession.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/Camera.hs HaskellMobile/
+        cp ${haskellMobileSrc}/src/HaskellMobile/BottomSheet.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/AppContext.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile.hs .
 
@@ -569,6 +583,7 @@ in {
         cp ${haskellMobileSrc}/cbits/location_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/auth_session_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/camera_bridge.c cbits/
+        cp ${haskellMobileSrc}/cbits/bottom_sheet_bridge.c cbits/
 
         ghc -staticlib \
           -O2 \
@@ -590,6 +605,7 @@ in {
           -optl-Wl,-u,_haskellOnCameraResult \
           -optl-Wl,-u,_haskellOnVideoFrame \
           -optl-Wl,-u,_haskellOnAudioChunk \
+          -optl-Wl,-u,_haskellOnBottomSheetResult \
           -optl-Wl,-u,_haskellLogLocale \
           cbits/platform_log.c \
           cbits/ui_bridge.c \
@@ -602,6 +618,7 @@ in {
           cbits/location_bridge.c \
           cbits/auth_session_bridge.c \
           cbits/camera_bridge.c \
+          cbits/bottom_sheet_bridge.c \
           Main.hs \
           HaskellMobile.hs
       '';
@@ -626,6 +643,7 @@ in {
         cp ${haskellMobileSrc}/include/LocationBridge.h $out/include/LocationBridge.h
         cp ${haskellMobileSrc}/include/AuthSessionBridge.h $out/include/AuthSessionBridge.h
         cp ${haskellMobileSrc}/include/CameraBridge.h $out/include/CameraBridge.h
+        cp ${haskellMobileSrc}/include/BottomSheetBridge.h $out/include/BottomSheetBridge.h
       '';
     };
 
@@ -683,6 +701,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${iosLib}/include/LocationBridge.h $out/share/ios/include/
         cp ${iosLib}/include/AuthSessionBridge.h $out/share/ios/include/
         cp ${iosLib}/include/CameraBridge.h $out/share/ios/include/
+        cp ${iosLib}/include/BottomSheetBridge.h $out/share/ios/include/
         ${patchProjectYml}
       '';
 
@@ -735,6 +754,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${haskellMobileSrc}/src/HaskellMobile/Location.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/AuthSession.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/Camera.hs HaskellMobile/
+        cp ${haskellMobileSrc}/src/HaskellMobile/BottomSheet.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile/AppContext.hs HaskellMobile/
         cp ${haskellMobileSrc}/src/HaskellMobile.hs .
 
@@ -761,6 +781,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${haskellMobileSrc}/cbits/location_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/auth_session_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/camera_bridge.c cbits/
+        cp ${haskellMobileSrc}/cbits/bottom_sheet_bridge.c cbits/
 
         ghc -staticlib \
           -O2 \
@@ -782,6 +803,7 @@ open(sys.argv[1], "w").write(yml)
           -optl-Wl,-u,_haskellOnCameraResult \
           -optl-Wl,-u,_haskellOnVideoFrame \
           -optl-Wl,-u,_haskellOnAudioChunk \
+          -optl-Wl,-u,_haskellOnBottomSheetResult \
           -optl-Wl,-u,_haskellLogLocale \
           cbits/platform_log.c \
           cbits/ui_bridge.c \
@@ -794,6 +816,7 @@ open(sys.argv[1], "w").write(yml)
           cbits/location_bridge.c \
           cbits/auth_session_bridge.c \
           cbits/camera_bridge.c \
+          cbits/bottom_sheet_bridge.c \
           Main.hs \
           HaskellMobile.hs
       '';
@@ -818,6 +841,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${haskellMobileSrc}/include/LocationBridge.h $out/include/LocationBridge.h
         cp ${haskellMobileSrc}/include/AuthSessionBridge.h $out/include/AuthSessionBridge.h
         cp ${haskellMobileSrc}/include/CameraBridge.h $out/include/CameraBridge.h
+        cp ${haskellMobileSrc}/include/BottomSheetBridge.h $out/include/BottomSheetBridge.h
       '';
     };
 
@@ -850,6 +874,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${watchosLib}/include/LocationBridge.h $out/share/watchos/include/
         cp ${watchosLib}/include/AuthSessionBridge.h $out/share/watchos/include/
         cp ${watchosLib}/include/CameraBridge.h $out/share/watchos/include/
+        cp ${watchosLib}/include/BottomSheetBridge.h $out/share/watchos/include/
       '';
 
       installPhase = "true";

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -155,6 +155,17 @@ let
     name = "haskell-mobile-camera-simulator-app";
   };
 
+  bottomSheetIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/BottomSheetDemoMain.hs;
+    simulator = true;
+  };
+  bottomSheetSimApp = lib.mkSimulatorApp {
+    iosLib = bottomSheetIos;
+    iosSrc = ../ios;
+    name = "haskell-mobile-bottomsheet-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -188,6 +199,7 @@ LOCATION_SHARE_DIR="${locationSimApp}/share/ios"
 WEBVIEW_SHARE_DIR="${webviewSimApp}/share/ios"
 AUTH_SESSION_SHARE_DIR="${authSessionSimApp}/share/ios"
 CAMERA_SHARE_DIR="${cameraSimApp}/share/ios"
+BOTTOM_SHEET_SHARE_DIR="${bottomSheetSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -205,6 +217,7 @@ PHASE7_OK=0
 PHASE8_OK=0
 PHASE9_OK=0
 PHASE10_OK=0
+PHASE11_OK=0
 
 cleanup() {
     echo ""
@@ -238,7 +251,11 @@ for share_dir in \
     "$NODEPOOL_SHARE_DIR" \
     "$BLE_SHARE_DIR" \
     "$DIALOG_SHARE_DIR" \
-    "$AUTH_SESSION_SHARE_DIR"; do
+    "$LOCATION_SHARE_DIR" \
+    "$WEBVIEW_SHARE_DIR" \
+    "$AUTH_SESSION_SHARE_DIR" \
+    "$CAMERA_SHARE_DIR" \
+    "$BOTTOM_SHEET_SHARE_DIR"; do
     a_path="$share_dir/lib/libHaskellMobile.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -278,6 +295,7 @@ cp "$COUNTER_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/counter/include/"
+cp "$COUNTER_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/counter/include/"
 cp -r "$COUNTER_SHARE_DIR/HaskellMobile" "$WORK_DIR/counter/"
 cp "$COUNTER_SHARE_DIR/project.yml" "$WORK_DIR/counter/"
 chmod -R u+w "$WORK_DIR/counter"
@@ -319,6 +337,7 @@ cp "$SCROLL_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/scroll/include/"
+cp "$SCROLL_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/scroll/include/"
 cp -r "$SCROLL_SHARE_DIR/HaskellMobile" "$WORK_DIR/scroll/"
 cp "$SCROLL_SHARE_DIR/project.yml" "$WORK_DIR/scroll/"
 chmod -R u+w "$WORK_DIR/scroll"
@@ -360,6 +379,7 @@ cp "$TEXTINPUT_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/textinput/include/"
+cp "$TEXTINPUT_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/textinput/include/"
 cp -r "$TEXTINPUT_SHARE_DIR/HaskellMobile" "$WORK_DIR/textinput/"
 cp "$TEXTINPUT_SHARE_DIR/project.yml" "$WORK_DIR/textinput/"
 chmod -R u+w "$WORK_DIR/textinput"
@@ -401,6 +421,7 @@ cp "$PERMISSION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/permission/include/
 cp "$PERMISSION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/permission/include/"
 cp "$PERMISSION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/permission/include/"
 cp "$PERMISSION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/permission/include/"
+cp "$PERMISSION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/permission/include/"
 cp -r "$PERMISSION_SHARE_DIR/HaskellMobile" "$WORK_DIR/permission/"
 cp "$PERMISSION_SHARE_DIR/project.yml" "$WORK_DIR/permission/"
 chmod -R u+w "$WORK_DIR/permission"
@@ -442,6 +463,7 @@ cp "$SECURE_STORAGE_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/securestorage/i
 cp "$SECURE_STORAGE_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/securestorage/include/"
+cp "$SECURE_STORAGE_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/securestorage/include/"
 cp -r "$SECURE_STORAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/securestorage/"
 cp "$SECURE_STORAGE_SHARE_DIR/project.yml" "$WORK_DIR/securestorage/"
 chmod -R u+w "$WORK_DIR/securestorage"
@@ -483,6 +505,7 @@ cp "$IMAGE_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/image/include/"
+cp "$IMAGE_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/image/include/"
 cp -r "$IMAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/image/"
 cp "$IMAGE_SHARE_DIR/project.yml" "$WORK_DIR/image/"
 chmod -R u+w "$WORK_DIR/image"
@@ -524,6 +547,7 @@ cp "$NODEPOOL_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/nodepool/include/"
+cp "$NODEPOOL_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/nodepool/include/"
 cp -r "$NODEPOOL_SHARE_DIR/HaskellMobile" "$WORK_DIR/nodepool/"
 cp "$NODEPOOL_SHARE_DIR/project.yml" "$WORK_DIR/nodepool/"
 chmod -R u+w "$WORK_DIR/nodepool"
@@ -565,6 +589,7 @@ cp "$BLE_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/ble/include/"
+cp "$BLE_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/ble/include/"
 cp -r "$BLE_SHARE_DIR/HaskellMobile" "$WORK_DIR/ble/"
 cp "$BLE_SHARE_DIR/project.yml" "$WORK_DIR/ble/"
 chmod -R u+w "$WORK_DIR/ble"
@@ -606,6 +631,7 @@ cp "$DIALOG_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/dialog/include/"
+cp "$DIALOG_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/dialog/include/"
 cp -r "$DIALOG_SHARE_DIR/HaskellMobile" "$WORK_DIR/dialog/"
 cp "$DIALOG_SHARE_DIR/project.yml" "$WORK_DIR/dialog/"
 chmod -R u+w "$WORK_DIR/dialog"
@@ -647,6 +673,7 @@ cp "$LOCATION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/location/include/"
+cp "$LOCATION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/location/include/"
 cp -r "$LOCATION_SHARE_DIR/HaskellMobile" "$WORK_DIR/location/"
 cp "$LOCATION_SHARE_DIR/project.yml" "$WORK_DIR/location/"
 chmod -R u+w "$WORK_DIR/location"
@@ -688,26 +715,10 @@ cp "$WEBVIEW_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/webview/include/"
 cp -r "$WEBVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/webview/"
 cp "$WEBVIEW_SHARE_DIR/project.yml" "$WORK_DIR/webview/"
 chmod -R u+w "$WORK_DIR/webview"
-
-# --- Stage and build camera demo app ---
-echo "=== Staging camera demo app ==="
-mkdir -p "$WORK_DIR/camera/lib" "$WORK_DIR/camera/include"
-cp "$CAMERA_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/camera/lib/"
-cp "$CAMERA_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/camera/include/"
-cp -r "$CAMERA_SHARE_DIR/HaskellMobile" "$WORK_DIR/camera/"
-cp "$CAMERA_SHARE_DIR/project.yml" "$WORK_DIR/camera/"
-chmod -R u+w "$WORK_DIR/camera"
 
 echo "=== Generating webview Xcode project ==="
 cd "$WORK_DIR/webview"
@@ -746,6 +757,7 @@ cp "$AUTH_SESSION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/authsession/inclu
 cp "$AUTH_SESSION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/authsession/include/"
+cp "$AUTH_SESSION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/authsession/include/"
 cp -r "$AUTH_SESSION_SHARE_DIR/HaskellMobile" "$WORK_DIR/authsession/"
 cp "$AUTH_SESSION_SHARE_DIR/project.yml" "$WORK_DIR/authsession/"
 chmod -R u+w "$WORK_DIR/authsession"
@@ -774,6 +786,24 @@ if [ -z "$AUTH_SESSION_APP" ]; then
 fi
 echo "AuthSession app: $AUTH_SESSION_APP"
 
+# --- Stage and build camera demo app ---
+echo "=== Staging camera demo app ==="
+mkdir -p "$WORK_DIR/camera/lib" "$WORK_DIR/camera/include"
+cp "$CAMERA_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/camera/lib/"
+cp "$CAMERA_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/camera/include/"
+cp -r "$CAMERA_SHARE_DIR/HaskellMobile" "$WORK_DIR/camera/"
+cp "$CAMERA_SHARE_DIR/project.yml" "$WORK_DIR/camera/"
+chmod -R u+w "$WORK_DIR/camera"
+
 echo "=== Generating camera Xcode project ==="
 cd "$WORK_DIR/camera"
 ${xcodegen}/bin/xcodegen generate
@@ -797,6 +827,48 @@ if [ -z "$CAMERA_APP" ]; then
     exit 1
 fi
 echo "Camera app: $CAMERA_APP"
+
+# --- Stage and build bottomsheet demo app ---
+echo "=== Staging bottomsheet demo app ==="
+mkdir -p "$WORK_DIR/bottomsheet/lib" "$WORK_DIR/bottomsheet/include"
+cp "$BOTTOM_SHEET_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/bottomsheet/lib/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp -r "$BOTTOM_SHEET_SHARE_DIR/HaskellMobile" "$WORK_DIR/bottomsheet/"
+cp "$BOTTOM_SHEET_SHARE_DIR/project.yml" "$WORK_DIR/bottomsheet/"
+chmod -R u+w "$WORK_DIR/bottomsheet"
+
+echo "=== Generating bottomsheet Xcode project ==="
+cd "$WORK_DIR/bottomsheet"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building bottomsheet demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/bottomsheet-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+BOTTOM_SHEET_APP=$(find "$WORK_DIR/bottomsheet-build" -name "*.app" -type d | head -1)
+if [ -z "$BOTTOM_SHEET_APP" ]; then
+    echo "ERROR: Could not find bottomsheet .app bundle"
+    exit 1
+fi
+echo "BottomSheet app: $BOTTOM_SHEET_APP"
 
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
@@ -859,7 +931,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -871,6 +943,7 @@ PHASE7_EXIT=0
 PHASE8_EXIT=0
 PHASE9_EXIT=0
 PHASE10_EXIT=0
+PHASE11_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -937,6 +1010,8 @@ echo "--- authsession ---"
 run_with_retry "authsession" bash "$TEST_SCRIPTS/ios/authsession.sh" || PHASE10_EXIT=1
 echo "--- camera ---"
 run_with_retry "camera" bash "$TEST_SCRIPTS/ios/camera.sh" || PHASE10_EXIT=1
+echo "--- bottomsheet ---"
+run_with_retry "bottomsheet" bash "$TEST_SCRIPTS/ios/bottomsheet.sh" || PHASE11_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1037,6 +1112,16 @@ else
     echo "PHASE 10 FAILED"
 fi
 
+if [ $PHASE11_EXIT -eq 0 ]; then
+    PHASE11_OK=1
+    echo ""
+    echo "PHASE 11 PASSED"
+else
+    PHASE11_OK=0
+    echo ""
+    echo "PHASE 11 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1114,6 +1199,13 @@ if [ $PHASE10_OK -eq 1 ]; then
     echo "PASS  Phase 10 — AuthSession demo app"
 else
     echo "FAIL  Phase 10 — AuthSession demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE11_OK -eq 1 ]; then
+    echo "PASS  Phase 11 — BottomSheet demo app"
+else
+    echo "FAIL  Phase 11 — BottomSheet demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -145,6 +145,17 @@ let
     name = "haskell-mobile-watchos-camera-simulator-app";
   };
 
+  bottomSheetWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/BottomSheetDemoMain.hs;
+    simulator = true;
+  };
+  bottomSheetSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = bottomSheetWatchos;
+    watchosSrc = ../watchos;
+    name = "haskell-mobile-watchos-bottomsheet-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -177,6 +188,7 @@ LOCATION_SHARE_DIR="${locationSimApp}/share/watchos"
 WEBVIEW_SHARE_DIR="${webviewSimApp}/share/watchos"
 AUTH_SESSION_SHARE_DIR="${authSessionSimApp}/share/watchos"
 CAMERA_SHARE_DIR="${cameraSimApp}/share/watchos"
+BOTTOM_SHEET_SHARE_DIR="${bottomSheetSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -193,6 +205,8 @@ PHASE6_OK=0
 PHASE7_OK=0
 PHASE8_OK=0
 PHASE9_OK=0
+PHASE10_OK=0
+PHASE11_OK=0
 
 cleanup() {
     echo ""
@@ -224,7 +238,11 @@ for share_dir in \
     "$NODEPOOL_SHARE_DIR" \
     "$BLE_SHARE_DIR" \
     "$DIALOG_SHARE_DIR" \
-    "$AUTH_SESSION_SHARE_DIR"; do
+    "$LOCATION_SHARE_DIR" \
+    "$WEBVIEW_SHARE_DIR" \
+    "$AUTH_SESSION_SHARE_DIR" \
+    "$CAMERA_SHARE_DIR" \
+    "$BOTTOM_SHEET_SHARE_DIR"; do
     a_path="$share_dir/lib/libHaskellMobile.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -264,6 +282,7 @@ cp "$COUNTER_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/counter/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/counter/include/"
 cp -r "$COUNTER_SHARE_DIR/HaskellMobile" "$WORK_DIR/counter/"
 cp "$COUNTER_SHARE_DIR/project.yml" "$WORK_DIR/counter/"
 chmod -R u+w "$WORK_DIR/counter"
@@ -305,6 +324,7 @@ cp "$SCROLL_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/scroll/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/scroll/include/"
 cp -r "$SCROLL_SHARE_DIR/HaskellMobile" "$WORK_DIR/scroll/"
 cp "$SCROLL_SHARE_DIR/project.yml" "$WORK_DIR/scroll/"
 chmod -R u+w "$WORK_DIR/scroll"
@@ -346,6 +366,7 @@ cp "$TEXTINPUT_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/textinput/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/textinput/include/"
 cp -r "$TEXTINPUT_SHARE_DIR/HaskellMobile" "$WORK_DIR/textinput/"
 cp "$TEXTINPUT_SHARE_DIR/project.yml" "$WORK_DIR/textinput/"
 chmod -R u+w "$WORK_DIR/textinput"
@@ -387,6 +408,7 @@ cp "$IMAGE_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/image/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/image/include/"
 cp -r "$IMAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/image/"
 cp "$IMAGE_SHARE_DIR/project.yml" "$WORK_DIR/image/"
 chmod -R u+w "$WORK_DIR/image"
@@ -428,6 +450,7 @@ cp "$SECURE_STORAGE_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/securestorage/i
 cp "$SECURE_STORAGE_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/securestorage/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/securestorage/include/"
 cp -r "$SECURE_STORAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/securestorage/"
 cp "$SECURE_STORAGE_SHARE_DIR/project.yml" "$WORK_DIR/securestorage/"
 chmod -R u+w "$WORK_DIR/securestorage"
@@ -468,6 +491,7 @@ cp "$NODEPOOL_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/nodepool/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/nodepool/include/"
 cp -r "$NODEPOOL_SHARE_DIR/HaskellMobile" "$WORK_DIR/nodepool/"
 cp "$NODEPOOL_SHARE_DIR/project.yml" "$WORK_DIR/nodepool/"
 chmod -R u+w "$WORK_DIR/nodepool"
@@ -509,6 +533,7 @@ cp "$BLE_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/ble/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/ble/include/"
 cp -r "$BLE_SHARE_DIR/HaskellMobile" "$WORK_DIR/ble/"
 cp "$BLE_SHARE_DIR/project.yml" "$WORK_DIR/ble/"
 chmod -R u+w "$WORK_DIR/ble"
@@ -550,6 +575,7 @@ cp "$DIALOG_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/dialog/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/dialog/include/"
 cp -r "$DIALOG_SHARE_DIR/HaskellMobile" "$WORK_DIR/dialog/"
 cp "$DIALOG_SHARE_DIR/project.yml" "$WORK_DIR/dialog/"
 chmod -R u+w "$WORK_DIR/dialog"
@@ -591,6 +617,7 @@ cp "$LOCATION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/location/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/location/include/"
 cp -r "$LOCATION_SHARE_DIR/HaskellMobile" "$WORK_DIR/location/"
 cp "$LOCATION_SHARE_DIR/project.yml" "$WORK_DIR/location/"
 chmod -R u+w "$WORK_DIR/location"
@@ -632,26 +659,10 @@ cp "$WEBVIEW_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/webview/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/webview/include/"
 cp -r "$WEBVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/webview/"
 cp "$WEBVIEW_SHARE_DIR/project.yml" "$WORK_DIR/webview/"
 chmod -R u+w "$WORK_DIR/webview"
-
-# --- Stage and build camera demo app ---
-echo "=== Staging camera demo app ==="
-mkdir -p "$WORK_DIR/camera/lib" "$WORK_DIR/camera/include"
-cp "$CAMERA_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/camera/lib/"
-cp "$CAMERA_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/camera/include/"
-cp "$CAMERA_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/camera/include/"
-cp -r "$CAMERA_SHARE_DIR/HaskellMobile" "$WORK_DIR/camera/"
-cp "$CAMERA_SHARE_DIR/project.yml" "$WORK_DIR/camera/"
-chmod -R u+w "$WORK_DIR/camera"
 
 echo "=== Generating webview Xcode project ==="
 cd "$WORK_DIR/webview"
@@ -690,6 +701,7 @@ cp "$AUTH_SESSION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/authsession/inclu
 cp "$AUTH_SESSION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/authsession/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/authsession/include/"
 cp -r "$AUTH_SESSION_SHARE_DIR/HaskellMobile" "$WORK_DIR/authsession/"
 cp "$AUTH_SESSION_SHARE_DIR/project.yml" "$WORK_DIR/authsession/"
 chmod -R u+w "$WORK_DIR/authsession"
@@ -718,6 +730,24 @@ if [ -z "$AUTH_SESSION_APP" ]; then
 fi
 echo "AuthSession app: $AUTH_SESSION_APP"
 
+# --- Stage and build camera demo app ---
+echo "=== Staging camera demo app ==="
+mkdir -p "$WORK_DIR/camera/lib" "$WORK_DIR/camera/include"
+cp "$CAMERA_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/camera/lib/"
+cp "$CAMERA_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/camera/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/camera/include/"
+cp -r "$CAMERA_SHARE_DIR/HaskellMobile" "$WORK_DIR/camera/"
+cp "$CAMERA_SHARE_DIR/project.yml" "$WORK_DIR/camera/"
+chmod -R u+w "$WORK_DIR/camera"
+
 echo "=== Generating camera Xcode project ==="
 cd "$WORK_DIR/camera"
 ${xcodegen}/bin/xcodegen generate
@@ -741,6 +771,48 @@ if [ -z "$CAMERA_APP" ]; then
     exit 1
 fi
 echo "Camera app: $CAMERA_APP"
+
+# --- Stage and build bottomsheet demo app ---
+echo "=== Staging bottomsheet demo app ==="
+mkdir -p "$WORK_DIR/bottomsheet/lib" "$WORK_DIR/bottomsheet/include"
+cp "$BOTTOM_SHEET_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/bottomsheet/lib/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp -r "$BOTTOM_SHEET_SHARE_DIR/HaskellMobile" "$WORK_DIR/bottomsheet/"
+cp "$BOTTOM_SHEET_SHARE_DIR/project.yml" "$WORK_DIR/bottomsheet/"
+chmod -R u+w "$WORK_DIR/bottomsheet"
+
+echo "=== Generating bottomsheet Xcode project ==="
+cd "$WORK_DIR/bottomsheet"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building bottomsheet demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/bottomsheet-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+BOTTOM_SHEET_APP=$(find "$WORK_DIR/bottomsheet-build" -name "*.app" -type d | head -1)
+if [ -z "$BOTTOM_SHEET_APP" ]; then
+    echo "ERROR: Could not find bottomsheet .app bundle"
+    exit 1
+fi
+echo "BottomSheet app: $BOTTOM_SHEET_APP"
 
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
@@ -805,7 +877,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.haskellmobile"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -816,6 +888,8 @@ PHASE6_EXIT=0
 PHASE7_EXIT=0
 PHASE8_EXIT=0
 PHASE9_EXIT=0
+PHASE10_EXIT=0
+PHASE11_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -872,7 +946,9 @@ run_with_retry "webview" bash "$TEST_SCRIPTS/watchos/webview.sh" || PHASE8_EXIT=
 echo "--- authsession ---"
 run_with_retry "authsession" bash "$TEST_SCRIPTS/watchos/authsession.sh" || PHASE9_EXIT=1
 echo "--- camera ---"
-run_with_retry "camera" bash "$TEST_SCRIPTS/watchos/camera.sh" || PHASE9_EXIT=1
+run_with_retry "camera" bash "$TEST_SCRIPTS/watchos/camera.sh" || PHASE10_EXIT=1
+echo "--- bottomsheet ---"
+run_with_retry "bottomsheet" bash "$TEST_SCRIPTS/watchos/bottomsheet.sh" || PHASE11_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -963,6 +1039,26 @@ else
     echo "PHASE 9 FAILED"
 fi
 
+if [ $PHASE10_EXIT -eq 0 ]; then
+    PHASE10_OK=1
+    echo ""
+    echo "PHASE 10 PASSED"
+else
+    PHASE10_OK=0
+    echo ""
+    echo "PHASE 10 FAILED"
+fi
+
+if [ $PHASE11_EXIT -eq 0 ]; then
+    PHASE11_OK=1
+    echo ""
+    echo "PHASE 11 PASSED"
+else
+    PHASE11_OK=0
+    echo ""
+    echo "PHASE 11 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1033,6 +1129,20 @@ if [ $PHASE9_OK -eq 1 ]; then
     echo "PASS  Phase 9 — AuthSession demo app"
 else
     echo "FAIL  Phase 9 — AuthSession demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE10_OK -eq 1 ]; then
+    echo "PASS  Phase 10 — Camera demo app"
+else
+    echo "FAIL  Phase 10 — Camera demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE11_OK -eq 1 ]; then
+    echo "PASS  Phase 11 — BottomSheet demo app"
+else
+    echo "FAIL  Phase 11 — BottomSheet demo app"
     FINAL_EXIT=1
 fi
 

--- a/src/HaskellMobile.hs
+++ b/src/HaskellMobile.hs
@@ -16,6 +16,7 @@ module HaskellMobile
   , haskellOnLocationUpdate
   , haskellOnAuthSessionResult
   , haskellOnCameraResult
+  , haskellOnBottomSheetResult
   -- Error handling
   , errorWidget
   -- Re-exports from Lifecycle
@@ -90,6 +91,11 @@ module HaskellMobile
   , stopVideoCapture
   , haskellOnVideoFrame
   , haskellOnAudioChunk
+  -- Re-exports from BottomSheet
+  , BottomSheetAction(..)
+  , BottomSheetConfig(..)
+  , BottomSheetState(..)
+  , showBottomSheet
   )
 where
 
@@ -105,6 +111,13 @@ import HaskellMobile.AuthSession
   , AuthSessionState(..)
   , startAuthSession
   , dispatchAuthSessionResult
+  )
+import HaskellMobile.BottomSheet
+  ( BottomSheetAction(..)
+  , BottomSheetConfig(..)
+  , BottomSheetState(..)
+  , showBottomSheet
+  , dispatchBottomSheetResult
   )
 import HaskellMobile.Ble
   ( BleAdapterStatus(..)
@@ -230,6 +243,7 @@ renderView ctxPtr = do
         , userLocationState      = acLocationState appCtx
         , userAuthSessionState   = acAuthSessionState appCtx
         , userCameraState        = acCameraState appCtx
+        , userBottomSheetState   = acBottomSheetState appCtx
         }
   widget <- viewFunction userState
   renderWidget (acRenderState appCtx) widget
@@ -426,6 +440,15 @@ haskellOnAudioChunk ctxPtr requestId audioDataPtr audioDataLen =
 
 foreign export ccall haskellOnAudioChunk
   :: Ptr AppContext -> CInt -> Ptr Word8 -> CInt -> IO ()
+-- | Handle a bottom sheet result from native code. Dispatches to the
+-- callback registered by 'showBottomSheet'.
+haskellOnBottomSheetResult :: Ptr AppContext -> CInt -> CInt -> IO ()
+haskellOnBottomSheetResult ctxPtr requestId actionCode =
+  withExceptionHandler ctxPtr $ do
+    appCtx <- derefAppContext ctxPtr
+    dispatchBottomSheetResult (acBottomSheetState appCtx) requestId actionCode
+
+foreign export ccall haskellOnBottomSheetResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 
 -- | Peek an optional CString: returns 'Nothing' for null pointers,
 -- 'Just' with the decoded 'Text' otherwise.

--- a/src/HaskellMobile/AppContext.hs
+++ b/src/HaskellMobile/AppContext.hs
@@ -17,6 +17,7 @@ import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, new
 import HaskellMobile.AuthSession (AuthSessionState(..), newAuthSessionState)
 import HaskellMobile.Ble (BleState(..), newBleState)
 import HaskellMobile.Camera (CameraState(..), newCameraState)
+import HaskellMobile.BottomSheet (BottomSheetState(..), newBottomSheetState)
 import HaskellMobile.Dialog (DialogState(..), newDialogState)
 import HaskellMobile.Lifecycle (MobileContext)
 import HaskellMobile.Location (LocationState(..), newLocationState)
@@ -40,6 +41,7 @@ data AppContext = AppContext
   , acLocationState       :: LocationState
   , acAuthSessionState    :: AuthSessionState
   , acCameraState         :: CameraState
+  , acBottomSheetState    :: BottomSheetState
   , acViewFunction        :: IORef (UserState -> IO Widget)
   }
 
@@ -56,6 +58,7 @@ newAppContext mobileApp = do
   locationState      <- newLocationState
   authSessionState   <- newAuthSessionState
   cameraState        <- newCameraState
+  bottomSheetState   <- newBottomSheetState
   viewRef            <- newIORef (maView mobileApp)
   let appContext = AppContext
         { acMobileContext      = maContext mobileApp
@@ -67,6 +70,7 @@ newAppContext mobileApp = do
         , acLocationState      = locationState
         , acAuthSessionState   = authSessionState
         , acCameraState        = cameraState
+        , acBottomSheetState   = bottomSheetState
         , acViewFunction       = viewRef
         }
   ptr <- castPtr . castStablePtrToPtr <$> newStablePtr appContext
@@ -78,6 +82,7 @@ newAppContext mobileApp = do
   writeIORef (lsContextPtr locationState) (castPtr ptr)
   writeIORef (asContextPtr authSessionState) (castPtr ptr)
   writeIORef (csContextPtr cameraState) (castPtr ptr)
+  writeIORef (bssContextPtr bottomSheetState) (castPtr ptr)
   pure ptr
 
 -- | Release a pointer previously created by 'newAppContext'.

--- a/src/HaskellMobile/BottomSheet.hs
+++ b/src/HaskellMobile/BottomSheet.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- | Bottom sheet / action menu API for mobile platforms.
 --
 -- Provides an imperative API for showing platform-native bottom sheets

--- a/src/HaskellMobile/BottomSheet.hs
+++ b/src/HaskellMobile/BottomSheet.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+-- | Bottom sheet / action menu API for mobile platforms.
+--
+-- Provides an imperative API for showing platform-native bottom sheets
+-- (Android BottomSheetDialog, iOS UISheetPresentationController,
+-- watchOS .confirmationDialog).
+-- Bottom sheets are fire-and-forget: the platform manages the sheet lifecycle
+-- independently of the Haskell UI rendering loop.
+--
+-- The callback registry follows the same sequential 'IORef' 'Int32'
+-- pattern used by "HaskellMobile.Dialog" and "HaskellMobile.Permission".
+module HaskellMobile.BottomSheet
+  ( BottomSheetAction(..)
+  , BottomSheetConfig(..)
+  , BottomSheetState(..)
+  , newBottomSheetState
+  , bottomSheetActionFromInt
+  , showBottomSheet
+  , dispatchBottomSheetResult
+  )
+where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
+import Data.Int (Int32)
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Foreign.C.String (CString, withCString)
+import Foreign.C.Types (CInt(..))
+import Foreign.Ptr (Ptr, nullPtr)
+import System.IO (hPutStrLn, stderr)
+
+-- | Result of a bottom sheet interaction.
+data BottomSheetAction
+  = BottomSheetItemSelected Int32  -- ^ 0-based index of the selected item
+  | BottomSheetDismissed           -- ^ The user dismissed the sheet without selecting
+  deriving (Show, Eq)
+
+-- | Configuration for a bottom sheet.
+data BottomSheetConfig = BottomSheetConfig
+  { bscTitle :: Text       -- ^ Sheet title
+  , bscItems :: [Text]     -- ^ Selectable item labels
+  }
+
+-- | Mutable state for the bottom sheet callback registry.
+data BottomSheetState = BottomSheetState
+  { bssCallbacks  :: IORef (IntMap (BottomSheetAction -> IO ()))
+    -- ^ Map from requestId -> bottom sheet result callback
+  , bssNextId     :: IORef Int32
+    -- ^ Next available request ID
+  , bssContextPtr :: IORef (Ptr ())
+    -- ^ Opaque context pointer passed to the C bridge.
+    -- Set by 'AppContext.newAppContext' after the 'StablePtr' is created.
+  }
+
+-- | Create a fresh 'BottomSheetState' with no pending callbacks.
+-- The context pointer is initially null and must be set via
+-- 'bssContextPtr' before calling 'showBottomSheet'.
+newBottomSheetState :: IO BottomSheetState
+newBottomSheetState = do
+  callbacks  <- newIORef IntMap.empty
+  nextId     <- newIORef 0
+  contextPtr <- newIORef nullPtr
+  pure BottomSheetState
+    { bssCallbacks  = callbacks
+    , bssNextId     = nextId
+    , bssContextPtr = contextPtr
+    }
+
+-- | Convert a C bridge action code to 'BottomSheetAction'.
+-- @-1@ is dismissed, @>= 0@ is item index.
+-- Returns 'Nothing' for codes @< -1@.
+bottomSheetActionFromInt :: CInt -> Maybe BottomSheetAction
+bottomSheetActionFromInt (-1) = Just BottomSheetDismissed
+bottomSheetActionFromInt code
+  | code >= 0 = Just (BottomSheetItemSelected (fromIntegral code))
+  | otherwise = Nothing
+
+-- | Show a bottom sheet with the given configuration.  Registers
+-- @callback@ and calls the C bridge.  The callback fires when the
+-- user taps an item or dismisses the sheet (or synchronously on
+-- desktop via the stub that auto-selects the first item).
+showBottomSheet :: BottomSheetState -> BottomSheetConfig -> (BottomSheetAction -> IO ()) -> IO ()
+showBottomSheet bottomSheetState config callback = do
+  requestId <- readIORef (bssNextId bottomSheetState)
+  modifyIORef' (bssCallbacks bottomSheetState) (IntMap.insert (fromIntegral requestId) callback)
+  writeIORef (bssNextId bottomSheetState) (requestId + 1)
+  ctx <- readIORef (bssContextPtr bottomSheetState)
+  let joinedItems = Text.unpack (Text.intercalate "\n" (bscItems config))
+  withCString (Text.unpack (bscTitle config)) $ \cTitle ->
+    withCString joinedItems $ \cItems ->
+      c_bottomSheetShow ctx (fromIntegral requestId) cTitle cItems
+
+-- | Dispatch a bottom sheet result from the platform back to the
+-- registered Haskell callback.  Removes the callback after firing.
+-- Unknown request IDs or action codes are silently logged to stderr.
+dispatchBottomSheetResult :: BottomSheetState -> CInt -> CInt -> IO ()
+dispatchBottomSheetResult bottomSheetState requestId actionCode =
+  case bottomSheetActionFromInt actionCode of
+    Nothing -> hPutStrLn stderr $
+      "dispatchBottomSheetResult: unknown action code " ++ show actionCode
+    Just action -> do
+      let reqKey = fromIntegral requestId
+      callbacks <- readIORef (bssCallbacks bottomSheetState)
+      case IntMap.lookup reqKey callbacks of
+        Just callback -> do
+          modifyIORef' (bssCallbacks bottomSheetState) (IntMap.delete reqKey)
+          callback action
+        Nothing -> hPutStrLn stderr $
+          "dispatchBottomSheetResult: unknown request ID " ++ show requestId
+
+-- | FFI import: show a bottom sheet via the C bridge.
+foreign import ccall "bottom_sheet_show"
+  c_bottomSheetShow :: Ptr () -> CInt -> CString -> CString -> IO ()

--- a/src/HaskellMobile/Types.hs
+++ b/src/HaskellMobile/Types.hs
@@ -11,6 +11,7 @@ where
 import HaskellMobile.AuthSession (AuthSessionState)
 import HaskellMobile.Ble (BleState)
 import HaskellMobile.Camera (CameraState)
+import HaskellMobile.BottomSheet (BottomSheetState)
 import HaskellMobile.Dialog (DialogState)
 import HaskellMobile.Lifecycle (MobileContext)
 import HaskellMobile.Location (LocationState)
@@ -30,6 +31,7 @@ data UserState = UserState
   , userLocationState      :: LocationState
   , userAuthSessionState   :: AuthSessionState
   , userCameraState        :: CameraState
+  , userBottomSheetState   :: BottomSheetState
   }
 
 -- | Application definition record. Downstream apps create one of these

--- a/test/BottomSheetDemoMain.hs
+++ b/test/BottomSheetDemoMain.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Mobile entry point for the bottom-sheet-demo test app.
+--
+-- Used by the emulator and simulator bottom sheet integration tests.
+-- Starts directly in bottom-sheet-demo mode so no runtime switching is needed.
+module Main where
+
+import Data.Text (pack)
+import Foreign.Ptr (Ptr)
+import HaskellMobile
+  ( MobileApp(..)
+  , UserState(..)
+  , BottomSheetAction(..)
+  , BottomSheetConfig(..)
+  , AppContext
+  , startMobileApp
+  , platformLog
+  , showBottomSheet
+  , loggingMobileContext
+  )
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+
+main :: IO (Ptr AppContext)
+main = do
+  ctxPtr <- startMobileApp bottomSheetDemoApp
+  platformLog "BottomSheet demo app registered"
+  pure ctxPtr
+
+-- | Bottom sheet demo: shows action menu on button tap.
+-- Used by integration tests to verify the bottom sheet FFI bridge end-to-end.
+bottomSheetDemoApp :: MobileApp
+bottomSheetDemoApp = MobileApp
+  { maContext = loggingMobileContext
+  , maView    = bottomSheetDemoView
+  }
+
+-- | Builds a Column with a label and a "Show Actions" button.
+bottomSheetDemoView :: UserState -> IO Widget
+bottomSheetDemoView userState = pure $ Column
+  [ Text TextConfig { tcLabel = "BottomSheet Demo", tcFontConfig = Nothing }
+  , Button ButtonConfig
+      { bcLabel = "Show Actions"
+      , bcAction = showBottomSheet (userBottomSheetState userState)
+          BottomSheetConfig
+            { bscTitle = "Choose Action"
+            , bscItems = ["Edit", "Delete", "Share"]
+            }
+          (\action -> platformLog ("BottomSheet result: " <> pack (show action)))
+      , bcFontConfig = Nothing
+      }
+  ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -126,6 +126,15 @@ import HaskellMobile.AuthSession
   , dispatchAuthSessionResult
   , authSessionResultFromInt
   )
+import HaskellMobile.BottomSheet
+  ( BottomSheetAction(..)
+  , BottomSheetConfig(..)
+  , BottomSheetState(..)
+  , newBottomSheetState
+  , showBottomSheet
+  , dispatchBottomSheetResult
+  , bottomSheetActionFromInt
+  )
 
 main :: IO ()
 main = do
@@ -134,10 +143,10 @@ main = do
   -- one context can be active for FFI permission dispatch.
   ffiCtxPtr <- startMobileApp mobileApp
   ffiAppCtx <- derefAppContext ffiCtxPtr
-  defaultMain (tests (acPermissionState ffiAppCtx) (acSecureStorageState ffiAppCtx) (acDialogState ffiAppCtx) (acAuthSessionState ffiAppCtx))
+  defaultMain (tests (acPermissionState ffiAppCtx) (acSecureStorageState ffiAppCtx) (acDialogState ffiAppCtx) (acAuthSessionState ffiAppCtx) (acBottomSheetState ffiAppCtx))
 
-tests :: PermissionState -> SecureStorageState -> DialogState -> AuthSessionState -> TestTree
-tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, appContextTests, exceptionHandlerTests]
+tests :: PermissionState -> SecureStorageState -> DialogState -> AuthSessionState -> BottomSheetState -> TestTree
+tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, appContextTests, exceptionHandlerTests]
 
 qcProps :: TestTree
 qcProps = testGroup "(checked by QuickCheck)"
@@ -320,6 +329,7 @@ uiTests = testGroup "UI"
       dummyLocationState <- newLocationState
       dummyAuthSessionState <- newAuthSessionState
       dummyCameraState <- newCameraState
+      dummyBottomSheetState <- newBottomSheetState
       let dummyUserState = UserState
             { userPermissionState    = dummyPermState
             , userSecureStorageState = dummySecureStorageState
@@ -328,6 +338,7 @@ uiTests = testGroup "UI"
             , userLocationState      = dummyLocationState
             , userAuthSessionState   = dummyAuthSessionState
             , userCameraState        = dummyCameraState
+            , userBottomSheetState   = dummyBottomSheetState
             }
       widget <- maView mobileApp dummyUserState
       -- mobileApp is the counter demo; verify it's a column
@@ -765,6 +776,7 @@ registrationTests = testGroup "Registration"
       dummyLocationState <- newLocationState
       dummyAuthSessionState <- newAuthSessionState
       dummyCameraState <- newCameraState
+      dummyBottomSheetState <- newBottomSheetState
       let dummyUserState = UserState
             { userPermissionState    = dummyPermState
             , userSecureStorageState = dummySecureStorageState
@@ -773,6 +785,7 @@ registrationTests = testGroup "Registration"
             , userLocationState      = dummyLocationState
             , userAuthSessionState   = dummyAuthSessionState
             , userCameraState        = dummyCameraState
+            , userBottomSheetState   = dummyBottomSheetState
             }
       viewFn <- readIORef (acViewFunction appCtx)
       widget <- viewFn dummyUserState
@@ -801,6 +814,7 @@ registrationTests = testGroup "Registration"
       dummyLocationState <- newLocationState
       dummyAuthSessionState <- newAuthSessionState
       dummyCameraState <- newCameraState
+      dummyBottomSheetState <- newBottomSheetState
       let dummyUserState = UserState
             { userPermissionState    = dummyPermState
             , userSecureStorageState = dummySecureStorageState
@@ -809,6 +823,7 @@ registrationTests = testGroup "Registration"
             , userLocationState      = dummyLocationState
             , userAuthSessionState   = dummyAuthSessionState
             , userCameraState        = dummyCameraState
+            , userBottomSheetState   = dummyBottomSheetState
             }
       viewFnA <- readIORef (acViewFunction appCtxA)
       viewFnB <- readIORef (acViewFunction appCtxB)
@@ -1443,6 +1458,66 @@ locationTests = testGroup "Location"
       freeAppContext ctxPtr
   ]
 
+bottomSheetTests :: BottomSheetState -> TestTree
+bottomSheetTests ffiBottomSheetState = sequentialTestGroup "BottomSheet" AllFinish
+  [ testCase "showBottomSheet registers callback and desktop stub selects first item" $ do
+      ref <- newIORef (Nothing :: Maybe BottomSheetAction)
+      showBottomSheet ffiBottomSheetState
+        BottomSheetConfig
+          { bscTitle = "Actions"
+          , bscItems = ["Edit", "Delete", "Share"]
+          }
+        (\action -> writeIORef ref (Just action))
+      result <- readIORef ref
+      result @?= Just (BottomSheetItemSelected 0)
+
+  , testCase "dispatchBottomSheetResult fires ItemSelected callback" $ do
+      ref <- newIORef (Nothing :: Maybe BottomSheetAction)
+      bottomSheetState <- newBottomSheetState
+      modifyIORef' (bssCallbacks bottomSheetState) (\_ ->
+        IntMap.singleton 0 (\action -> writeIORef ref (Just action)))
+      dispatchBottomSheetResult bottomSheetState 0 2  -- item index 2
+      result <- readIORef ref
+      result @?= Just (BottomSheetItemSelected 2)
+
+  , testCase "dispatchBottomSheetResult fires Dismissed callback" $ do
+      ref <- newIORef (Nothing :: Maybe BottomSheetAction)
+      bottomSheetState <- newBottomSheetState
+      modifyIORef' (bssCallbacks bottomSheetState) (\_ ->
+        IntMap.singleton 0 (\action -> writeIORef ref (Just action)))
+      dispatchBottomSheetResult bottomSheetState 0 (-1)  -- dismissed
+      result <- readIORef ref
+      result @?= Just BottomSheetDismissed
+
+  , testCase "callback removed after dispatch (idempotency)" $ do
+      ref <- newIORef (0 :: Int)
+      bottomSheetState <- newBottomSheetState
+      modifyIORef' (bssCallbacks bottomSheetState) (\_ ->
+        IntMap.singleton 0 (\_ -> modifyIORef' ref (+ 1)))
+      dispatchBottomSheetResult bottomSheetState 0 0
+      count1 <- readIORef ref
+      count1 @?= 1
+      -- Second dispatch for same ID should be a no-op (callback removed)
+      dispatchBottomSheetResult bottomSheetState 0 0
+      count2 <- readIORef ref
+      count2 @?= 1
+
+  , testCase "bottomSheetActionFromInt roundtrips valid codes" $ do
+      bottomSheetActionFromInt 0 @?= Just (BottomSheetItemSelected 0)
+      bottomSheetActionFromInt 1 @?= Just (BottomSheetItemSelected 1)
+      bottomSheetActionFromInt 5 @?= Just (BottomSheetItemSelected 5)
+      bottomSheetActionFromInt (-1) @?= Just BottomSheetDismissed
+
+  , testCase "bottomSheetActionFromInt rejects invalid codes" $ do
+      bottomSheetActionFromInt (-2) @?= Nothing
+      bottomSheetActionFromInt (-100) @?= Nothing
+
+  , testCase "unknown requestId does not crash" $ do
+      bottomSheetState <- newBottomSheetState
+      -- Should not throw (logs to stderr)
+      dispatchBottomSheetResult bottomSheetState 999 0
+  ]
+
 -- | Tests for the AppContext FFI path.
 cameraTests :: TestTree
 cameraTests = testGroup "Camera"
@@ -1664,6 +1739,7 @@ viewIsErrorWidget ctxPtr = do
         , userLocationState      = acLocationState appCtx
         , userAuthSessionState   = acAuthSessionState appCtx
         , userCameraState        = acCameraState appCtx
+        , userBottomSheetState   = acBottomSheetState appCtx
         }
   widget <- viewFn userState
   case widget of

--- a/test/android/bottomsheet.sh
+++ b/test/android/bottomsheet.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Android bottom sheet test: install APK, tap Show Actions, tap Edit item,
+# and assert that the callback fires correctly.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, BOTTOM_SHEET_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+install_apk "$BOTTOM_SHEET_APK" || { echo "FAIL: install_apk"; exit 1; }
+
+"$ADB" -s "$EMULATOR_SERIAL" logcat -c
+"$ADB" -s "$EMULATOR_SERIAL" shell am start -n "$PACKAGE/$ACTIVITY"
+
+wait_for_logcat "setRoot" 120 || true
+sleep 5
+
+# Tap the "Show Actions" button
+tap_button "Show Actions" || { echo "FAIL: could not tap Show Actions"; EXIT_CODE=1; }
+sleep 3
+
+# Tap "Edit" in the bottom sheet
+tap_button "Edit" || { echo "FAIL: could not tap Edit"; EXIT_CODE=1; }
+sleep 3
+
+LOGCAT_FILE="$WORK_DIR/bottomsheet_logcat.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_FILE" 2>&1
+
+assert_logcat "$LOGCAT_FILE" "BottomSheet result: BottomSheetItemSelected 0" "bottom sheet callback fires with BottomSheetItemSelected 0"
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/bottomsheet.sh
+++ b/test/ios/bottomsheet.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# iOS bottom sheet test: install app, auto-tap Show Actions,
+# assert that the callback fires with correct result.
+#
+# --autotest-buttons fires onUIEvent(0) at t+3s (Show Actions),
+# exercising the bottom sheet round-trip.
+# In autotest mode, the iOS bridge auto-selects the first item.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, BOTTOM_SHEET_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+xcrun simctl install "$SIM_UDID" "$BOTTOM_SHEET_APP"
+echo "BottomSheet app installed."
+
+STREAM_LOG="$WORK_DIR/bottomsheet_stream.txt"
+> "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$BUNDLE_ID\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
+sleep 2
+
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest-buttons
+
+# Wait for the bottom sheet result (callback from the demo app)
+wait_for_log "$STREAM_LOG" "BottomSheet result" 60
+WAIT_RC=$?
+if [ $WAIT_RC -eq 2 ]; then
+    dump_ios_log "$STREAM_LOG" "bottomsheet"
+    echo "FATAL: Native library failed to load — aborting"
+    exit 1
+fi
+
+sleep 5
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+assert_log "$STREAM_LOG" "BottomSheet result: BottomSheetItemSelected 0" "bottom sheet callback fires with BottomSheetItemSelected 0"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/watchos/bottomsheet.sh
+++ b/test/watchos/bottomsheet.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# watchOS bottom sheet test: install app, auto-tap Show Actions,
+# assert that the callback fires with correct result.
+#
+# --autotest-buttons fires onUIEvent(0) at t+3s (Show Actions),
+# exercising the bottom sheet round-trip via SwiftUI .confirmationDialog().
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, BOTTOM_SHEET_APP, WORK_DIR, LOG_SUBSYSTEM
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+xcrun simctl install "$SIM_UDID" "$BOTTOM_SHEET_APP"
+echo "BottomSheet app installed."
+
+STREAM_LOG="$WORK_DIR/bottomsheet_stream.txt"
+> "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$LOG_SUBSYSTEM\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
+sleep 2
+
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest-buttons
+
+# Wait for the bottom sheet result
+wait_for_log "$STREAM_LOG" "BottomSheet result" 60 || true
+
+sleep 2
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+assert_log "$STREAM_LOG" "BottomSheet result: BottomSheetItemSelected 0" "bottom sheet callback fires with BottomSheetItemSelected 0"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/watchos/HaskellMobile/BottomSheetBridge.swift
+++ b/watchos/HaskellMobile/BottomSheetBridge.swift
@@ -1,0 +1,72 @@
+import Foundation
+import os.log
+
+/// watchOS bottom sheet bridge -- uses SwiftUI .confirmationDialog() via notification center.
+/// Provides @_cdecl wrappers callable from C for the platform-agnostic dispatcher.
+
+private let bridgeLog = OSLog(subsystem: "me.jappie.haskellmobile", category: "BottomSheetBridge")
+
+/// Notification posted when a bottom sheet should be shown.
+/// userInfo keys: "requestId", "title", "items", "ctx"
+let bottomSheetShowNotificationName = Notification.Name("HaskellMobileShowBottomSheet")
+
+/// Holds pending bottom sheet info for SwiftUI to observe.
+class BottomSheetManager: ObservableObject {
+    static let shared = BottomSheetManager()
+
+    @Published var isPresented: Bool = false
+    @Published var title: String = ""
+    @Published var items: [String] = []
+
+    var requestId: Int32 = 0
+    var ctx: UnsafeMutableRawPointer? = nil
+
+    func show(ctx: UnsafeMutableRawPointer?, requestId: Int32,
+              title: String, items: [String]) {
+        self.ctx = ctx
+        self.requestId = requestId
+        self.title = title
+        self.items = items
+        self.isPresented = true
+    }
+
+    func onItemSelected(_ index: Int32) {
+        isPresented = false
+        haskellOnBottomSheetResult(ctx, requestId, index)
+    }
+
+    func onDismissed() {
+        isPresented = false
+        haskellOnBottomSheetResult(ctx, requestId, BOTTOM_SHEET_DISMISSED)
+    }
+}
+
+@_cdecl("watchos_bottom_sheet_show")
+func watchosBottomSheetShow(_ ctx: UnsafeMutableRawPointer?,
+                             _ requestId: Int32,
+                             _ title: UnsafePointer<CChar>?,
+                             _ items: UnsafePointer<CChar>?) {
+    guard let title = title, let items = items else {
+        haskellOnBottomSheetResult(ctx, requestId, BOTTOM_SHEET_DISMISSED)
+        return
+    }
+
+    let titleStr = String(cString: title)
+    let itemsStr = String(cString: items)
+    let itemLabels = itemsStr.components(separatedBy: "\n")
+
+    os_log("bottom_sheet_show(title=%{public}s, id=%d)", log: bridgeLog, type: .info, titleStr, requestId)
+
+    // In autotest mode, auto-select first item without presenting the sheet.
+    let args = CommandLine.arguments
+    if args.contains("--autotest-buttons") || args.contains("--autotest") {
+        os_log("bottom_sheet_show: autotest mode -- auto-selecting first item", log: bridgeLog, type: .info)
+        haskellOnBottomSheetResult(ctx, requestId, 0)
+        return
+    }
+
+    DispatchQueue.main.async {
+        BottomSheetManager.shared.show(ctx: ctx, requestId: requestId,
+                                        title: titleStr, items: itemLabels)
+    }
+}

--- a/watchos/HaskellMobile/HaskellMobile-Bridging-Header.h
+++ b/watchos/HaskellMobile/HaskellMobile-Bridging-Header.h
@@ -7,6 +7,7 @@
 #include "LocationBridge.h"
 #include "AuthSessionBridge.h"
 #include "CameraBridge.h"
+#include "BottomSheetBridge.h"
 
 /* Dispatch a text change event to Haskell.
  * Not declared in HaskellMobile.h but exported via foreign export ccall. */

--- a/watchos/HaskellMobile/UIBridgeSetup.c
+++ b/watchos/HaskellMobile/UIBridgeSetup.c
@@ -10,6 +10,7 @@
 #include "SecureStorageBridge.h"
 #include "DialogBridge.h"
 #include "AuthSessionBridge.h"
+#include "BottomSheetBridge.h"
 #include <os/log.h>
 #include <string.h>
 
@@ -49,6 +50,10 @@ extern void watchos_dialog_show(void *ctx, int32_t requestId,
 extern void watchos_auth_session_start(void *ctx, int32_t requestId,
                                         const char *authUrl,
                                         const char *callbackScheme);
+
+/* Forward declaration of Swift @_cdecl bottom sheet function */
+extern void watchos_bottom_sheet_show(void *ctx, int32_t requestId,
+                                       const char *title, const char *items);
 
 static UIBridgeCallbacks g_watchos_callbacks = {
     .createNode  = watchos_create_node,
@@ -95,4 +100,8 @@ void setup_watchos_ui_bridge(void *haskellCtx)
     /* Register Swift auth session callback with platform-agnostic dispatcher */
     auth_session_register_impl(watchos_auth_session_start);
     os_log_info(log, "watchOS auth session bridge initialized");
+
+    /* Register Swift bottom sheet callback with platform-agnostic dispatcher */
+    bottom_sheet_register_impl(watchos_bottom_sheet_show);
+    os_log_info(log, "watchOS bottom sheet bridge initialized");
 }


### PR DESCRIPTION
## Summary
- Adds platform-native bottom sheet / action menu support (Android `AlertDialog.setItems`, iOS `UIAlertController` actionSheet, watchOS `.confirmationDialog`)
- Follows the same C bridge pattern as Dialog: Haskell callback registry → C dispatcher → platform impl → async result → FFI export → Haskell dispatch
- Content model: title + list of labeled items; action code >= 0 = item index, -1 = dismissed

## Changes
- **New files (10):** `BottomSheetBridge.h`, `bottom_sheet_bridge.c`, `BottomSheet.hs`, `bottom_sheet_android.c`, `BottomSheetBridgeIOS.m`, `BottomSheetBridge.swift`, `BottomSheetDemoMain.hs`, 3 integration test scripts
- **Modified files (16):** `HaskellMobileActivity.java`, `jni_bridge.c`, `HaskellMobile.hs`, `AppContext.hs`, `Types.hs`, `HaskellMobile.h`, `haskell-mobile.cabal`, `HaskellBridge.swift`, bridging headers, `UIBridgeSetup.c`, `Test.hs`, `nix/lib.nix`, 3 nix test runners

## Test plan
- [x] `cabal build` — zero warnings
- [x] `cabal test` — all 150 tests pass (7 new BottomSheet tests)
- [ ] CI: nix-build job passes
- [ ] CI: android emulator tests pass (bottomsheet.sh)
- [ ] CI: iOS simulator tests pass (bottomsheet.sh)
- [ ] CI: watchOS simulator tests pass (bottomsheet.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)