### PR TITLE
Implement incremental rendering with Trees That Grow (#97)

### DIFF
--- a/docs/incremental-rendering-approaches.md
+++ b/docs/incremental-rendering-approaches.md
@@ -1,0 +1,414 @@
+# Incremental Rendering: Approaches and Trade-offs
+
+Issue: #97
+
+## Problem Statement
+
+Every UI event triggers a full clear-and-rebuild cycle. `Bridge.clear` destroys
+all native views, `resetCallbacks` wipes the Haskell callback registry (including
+resetting the ID counter to 0), and the entire widget tree is recreated from
+scratch via `renderNode`.
+
+For a screen with 50 widgets where only 1 counter label changes, this means
+50 `destroyNode` calls + 50 `createNode` calls + ~150 property-setting calls.
+On Android, each FFI call crosses JNI, which adds overhead per call. More
+importantly, destroying and recreating native views can cause visible flicker,
+loss of focus state in TextInput fields, and scroll position resets in
+ScrollViews.
+
+The goal: diff old and new widget trees and emit only minimal bridge operations.
+
+## Current Architecture (Baseline)
+
+```
+User event
+  -> Haskell callback fires
+  -> callback calls renderWidget
+  -> Bridge.clear (destroy ALL native views)
+  -> resetCallbacks (wipe IntMaps, reset rsNextId to 0)
+  -> renderNode (walk entire Widget tree, create all native views)
+  -> Bridge.setRoot
+```
+
+Key types on master:
+
+```haskell
+-- Widget.hs: no type parameter, callbacks are bare IO
+data ButtonConfig = ButtonConfig
+  { bcLabel  :: Text
+  , bcAction :: IO ()            -- can't derive Eq
+  , bcFontConfig :: Maybe FontConfig
+  }
+
+data Widget
+  = Text TextConfig              -- has Eq (no callbacks)
+  | Button ButtonConfig          -- no Eq (IO () field)
+  | TextInput TextInputConfig    -- no Eq (Text -> IO () field)
+  | Column [Widget]
+  | ...
+
+-- Render.hs: full rebuild every time
+renderWidget :: RenderState -> Widget -> IO ()
+renderWidget rs widget = do
+  Bridge.clear
+  resetCallbacks rs
+  rootId <- renderNode rs widget
+  Bridge.setRoot rootId
+```
+
+The fundamental blocker for diffing is that `Widget` can't derive `Eq` because
+`ButtonConfig`, `TextInputConfig`, and `WebViewConfig` contain `IO ()` /
+`Text -> IO ()` callbacks. Without equality comparison, you can't tell whether
+a widget has changed.
+
+## The Core Dilemma: Comparing Widgets That Contain Callbacks
+
+Any incremental rendering approach must solve: "Has this widget changed since
+last render?" Five approaches are considered below.
+
+---
+
+## Approach A: Trees That Grow (TTG) + toUnit Stripping
+
+**Branch:** `feature/incremental-render` (PR #125)
+
+### Mechanism
+
+Parameterise `Widget` over a phase type `p`. Use closed type families to resolve
+callback types per phase:
+
+```haskell
+data User  -- user-facing phase
+
+type family ButtonCb p where
+  ButtonCb User = IO ()
+  ButtonCb p    = p
+
+data ButtonConfig p = ButtonConfig
+  { bcLabel  :: Text
+  , bcAction :: ButtonCb p
+  , bcFontConfig :: Maybe FontConfig
+  }
+
+data Widget p = Text TextConfig | Button (ButtonConfig p) | ...
+
+deriving instance Eq (Widget ())  -- all callbacks become (), which has Eq
+```
+
+Strip callbacks with `toUnit :: Widget p -> Widget ()`, then compare:
+
+```haskell
+toUnit newWidget == storedUnitWidget  -- structural equality
+```
+
+A retained `RenderedNode` tree maps each widget to its native node ID and
+callback ID. On re-render: walk both trees in lockstep, compare via `toUnit`,
+skip unchanged subtrees, destroy/create only what changed.
+
+### Strengths
+
+- **Compiler-verified completeness:** `toUnit` constructs records field-by-field.
+  Adding a field without updating `toUnit` causes a compile error. Derived `Eq`
+  covers all fields automatically.
+- **No user-visible API change in construction syntax:** `ButtonCb User = IO ()`,
+  so existing `Button ButtonConfig { bcAction = putStrLn "hi" }` works unchanged.
+- **Clean phase separation:** Could later use `Widget Int32` for a phase where
+  callbacks are registered IDs rather than closures.
+
+### Weaknesses
+
+1. **Callback atomicity gap:** The implementation clears both callback IntMaps at
+   the start of each render (`clearCallbackMaps`), then re-registers callbacks as
+   the diff walk proceeds. If a native event fires during this window, the
+   callback ID maps to nothing and the event is silently dropped. This is the main
+   fragility concern.
+
+2. **Over-comparison on every render:** `toUnit` allocates a full `Widget ()` mirror
+   of the tree on every render cycle, just to compare it. For a 500-widget tree,
+   that's 500 allocations even if nothing changed. Haskell's GC handles short-lived
+   allocations well, but it's still work.
+
+3. **No in-place property patching:** When a Text label changes from "Count: 5" to
+   "Count: 6", the current implementation destroys the old Text node and creates a
+   new one. It should instead call `setStrProp` on the existing node. This requires
+   comparing individual properties, not just whole-widget equality — but `toUnit`
+   only gives a binary same/different answer.
+
+4. **Type signature pollution:** Every function touching a `Widget` gains a phase
+   parameter (`Widget User` instead of `Widget`). All 16 demo apps, the test suite,
+   and downstream consumers must update signatures. The change is mechanical but
+   wide-reaching.
+
+5. **Callback ID growth:** `rsNextId` monotonically increases and never reclaims
+   IDs. After thousands of renders with changing widgets, the counter grows
+   unboundedly. The IntMap itself is rebuilt each render so memory is bounded, but
+   native view tags may hit platform limits on some implementations.
+
+---
+
+## Approach B: Explicit Widget Keys + Keyed Diffing
+
+### Mechanism
+
+Add an optional user-supplied key to each widget, similar to React's `key` prop:
+
+```haskell
+data Widget
+  = Text TextConfig
+  | Button ButtonConfig
+  | Keyed Text Widget    -- user-supplied stable identity
+  | ...
+```
+
+The renderer maintains a `Map Text NativeNodeId`. On re-render, instead of
+comparing widget equality, match widgets by key. Matched widgets get in-place
+property updates; unmatched ones get destroyed/created.
+
+For keyless widgets, fall back to positional matching (same index in the child
+list = same widget).
+
+### Strengths
+
+- **No type system changes:** `Widget` stays as-is, no phase parameter, no
+  type families.
+- **User controls identity:** Keys express intent ("this is the same counter")
+  rather than structural equality ("these two trees look the same").
+- **Natural property patching:** Since you know *which* old node corresponds to
+  which new widget, you can diff individual properties and emit `setStrProp`
+  calls for just what changed.
+- **Familiar pattern:** React, Flutter, and SwiftUI all use keys/identity for
+  reconciliation.
+
+### Weaknesses
+
+- **User burden:** Users must remember to add keys to dynamic lists, or diffs
+  produce pathological results (same problem React has).
+- **No compiler enforcement:** Forgetting a key silently falls back to
+  positional matching, which can produce subtle bugs with reordering.
+- **Callback comparison still unsolved:** Two `ButtonConfig` values with the
+  same label but different `IO ()` callbacks look identical to a key-based diff.
+  The renderer must always re-register callbacks even for "unchanged" widgets.
+  This is fine in practice (re-registering a closure in an IntMap is cheap)
+  but means the Haskell side always does O(n) work.
+- **Not clear how to handle `Styled`:** A `Styled` wrapper changes visual
+  properties without changing identity. Key-based matching would need to
+  look through `Styled` to find the keyed child.
+
+---
+
+## Approach C: Generation Counter (Dirty Flagging)
+
+### Mechanism
+
+Instead of comparing the full widget tree, track *which* parts of the state
+changed and only re-render those subtrees:
+
+```haskell
+data RenderState = RenderState
+  { rsGeneration    :: IORef Word64
+  , rsDirtyWidgets  :: IORef (Set WidgetPath)
+  , rsNativeNodes   :: IORef (Map WidgetPath Int32)
+  , ...
+  }
+
+-- When state changes, mark the affected widget path as dirty
+markDirty :: RenderState -> WidgetPath -> IO ()
+
+-- Re-render only walks dirty paths
+renderWidget :: RenderState -> Widget -> IO ()
+```
+
+The app's state management layer (currently just `IORef UserState`) would need
+to integrate with the dirty-tracking system.
+
+### Strengths
+
+- **Minimal work on each render:** Only dirty subtrees are visited at all.
+  No tree walk, no allocation of comparison structures.
+- **No type system changes** to `Widget`.
+- **Scales well:** O(dirty nodes) instead of O(total nodes).
+
+### Weaknesses
+
+- **Invasive to user code:** The user must explicitly mark dirty paths or use
+  a state management system that does it automatically. This is a fundamentally
+  different programming model (push-based vs pull-based).
+- **WidgetPath fragility:** Paths like `[Column, 0, Row, 2, Button]` break
+  when the tree structure changes (e.g., wrapping a widget in a Styled node).
+- **Missed updates:** If the dirty tracking fails to mark a node, the UI is
+  silently stale. Hard to debug.
+- **Doesn't leverage Haskell's strengths:** Haskell's pure functions naturally
+  produce new widget trees. Dirty tracking fights this by requiring imperative
+  mutation tracking alongside the pure view function.
+
+---
+
+## Approach D: Stable Callback IDs (User-Assigned)
+
+### Mechanism
+
+Instead of the renderer assigning callback IDs, the user provides stable IDs
+at widget construction:
+
+```haskell
+data ButtonConfig = ButtonConfig
+  { bcLabel      :: Text
+  , bcCallbackId :: CallbackId    -- user-assigned, stable across renders
+  , bcAction     :: IO ()
+  , bcFontConfig :: Maybe FontConfig
+  }
+
+-- Callbacks registered separately from the widget tree
+registerCallback :: RenderState -> CallbackId -> IO () -> IO ()
+```
+
+The widget tree becomes pure data (no IO callbacks inline), and can derive `Eq`
+naturally. The renderer diffs the pure tree and emits bridge calls. Callbacks
+are managed in a separate registry keyed by stable IDs.
+
+### Strengths
+
+- **Widget derives Eq naturally:** No phase parameter, no type families,
+  no toUnit.
+- **Callback stability for free:** Native views keep the same callback ID
+  tag across renders because the user assigned it.
+- **Clean separation of concerns:** View description (pure) vs event handling
+  (separate registration) — similar to Elm architecture.
+- **No atomicity gap:** Callback IntMaps are never cleared, only updated.
+
+### Weaknesses
+
+- **Significant API change:** Users must manage callback IDs manually. This
+  is error-prone and boilerplate-heavy: `bcCallbackId = CallbackId "increment-btn"`.
+- **Namespace collisions:** If two widgets accidentally share a callback ID,
+  one silently overwrites the other.
+- **Stale callbacks:** If a widget is removed but its callback isn't
+  unregistered, the IntMap leaks closures that reference stale state.
+- **Doesn't match React/Flutter mental model:** Modern UI frameworks let you
+  write callbacks inline. Extracting them to a separate registry is ergonomic
+  regression.
+
+---
+
+## Approach E: Hybrid — Structural Comparison Function + Callback Re-registration
+
+### Mechanism
+
+Write a manual `structuralEq :: Widget -> Widget -> Bool` that compares all
+fields except callbacks:
+
+```haskell
+structuralEq :: Widget -> Widget -> Bool
+structuralEq (Text c1) (Text c2) = c1 == c2
+structuralEq (Button c1) (Button c2) =
+  bcLabel c1 == bcLabel c2 && bcFontConfig c1 == bcFontConfig c2
+structuralEq (Column cs1) (Column cs2) =
+  length cs1 == length cs2 && and (zipWith structuralEq cs1 cs2)
+structuralEq _ _ = False
+```
+
+No type system changes. The retained tree stores old widgets and their native
+node IDs. On re-render, walk both trees, use `structuralEq` to detect changes,
+and always re-register callbacks from the new tree.
+
+### Strengths
+
+- **No type changes at all:** `Widget` stays exactly as-is. No downstream
+  signature changes.
+- **Simple to understand:** One function, one concept.
+- **Can do property-level patching:** Since `structuralEq` examines fields
+  individually, it could also return *which* fields changed and emit targeted
+  `setStrProp` / `setNumProp` calls.
+
+### Weaknesses
+
+- **Not compiler-verified:** Adding a new field to `ButtonConfig` without
+  updating `structuralEq` silently misses that field in comparisons. This is
+  the main argument against this approach — it's the kind of bug that only
+  manifests at runtime.
+- **Maintenance burden:** Every new widget type or config field requires
+  updating `structuralEq`. With TTG, derived `Eq` handles this automatically.
+- **Still needs callback re-registration:** Even when `structuralEq` says
+  "unchanged", the renderer must re-register callbacks because the closures
+  may have captured new state. Same O(n) callback overhead as Approach B.
+
+---
+
+## Comparison Matrix
+
+| Concern | A: TTG | B: Keys | C: Dirty | D: Stable IDs | E: Manual Eq |
+|---|---|---|---|---|---|
+| Compiler-verified | Yes (derived Eq) | N/A | N/A | Yes (derived Eq) | No |
+| Type signature changes | Yes (`Widget User`) | No | No | Yes (`CallbackId`) | No |
+| User API change | Minimal (signatures only) | Keys on dynamic lists | State management | Major (ID assignment) | None |
+| Callback atomicity | Gap exists | N/A (always re-register) | N/A | No gap | N/A (always re-register) |
+| Property-level patching | No (binary equal/not) | Yes | Yes | Yes | Yes |
+| GC pressure per render | O(n) toUnit allocation | Low | O(dirty) | Low | Low |
+| Missed-field risk | None | None | N/A | None | High |
+| Familiar to React/Flutter devs | No | Yes | Somewhat | No | No |
+
+## Bridge API Constraints
+
+Any approach must work within the existing C bridge (`UIBridge.h`):
+
+- `createNode(nodeType) -> nodeId` — allocates a native view, returns ID
+- `setStrProp(nodeId, propId, value)` — set a string property on existing node
+- `setNumProp(nodeId, propId, value)` — set a numeric property on existing node
+- `setHandler(nodeId, eventType, callbackId)` — associate a callback ID with a node
+- `addChild(parentId, childId)` / `removeChild(parentId, childId)` — tree structure
+- `destroyNode(nodeId)` — free a native view
+- `setRoot(nodeId)` — set the display root
+- `clear()` — destroy all nodes
+
+Notably, the bridge already supports `setStrProp` / `setNumProp` on existing
+nodes and `removeChild` / `destroyNode` for targeted mutations. The current
+renderer just doesn't use them — it always clears everything and rebuilds.
+
+Property-level patching (calling `setStrProp` to update just a label) is
+already supported by the bridge and would be the most efficient approach.
+Approaches B, D, and E naturally support this. Approach A would need additional
+per-field comparison logic beyond `toUnit` equality.
+
+## Callback Lifecycle: The Central Challenge
+
+All approaches share a tension between two requirements:
+
+1. **Callback closures must reflect current state.** A button's `IO ()` action
+   typically closes over an `IORef` or `MVar` — the closure itself may be
+   identical across renders, or the user may construct a fresh closure each
+   time (e.g., `bcAction = modifyIORef' counter (+ amount)` where `amount`
+   changes). We can't compare closures, so we must assume they always change.
+
+2. **Native views carry callback ID tags.** When the user taps a button,
+   Android/iOS sends the callback ID back to Haskell. The Haskell side looks
+   up the ID in an IntMap to find the closure.
+
+The safest lifecycle is:
+- Build the new callback IntMap during the diff walk
+- Swap the new IntMap into the RenderState atomically after the walk completes
+- Never clear + rebuild with a gap in between
+
+This eliminates the atomicity gap from Approach A and applies to any approach.
+
+## Recommendation
+
+No single approach is clearly superior. Key considerations:
+
+- If **type safety** is the priority (can't forget a field), Approach A (TTG)
+  or D (Stable IDs) provide compiler verification. A is less invasive to user
+  code.
+- If **minimal API churn** is the priority, Approach E (manual structuralEq)
+  or B (keys) avoid type parameter changes entirely.
+- If **performance** is the priority (minimal work per render), Approach C
+  (dirty flagging) does the least work but requires the most invasive changes
+  to the programming model.
+- Approach A's atomicity gap should be fixed regardless — building new IntMaps
+  and swapping at the end is strictly better than clear-then-rebuild.
+- Property-level patching (`setStrProp` on the existing node instead of
+  destroy+create) gives the biggest real-world performance win and is
+  independent of which diffing strategy is chosen.
+
+A pragmatic path forward might combine elements: use TTG for the type-safe
+comparison foundation (Approach A), add property-level patching to avoid
+unnecessary destroy/create, and fix the callback atomicity gap by building
+new maps during the walk and swapping at the end.

--- a/docs/incremental-rendering-approaches.md
+++ b/docs/incremental-rendering-approaches.md
@@ -334,18 +334,161 @@ and always re-register callbacks from the new tree.
 
 ---
 
-## Comparison Matrix
+## Approach F: Opaque Action Handles with ActionM Barrier
 
-| Concern | A: TTG | B: Keys | C: Dirty | D: Stable IDs | E: Manual Eq |
-|---|---|---|---|---|---|
-| Compiler-verified | Yes (derived Eq) | N/A | N/A | Yes (derived Eq) | No |
-| Type signature changes | Yes (`Widget User`) | No | No | Yes (`CallbackId`) | No |
-| User API change | Minimal (signatures only) | Keys on dynamic lists | State management | Major (ID assignment) | None |
-| Callback atomicity | Gap exists | N/A (always re-register) | N/A | No gap | N/A (always re-register) |
-| Property-level patching | No (binary equal/not) | Yes | Yes | Yes | Yes |
-| GC pressure per render | O(n) toUnit allocation | Low | O(dirty) | Low | Low |
-| Missed-field risk | None | None | N/A | None | High |
-| Familiar to React/Flutter devs | No | Yes | Somewhat | No | No |
+### Mechanism
+
+Replace `IO ()` callbacks in config types with opaque newtypes that wrap an
+Int (the callback ID). Provide a restricted monad `ActionM` with a hidden
+constructor for creating actions. The only way to run `ActionM` is via
+`setupAction`, which the documentation tells users to call at initialisation.
+
+```haskell
+-- Opaque: hidden constructors, only carry the registered callback ID.
+-- Derive Eq, Ord — they're just numbers.
+newtype Action   = Action   { actionId   :: Int } deriving (Eq, Ord)
+newtype OnChange = OnChange { onChangeId :: Int } deriving (Eq, Ord)
+
+-- Config types carry handles, not closures.
+data ButtonConfig = ButtonConfig
+  { bcLabel      :: Text
+  , bcAction     :: Action
+  , bcFontConfig :: Maybe FontConfig
+  } deriving (Eq)
+
+data TextInputConfig = TextInputConfig
+  { tiInputType  :: InputType
+  , tiHint       :: Text
+  , tiValue      :: Text
+  , tiOnChange   :: OnChange
+  , tiFontConfig :: Maybe FontConfig
+  } deriving (Eq)
+
+-- Restricted monad: hidden constructor, can't be used inside the view function
+-- without going through setupAction.
+newtype ActionM a = ActionM { unActionM :: IO a }
+  deriving (Functor, Applicative, Monad)
+
+-- The only operations available in ActionM.
+createAction   :: IO ()           -> ActionM Action
+createOnChange :: (Text -> IO ()) -> ActionM OnChange
+
+-- The only way to escape ActionM. Documentation says: call at init time.
+setupAction :: RenderState -> ActionM a -> IO a
+```
+
+Usage:
+
+```haskell
+myApp :: IO MobileApp
+myApp = do
+  counter <- newIORef 0
+  rs <- newRenderState
+  (onIncrement, onDecrement) <- setupAction rs $ do
+    inc <- createAction (modifyIORef' counter (+ 1))
+    dec <- createAction (modifyIORef' counter (subtract 1))
+    pure (inc, dec)
+
+  pure MobileApp
+    { maView = \state -> pure $ Column    -- no ActionM here
+        [ Text (TextConfig (pack $ show (count state)) Nothing)
+        , Button (ButtonConfig "+" onIncrement Nothing)
+        , Button (ButtonConfig "-" onDecrement Nothing)
+        ]
+    }
+```
+
+### How diffing works
+
+Since `Action` and `OnChange` are just Ints, `ButtonConfig`, `TextInputConfig`,
+and `Widget` all derive `Eq` naturally — no TTG, no `toUnit`, no phase parameter.
+
+The retained tree stores the previous `Widget` and its native node IDs.
+On re-render:
+
+1. Compare `oldWidget == newWidget` (derived `Eq`, comparing Action Ints).
+2. If equal → skip, native node stays as-is, callback IntMap unchanged.
+3. If different → diff properties, emit targeted bridge calls.
+
+Callback IntMaps are **never cleared**. Actions registered at init time stay
+valid for the lifetime of the app. The renderer never touches the callback
+registry — it only reads Action IDs from the widget tree and passes them to
+`Bridge.setHandler`.
+
+### Callback lifecycle
+
+Actions close over `IORef`s / `MVar`s. The closure is stable — registered once,
+fires many times. Each firing reads current state from the ref:
+
+```haskell
+-- Registered once, but reads counter's current value each time it fires.
+onIncrement <- createAction (modifyIORef' counter (+ 1))
+```
+
+This covers the common case. For the rare case where the closure body itself
+must change (not just the state it reads), `updateAction` could be provided:
+
+```haskell
+updateAction :: RenderState -> Action -> IO () -> IO ()
+```
+
+But the need for this should be rare — closing over an IORef and branching
+inside the closure handles most dynamic behaviour.
+
+### Strengths
+
+- **Widget derives `Eq` naturally.** No TTG, no `toUnit`, no phase parameter.
+  `ButtonConfig`, `TextInputConfig`, `WebViewConfig`, `Widget` all get derived
+  `Eq` and `Show` with no special machinery.
+- **No callback atomicity gap.** IntMaps are populated at init and never cleared.
+  Events can fire at any time — the closure is always there.
+- **No per-render allocation.** No `toUnit` mirror tree, no fresh callback IDs
+  per render. The widget tree is diffed directly.
+- **Type system guides correct usage.** `ActionM` is opaque — you can't call
+  `createAction` inside the view function without explicitly calling `setupAction`,
+  which the documentation warns against doing per-render. The type doesn't prevent
+  misuse, but it makes it visible and deliberate.
+- **Property-level patching is natural.** Since you're comparing real `Eq` on
+  config types, you can also compare individual fields and emit targeted
+  `setStrProp` / `setNumProp` for just the changed property.
+- **No type signature pollution.** `Widget` stays `Widget`, not `Widget User`.
+  No downstream changes to demo apps or consumer code.
+- **Familiar pattern.** Similar to resource acquisition (`bracket`, `withFile`).
+  Register resources at startup, use handles thereafter.
+
+### Weaknesses
+
+- **API change for callback construction.** Users must switch from inline
+  `bcAction = modifyIORef' ref (+1)` to a two-step register-then-reference
+  pattern. This is a real ergonomic cost.
+- **Upfront registration.** All callbacks must be created before the first
+  render. Dynamic lists of widgets (e.g., a todo list where each item has a
+  delete button) require either pre-allocating a pool of Actions or calling
+  `setupAction` when items are added, which blurs the init-time boundary.
+- **Social contract, not enforcement.** `ActionM` discourages per-render
+  creation but doesn't prevent it — a user can call `setupAction rs $ createAction ...`
+  inside their view function. The consequence (fresh IDs each render, defeating
+  Eq) is non-obvious.
+- **Stale closure risk.** If the user's closure captures a value directly (not
+  via IORef), the closure is frozen at registration time. Subsequent state
+  changes won't be reflected. This is a footgun for users coming from
+  React-style "inline closures that capture current state by value."
+- **Dynamic callback escape hatch needed.** For widgets whose callback body
+  truly changes (not just the state it reads), `updateAction` is needed. This
+  complicates the "register once" model.
+
+---
+
+| Concern | A: TTG | B: Keys | C: Dirty | D: Stable IDs | E: Manual Eq | F: ActionM |
+|---|---|---|---|---|---|---|
+| Compiler-verified | Yes (derived Eq) | N/A | N/A | Yes (derived Eq) | No | Yes (derived Eq) |
+| Type signature changes | Yes (`Widget User`) | No | No | Yes (`CallbackId`) | No | No |
+| User API change | Minimal (signatures only) | Keys on dynamic lists | State management | Major (ID assignment) | None | Moderate (register + use) |
+| Callback atomicity | Gap exists | N/A (always re-register) | N/A | No gap | N/A (always re-register) | No gap |
+| Property-level patching | No (binary equal/not) | Yes | Yes | Yes | Yes | Yes |
+| GC pressure per render | O(n) toUnit allocation | Low | O(dirty) | Low | Low | Low |
+| Missed-field risk | None | None | N/A | None | High | None |
+| Familiar to React/Flutter devs | No | Yes | Somewhat | No | No | Somewhat (resource handles) |
 
 ## Bridge API Constraints
 
@@ -383,32 +526,42 @@ All approaches share a tension between two requirements:
    Android/iOS sends the callback ID back to Haskell. The Haskell side looks
    up the ID in an IntMap to find the closure.
 
-The safest lifecycle is:
+For approaches A–E (where callbacks live inside the widget tree), the safest
+lifecycle is:
 - Build the new callback IntMap during the diff walk
 - Swap the new IntMap into the RenderState atomically after the walk completes
 - Never clear + rebuild with a gap in between
 
-This eliminates the atomicity gap from Approach A and applies to any approach.
+Approach F sidesteps this tension entirely: callbacks are registered at init
+time into a persistent IntMap that is never cleared or rebuilt. The widget tree
+carries only opaque integer handles, so there is no callback lifecycle to
+manage during rendering at all.
 
 ## Recommendation
 
 No single approach is clearly superior. Key considerations:
 
-- If **type safety** is the priority (can't forget a field), Approach A (TTG)
-  or D (Stable IDs) provide compiler verification. A is less invasive to user
-  code.
+- If **type safety** is the priority (can't forget a field), Approaches A (TTG),
+  D (Stable IDs), and F (ActionM) all provide compiler-verified `Eq`. F
+  achieves this without type parameter pollution.
 - If **minimal API churn** is the priority, Approach E (manual structuralEq)
-  or B (keys) avoid type parameter changes entirely.
+  or B (keys) avoid type changes entirely, but E risks silent field omission.
 - If **performance** is the priority (minimal work per render), Approach C
   (dirty flagging) does the least work but requires the most invasive changes
-  to the programming model.
-- Approach A's atomicity gap should be fixed regardless — building new IntMaps
-  and swapping at the end is strictly better than clear-then-rebuild.
+  to the programming model. Approach F also has low per-render cost since
+  callbacks are pre-registered.
+- If **callback safety** is the priority, Approach F eliminates the problem
+  entirely — callbacks live in a persistent registry that is never cleared
+  during rendering. Approaches A–E all require some form of callback lifecycle
+  management during the render pass.
 - Property-level patching (`setStrProp` on the existing node instead of
   destroy+create) gives the biggest real-world performance win and is
-  independent of which diffing strategy is chosen.
+  independent of which diffing strategy is chosen. Approaches B, D, E, and F
+  support this naturally. Approach A would need additional per-field comparison.
 
-A pragmatic path forward might combine elements: use TTG for the type-safe
-comparison foundation (Approach A), add property-level patching to avoid
-unnecessary destroy/create, and fix the callback atomicity gap by building
-new maps during the walk and swapping at the end.
+Approach F (ActionM handles) is the current front-runner. It gives derived `Eq`
+with no type parameter changes, eliminates the callback atomicity problem, and
+nudges users toward stable callbacks via the restricted `ActionM` monad. The
+main open question is ergonomics for dynamic widget lists (e.g., a todo list
+where each item gets its own delete action) — this may require a pool pattern
+or a controlled escape hatch via `setupAction`.

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -87,7 +87,7 @@ in {
     , extraGhcIncludeDirs ? []
     , crossDeps ? null          # output of cross-deps.nix (lib/, hi/, pkgdb/)
     , maxNodes ? 256            # static pool size (ignored when dynamicNodePool=true)
-    , dynamicNodePool ? false   # use malloc/realloc instead of fixed array
+    , dynamicNodePool ? true    # use malloc/realloc instead of fixed array
     , soMaxSizeMB ? 200         # fail build if .so exceeds this (MB), catches whole-archive bloat
     }:
     let
@@ -645,7 +645,7 @@ in {
     , iosSrc
     , name ? "simulator-app"
     , maxNodes ? 256            # static pool size (ignored when dynamicNodePool=true)
-    , dynamicNodePool ? false   # use malloc/realloc instead of fixed array
+    , dynamicNodePool ? true    # use malloc/realloc instead of fixed array
     }:
     let
       nodePoolCFlags =

--- a/src/HaskellMobile.hs
+++ b/src/HaskellMobile.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
 module HaskellMobile
-  ( MobileApp(..)
+  ( -- * Widget phase types (re-exported from Widget)
+    User
+    -- * Core types
+  , MobileApp(..)
   , UserState(..)
   , startMobileApp
   -- FFI exports
@@ -189,7 +192,7 @@ import HaskellMobile.SecureStorage
   , dispatchSecureStorageResult
   )
 import HaskellMobile.Types (MobileApp(..), UserState(..))
-import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), TextConfig(..), User, Widget(..))
 
 -- | Create an 'AppContext' from a 'MobileApp' and return it as a typed
 -- pointer suitable for the C FFI. This is the user-facing API: the user's
@@ -250,7 +253,7 @@ renderView ctxPtr = do
 
 -- | A widget that displays an error message with a dismiss button.
 -- The dismiss button restores the original view via a closure.
-errorWidget :: Ptr AppContext -> (UserState -> IO Widget) -> SomeException -> Widget
+errorWidget :: Ptr AppContext -> (UserState -> IO (Widget User)) -> SomeException -> Widget User
 errorWidget ctxPtr originalView exc = Column
   [ Text TextConfig
       { tcLabel      = "An error occurred"

--- a/src/HaskellMobile/AppContext.hs
+++ b/src/HaskellMobile/AppContext.hs
@@ -25,7 +25,7 @@ import HaskellMobile.Permission (PermissionState(..), newPermissionState)
 import HaskellMobile.Render (RenderState, newRenderState)
 import HaskellMobile.SecureStorage (SecureStorageState(..), newSecureStorageState)
 import HaskellMobile.Types (MobileApp(..), UserState(..))
-import HaskellMobile.Widget (Widget)
+import HaskellMobile.Widget (User, Widget)
 
 -- | Combines user-supplied lifecycle callbacks with the rendering engine's
 -- mutable state, the permission callback registry, the secure storage
@@ -42,7 +42,7 @@ data AppContext = AppContext
   , acAuthSessionState    :: AuthSessionState
   , acCameraState         :: CameraState
   , acBottomSheetState    :: BottomSheetState
-  , acViewFunction        :: IORef (UserState -> IO Widget)
+  , acViewFunction        :: IORef (UserState -> IO (Widget User))
   }
 
 -- | Create a fresh 'AppContext' from a 'MobileApp', allocating a new

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -2,11 +2,13 @@
 -- | Rendering engine that converts a 'Widget' tree into native UI
 -- via the C bridge.
 --
--- Uses a full clear-and-rebuild strategy on every render.
--- Maintains callback registries so native button presses and text
--- changes can be dispatched back to Haskell 'IO' actions.
+-- Uses an incremental diff strategy: on each render, the new widget
+-- tree is compared (via 'toUnit') against the previously rendered
+-- tree. Only changed subtrees are destroyed and recreated; unchanged
+-- nodes keep their native views and callback IDs.
 module HaskellMobile.Render
   ( RenderState(..)
+  , RenderedNode(..)
   , newRenderState
   , renderWidget
   , dispatchEvent
@@ -19,19 +21,59 @@ import Data.Int (Int32)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Text (Text, pack)
-import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
+import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), User, WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex, toUnit)
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
+-- ---------------------------------------------------------------------------
+-- Rendered tree: retained structure for incremental diffing
+-- ---------------------------------------------------------------------------
+
+-- | A snapshot of a rendered widget, retaining the unit-stripped widget
+-- (for equality comparison), native node IDs, and callback IDs.
+data RenderedNode
+  = RenderedLeaf
+      (Widget ())    -- ^ Unit-stripped widget for equality comparison.
+      Int32          -- ^ Native node ID from the platform bridge.
+      (Maybe Int32)  -- ^ Callback ID if this leaf has a handler.
+  | RenderedContainer
+      (Widget ())    -- ^ Unit-stripped widget.
+      Int32          -- ^ Native node ID.
+      [RenderedNode] -- ^ Rendered children.
+  | RenderedStyled
+      (Widget ())    -- ^ Unit-stripped widget.
+      WidgetStyle    -- ^ Applied style (for change detection).
+      RenderedNode   -- ^ Child (Styled doesn't own a native node).
+
+-- | Get the native node ID for a rendered node.
+-- 'RenderedStyled' follows through to its child's node ID.
+renderedNodeId :: RenderedNode -> Int32
+renderedNodeId (RenderedLeaf _ nodeId _)      = nodeId
+renderedNodeId (RenderedContainer _ nodeId _)  = nodeId
+renderedNodeId (RenderedStyled _ _ child)      = renderedNodeId child
+
+-- | Get the unit-stripped widget for a rendered node.
+renderedUnitWidget :: RenderedNode -> Widget ()
+renderedUnitWidget (RenderedLeaf unitW _ _)     = unitW
+renderedUnitWidget (RenderedContainer unitW _ _) = unitW
+renderedUnitWidget (RenderedStyled unitW _ _)    = unitW
+
+-- ---------------------------------------------------------------------------
+-- Render state
+-- ---------------------------------------------------------------------------
+
 -- | Mutable state for the rendering engine.
--- Holds the callback registries and next callback ID counter.
+-- Holds the callback registries, next callback ID counter, and the
+-- previously rendered tree for incremental diffing.
 data RenderState = RenderState
   { rsCallbacks     :: IORef (IntMap (IO ()))
-    -- ^ Map from callbackId -> IO action (for clicks)
+    -- ^ Map from callbackId -> IO action (for clicks).
   , rsTextCallbacks :: IORef (IntMap (Text -> IO ()))
-    -- ^ Map from callbackId -> text change handler
+    -- ^ Map from callbackId -> text change handler.
   , rsNextId        :: IORef Int32
-    -- ^ Next available callback ID
+    -- ^ Next available callback ID (monotonically increasing, never reset).
+  , rsRenderedTree  :: IORef (Maybe RenderedNode)
+    -- ^ The previously rendered tree, or 'Nothing' for the first render.
   }
 
 -- | Create a fresh 'RenderState' with no registered callbacks.
@@ -40,13 +82,19 @@ newRenderState = do
   callbacks     <- newIORef IntMap.empty
   textCallbacks <- newIORef IntMap.empty
   nextId        <- newIORef 0
+  renderedTree  <- newIORef Nothing
   pure RenderState
     { rsCallbacks     = callbacks
     , rsTextCallbacks = textCallbacks
     , rsNextId        = nextId
+    , rsRenderedTree  = renderedTree
     }
 
--- | Register a click callback and return its ID.
+-- ---------------------------------------------------------------------------
+-- Callback registration
+-- ---------------------------------------------------------------------------
+
+-- | Register a click callback and return its fresh ID.
 registerCallback :: RenderState -> IO () -> IO Int32
 registerCallback rs action = do
   cid <- readIORef (rsNextId rs)
@@ -54,7 +102,7 @@ registerCallback rs action = do
   writeIORef (rsNextId rs) (cid + 1)
   pure cid
 
--- | Register a text-change callback and return its ID.
+-- | Register a text-change callback and return its fresh ID.
 registerTextCallback :: RenderState -> (Text -> IO ()) -> IO Int32
 registerTextCallback rs action = do
   cid <- readIORef (rsNextId rs)
@@ -62,12 +110,29 @@ registerTextCallback rs action = do
   writeIORef (rsNextId rs) (cid + 1)
   pure cid
 
--- | Reset both callback registries (called before each re-render).
-resetCallbacks :: RenderState -> IO ()
-resetCallbacks rs = do
+-- | Re-register a click callback at an existing ID.
+-- Used for reused nodes: native view keeps the old callback ID tag,
+-- but the Haskell closure is updated to the new action.
+registerCallbackAt :: RenderState -> Int32 -> IO () -> IO ()
+registerCallbackAt rs callbackId action =
+  modifyIORef' (rsCallbacks rs) (IntMap.insert (fromIntegral callbackId) action)
+
+-- | Re-register a text-change callback at an existing ID.
+registerTextCallbackAt :: RenderState -> Int32 -> (Text -> IO ()) -> IO ()
+registerTextCallbackAt rs callbackId action =
+  modifyIORef' (rsTextCallbacks rs) (IntMap.insert (fromIntegral callbackId) action)
+
+-- | Clear callback registries for a fresh render pass.
+-- Does NOT reset 'rsNextId' — IDs grow monotonically so reused nodes
+-- keep valid tags.
+clearCallbackMaps :: RenderState -> IO ()
+clearCallbackMaps rs = do
   writeIORef (rsCallbacks rs) IntMap.empty
   writeIORef (rsTextCallbacks rs) IntMap.empty
-  writeIORef (rsNextId rs) 0
+
+-- ---------------------------------------------------------------------------
+-- Bridge helpers
+-- ---------------------------------------------------------------------------
 
 -- | Map an 'InputType' to the numeric code sent to the platform bridge.
 inputTypeToInt :: InputType -> Int32
@@ -79,71 +144,6 @@ applyFontConfig :: Int32 -> Maybe FontConfig -> IO ()
 applyFontConfig nodeId (Just (FontConfig size)) =
   Bridge.setNumProp nodeId Bridge.PropFontSize size
 applyFontConfig _nodeId Nothing = pure ()
-
--- | Render a single 'Widget' node, returning its native node ID.
-renderNode :: RenderState -> Widget -> IO Int32
-renderNode _rs (Text config) = do
-  nodeId <- Bridge.createNode Bridge.NodeText
-  Bridge.setStrProp nodeId Bridge.PropText (tcLabel config)
-  applyFontConfig nodeId (tcFontConfig config)
-  pure nodeId
-renderNode rs (Button config) = do
-  nodeId <- Bridge.createNode Bridge.NodeButton
-  Bridge.setStrProp nodeId Bridge.PropText (bcLabel config)
-  callbackId <- registerCallback rs (bcAction config)
-  Bridge.setHandler nodeId Bridge.EventClick callbackId
-  applyFontConfig nodeId (bcFontConfig config)
-  pure nodeId
-renderNode rs (TextInput config) = do
-  nodeId <- Bridge.createNode Bridge.NodeTextInput
-  Bridge.setStrProp nodeId Bridge.PropText (tiValue config)
-  Bridge.setStrProp nodeId Bridge.PropHint (tiHint config)
-  Bridge.setNumProp nodeId Bridge.PropInputType (fromIntegral (inputTypeToInt (tiInputType config)))
-  callbackId <- registerTextCallback rs (tiOnChange config)
-  Bridge.setHandler nodeId Bridge.EventTextChange callbackId
-  applyFontConfig nodeId (tiFontConfig config)
-  pure nodeId
-renderNode rs (Column children) = do
-  nodeId <- Bridge.createNode Bridge.NodeColumn
-  renderChildren rs nodeId children
-  pure nodeId
-renderNode rs (Row children) = do
-  nodeId <- Bridge.createNode Bridge.NodeRow
-  renderChildren rs nodeId children
-  pure nodeId
-renderNode rs (ScrollView children) = do
-  nodeId <- Bridge.createNode Bridge.NodeScrollView
-  renderChildren rs nodeId children
-  pure nodeId
-renderNode _rs (Image config) = do
-  nodeId <- Bridge.createNode Bridge.NodeImage
-  case icSource config of
-    ImageResource (ResourceName name) -> Bridge.setStrProp nodeId Bridge.PropImageResource name
-    ImageData bytes                   -> Bridge.setImageData nodeId bytes
-    ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
-  Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
-  pure nodeId
-renderNode rs (WebView config) = do
-  nodeId <- Bridge.createNode Bridge.NodeWebView
-  Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
-  case wvOnPageLoad config of
-    Just action -> do
-      callbackId <- registerCallback rs action
-      Bridge.setHandler nodeId Bridge.EventClick callbackId
-    Nothing -> pure ()
-  pure nodeId
-renderNode rs (Styled style child) = do
-  nodeId <- renderNode rs child
-  applyStyle nodeId style
-  pure nodeId
-
--- | Render a list of children and add them to a parent container.
-renderChildren :: RenderState -> Int32 -> [Widget] -> IO ()
-renderChildren rs parentId children =
-  mapM_ (\child -> do
-    childId <- renderNode rs child
-    Bridge.addChild parentId childId
-  ) children
 
 -- | Map a 'ScaleType' to the numeric code sent to the platform bridge.
 scaleTypeToDouble :: ScaleType -> Double
@@ -174,14 +174,275 @@ applyStyle nodeId style = do
     Just color -> Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex color)
     Nothing    -> pure ()
 
--- | Full render: clear the screen, reset callbacks, build the widget
--- tree, and set the root node.
-renderWidget :: RenderState -> Widget -> IO ()
+-- ---------------------------------------------------------------------------
+-- Creating rendered nodes from scratch
+-- ---------------------------------------------------------------------------
+
+-- | Create a native node from a 'Widget', returning a 'RenderedNode'
+-- snapshot. Used for fresh creation (no old node to diff against).
+createRenderedNode :: RenderState -> Widget User -> IO RenderedNode
+createRenderedNode _rs (Text config) = do
+  nodeId <- Bridge.createNode Bridge.NodeText
+  Bridge.setStrProp nodeId Bridge.PropText (tcLabel config)
+  applyFontConfig nodeId (tcFontConfig config)
+  pure (RenderedLeaf (toUnit (Text config)) nodeId Nothing)
+createRenderedNode rs (Button config) = do
+  nodeId <- Bridge.createNode Bridge.NodeButton
+  Bridge.setStrProp nodeId Bridge.PropText (bcLabel config)
+  callbackId <- registerCallback rs (bcAction config)
+  Bridge.setHandler nodeId Bridge.EventClick callbackId
+  applyFontConfig nodeId (bcFontConfig config)
+  pure (RenderedLeaf (toUnit (Button config)) nodeId (Just callbackId))
+createRenderedNode rs (TextInput config) = do
+  nodeId <- Bridge.createNode Bridge.NodeTextInput
+  Bridge.setStrProp nodeId Bridge.PropText (tiValue config)
+  Bridge.setStrProp nodeId Bridge.PropHint (tiHint config)
+  Bridge.setNumProp nodeId Bridge.PropInputType (fromIntegral (inputTypeToInt (tiInputType config)))
+  callbackId <- registerTextCallback rs (tiOnChange config)
+  Bridge.setHandler nodeId Bridge.EventTextChange callbackId
+  applyFontConfig nodeId (tiFontConfig config)
+  pure (RenderedLeaf (toUnit (TextInput config)) nodeId (Just callbackId))
+createRenderedNode rs (Column children) = do
+  nodeId <- Bridge.createNode Bridge.NodeColumn
+  childNodes <- mapM (\child -> do
+    childNode <- createRenderedNode rs child
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure childNode
+    ) children
+  pure (RenderedContainer (Column (map toUnit children)) nodeId childNodes)
+createRenderedNode rs (Row children) = do
+  nodeId <- Bridge.createNode Bridge.NodeRow
+  childNodes <- mapM (\child -> do
+    childNode <- createRenderedNode rs child
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure childNode
+    ) children
+  pure (RenderedContainer (Row (map toUnit children)) nodeId childNodes)
+createRenderedNode rs (ScrollView children) = do
+  nodeId <- Bridge.createNode Bridge.NodeScrollView
+  childNodes <- mapM (\child -> do
+    childNode <- createRenderedNode rs child
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure childNode
+    ) children
+  pure (RenderedContainer (ScrollView (map toUnit children)) nodeId childNodes)
+createRenderedNode _rs (Image config) = do
+  nodeId <- Bridge.createNode Bridge.NodeImage
+  case icSource config of
+    ImageResource (ResourceName name) -> Bridge.setStrProp nodeId Bridge.PropImageResource name
+    ImageData bytes                   -> Bridge.setImageData nodeId bytes
+    ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
+  Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
+  pure (RenderedLeaf (toUnit (Image config)) nodeId Nothing)
+createRenderedNode rs (WebView config) = do
+  nodeId <- Bridge.createNode Bridge.NodeWebView
+  Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
+  maybeCallbackId <- case wvOnPageLoad config of
+    Just action -> do
+      callbackId <- registerCallback rs action
+      Bridge.setHandler nodeId Bridge.EventClick callbackId
+      pure (Just callbackId)
+    Nothing -> pure Nothing
+  pure (RenderedLeaf (toUnit (WebView config)) nodeId maybeCallbackId)
+createRenderedNode rs (Styled style child) = do
+  childNode <- createRenderedNode rs child
+  applyStyle (renderedNodeId childNode) style
+  pure (RenderedStyled (Styled style (toUnit child)) style childNode)
+
+-- ---------------------------------------------------------------------------
+-- Destroying rendered subtrees
+-- ---------------------------------------------------------------------------
+
+-- | Recursively destroy all native nodes in a rendered subtree.
+destroyRenderedSubtree :: RenderedNode -> IO ()
+destroyRenderedSubtree (RenderedLeaf _ nodeId _) =
+  Bridge.destroyNode nodeId
+destroyRenderedSubtree (RenderedContainer _ nodeId children) = do
+  mapM_ destroyRenderedSubtree children
+  Bridge.destroyNode nodeId
+destroyRenderedSubtree (RenderedStyled _ _ child) =
+  destroyRenderedSubtree child
+
+-- ---------------------------------------------------------------------------
+-- Incremental diff algorithm
+-- ---------------------------------------------------------------------------
+
+-- | Check whether two widgets use the same constructor (node type).
+-- Does not compare contents — just the outermost constructor tag.
+sameNodeType :: Widget () -> Widget () -> Bool
+sameNodeType (Text _)        (Text _)        = True
+sameNodeType (Button _)      (Button _)      = True
+sameNodeType (TextInput _)   (TextInput _)   = True
+sameNodeType (Column _)      (Column _)      = True
+sameNodeType (Row _)         (Row _)         = True
+sameNodeType (ScrollView _)  (ScrollView _)  = True
+sameNodeType (Image _)       (Image _)       = True
+sameNodeType (WebView _)     (WebView _)     = True
+sameNodeType (Styled _ _)    (Styled _ _)    = True
+sameNodeType _               _               = False
+
+-- | Diff the old rendered tree against a new 'Widget User' and produce
+-- an updated 'RenderedNode', emitting only the necessary bridge calls.
+--
+-- Cases:
+-- 1. No old node → create from scratch.
+-- 2. @toUnit new == rnUnitWidget old@ → reuse native node, re-register callbacks.
+-- 3. Same container type, children differ → keep container, diff children.
+-- 4. Same Styled, diff child recursively, re-apply style if changed.
+-- 5. Same leaf type but properties differ → destroy old, create new.
+-- 6. Different node type → destroy old subtree, create new.
+diffRenderNode :: RenderState -> Maybe RenderedNode -> Widget User -> IO RenderedNode
+-- Case 1: No previous node — create from scratch.
+diffRenderNode rs Nothing newWidget =
+  createRenderedNode rs newWidget
+
+-- Case 2: Exact match — reuse native node, just re-register callbacks.
+diffRenderNode rs (Just oldNode) newWidget
+  | toUnit newWidget == renderedUnitWidget oldNode =
+    reRegisterCallbacks rs oldNode newWidget
+
+-- Case 4: Both are Styled — diff child recursively.
+diffRenderNode rs (Just (RenderedStyled _ oldStyle oldChild)) (Styled newStyle newChild) = do
+  diffedChild <- diffRenderNode rs (Just oldChild) newChild
+  -- Re-apply style if it changed.
+  if newStyle /= oldStyle
+    then applyStyle (renderedNodeId diffedChild) newStyle
+    else pure ()
+  pure (RenderedStyled (Styled newStyle (toUnit newChild)) newStyle diffedChild)
+
+-- Case 3: Same container type, children may differ — keep container, diff children.
+diffRenderNode rs (Just oldNode@(RenderedContainer _ containerNodeId oldChildren)) newWidget
+  | sameNodeType (renderedUnitWidget oldNode) (toUnit newWidget) =
+    case newWidget of
+      Column newChildren     -> diffContainer rs containerNodeId oldChildren newChildren (Column . map toUnit)
+      Row newChildren        -> diffContainer rs containerNodeId oldChildren newChildren (Row . map toUnit)
+      ScrollView newChildren -> diffContainer rs containerNodeId oldChildren newChildren (ScrollView . map toUnit)
+      -- Non-container but same type at container level shouldn't happen,
+      -- but fall through to destroy+create for safety.
+      _ -> replaceNode rs oldNode newWidget
+
+-- Case 5/6: Same leaf type with different properties, or completely different
+-- node types — destroy old and create new.
+diffRenderNode rs (Just oldNode) newWidget =
+  replaceNode rs oldNode newWidget
+
+-- | Diff container children: remove all children from parent, diff each
+-- individually, then re-add all in correct order.
+diffContainer :: RenderState -> Int32 -> [RenderedNode] -> [Widget User]
+              -> ([Widget ()] -> Widget ()) -> IO RenderedNode
+diffContainer rs containerNodeId oldChildren newChildren mkUnitWidget = do
+  -- Remove all children from the container (order may change).
+  mapM_ (\oldChild -> Bridge.removeChild containerNodeId (renderedNodeId oldChild)) oldChildren
+  -- Diff each child position, pairing old children with new where available.
+  let paired = zipPadded oldChildren newChildren
+  diffedChildren <- mapM (\(maybeOld, newChild) ->
+    diffRenderNode rs maybeOld newChild
+    ) paired
+  -- Destroy any excess old children that weren't paired.
+  let excessOld = drop (length newChildren) oldChildren
+  mapM_ destroyRenderedSubtree excessOld
+  -- Re-add all children in the correct order.
+  mapM_ (\child -> Bridge.addChild containerNodeId (renderedNodeId child)) diffedChildren
+  pure (RenderedContainer (mkUnitWidget (map toUnit newChildren)) containerNodeId diffedChildren)
+
+-- | Zip two lists, padding the shorter one with 'Nothing'.
+-- Returns @(Maybe old, new)@ pairs covering all new elements.
+zipPadded :: [a] -> [b] -> [(Maybe a, b)]
+zipPadded [] newItems         = map (\new -> (Nothing, new)) newItems
+zipPadded _ []                = []
+zipPadded (old:olds) (new:news) = (Just old, new) : zipPadded olds news
+
+-- | Destroy an old node and create a fresh replacement.
+replaceNode :: RenderState -> RenderedNode -> Widget User -> IO RenderedNode
+replaceNode rs oldNode newWidget = do
+  destroyRenderedSubtree oldNode
+  createRenderedNode rs newWidget
+
+-- | Re-register callbacks for a node that is being reused (exact match).
+-- The native view keeps its node ID; only the Haskell-side closures
+-- are updated in the callback maps.
+reRegisterCallbacks :: RenderState -> RenderedNode -> Widget User -> IO RenderedNode
+reRegisterCallbacks rs (RenderedLeaf unitW nodeId maybeCbId) newWidget =
+  case (newWidget, maybeCbId) of
+    (Button config, Just cbId) -> do
+      registerCallbackAt rs cbId (bcAction config)
+      pure (RenderedLeaf unitW nodeId maybeCbId)
+    (TextInput config, Just cbId) -> do
+      registerTextCallbackAt rs cbId (tiOnChange config)
+      pure (RenderedLeaf unitW nodeId maybeCbId)
+    (WebView config, Just cbId) ->
+      case wvOnPageLoad config of
+        Just action -> do
+          registerCallbackAt rs cbId action
+          pure (RenderedLeaf unitW nodeId maybeCbId)
+        Nothing ->
+          pure (RenderedLeaf unitW nodeId maybeCbId)
+    _ ->
+      -- Text, Image, or leaf without callback — nothing to re-register.
+      pure (RenderedLeaf unitW nodeId maybeCbId)
+
+reRegisterCallbacks rs (RenderedContainer unitW nodeId oldChildren) newWidget =
+  case newWidget of
+    Column newChildren -> do
+      reregisteredChildren <- reRegisterChildCallbacks (reRegisterCallbacks rs) oldChildren newChildren
+      pure (RenderedContainer unitW nodeId reregisteredChildren)
+    Row newChildren -> do
+      reregisteredChildren <- reRegisterChildCallbacks (reRegisterCallbacks rs) oldChildren newChildren
+      pure (RenderedContainer unitW nodeId reregisteredChildren)
+    ScrollView newChildren -> do
+      reregisteredChildren <- reRegisterChildCallbacks (reRegisterCallbacks rs) oldChildren newChildren
+      pure (RenderedContainer unitW nodeId reregisteredChildren)
+    _ ->
+      -- Shouldn't happen (same unit widget implies same constructor),
+      -- but return unchanged for safety.
+      pure (RenderedContainer unitW nodeId oldChildren)
+
+reRegisterCallbacks rs (RenderedStyled unitW style oldChild) (Styled _style newChild) = do
+  reregisteredChild <- reRegisterCallbacks rs oldChild newChild
+  pure (RenderedStyled unitW style reregisteredChild)
+reRegisterCallbacks _rs styled@(RenderedStyled {}) _newWidget =
+  -- Shouldn't happen (same unit widget implies Styled), but return unchanged.
+  pure styled
+
+-- | Re-register callbacks for paired old/new children.
+-- Assumes the lists have the same length (caller guarantees via toUnit equality).
+reRegisterChildCallbacks :: (RenderedNode -> Widget User -> IO RenderedNode)
+                         -> [RenderedNode] -> [Widget User] -> IO [RenderedNode]
+reRegisterChildCallbacks _reReg [] [] = pure []
+reRegisterChildCallbacks reReg (old:olds) (new:news) = do
+  result <- reReg old new
+  rest <- reRegisterChildCallbacks reReg olds news
+  pure (result : rest)
+reRegisterChildCallbacks _reReg _ _ = pure []  -- mismatched lengths — shouldn't happen
+
+-- ---------------------------------------------------------------------------
+-- Top-level render entry point
+-- ---------------------------------------------------------------------------
+
+-- | Incremental render: diffs the new widget tree against the previously
+-- rendered tree and emits only the necessary bridge operations.
+--
+-- On the first call (no previous tree), performs a full creation.
+-- On subsequent calls, reuses unchanged native nodes.
+renderWidget :: RenderState -> Widget User -> IO ()
 renderWidget rs widget = do
-  Bridge.clear
-  resetCallbacks rs
-  rootId <- renderNode rs widget
-  Bridge.setRoot rootId
+  -- Clear callback maps for this render pass. rsNextId is NOT reset
+  -- so reused nodes keep valid callback IDs and new nodes get fresh ones.
+  clearCallbackMaps rs
+  oldTree <- readIORef (rsRenderedTree rs)
+  newTree <- diffRenderNode rs oldTree widget
+  -- Set root if this is the first render or the root node changed.
+  case oldTree of
+    Nothing -> Bridge.setRoot (renderedNodeId newTree)
+    Just old
+      | renderedNodeId old /= renderedNodeId newTree ->
+          Bridge.setRoot (renderedNodeId newTree)
+      | otherwise -> pure ()
+  writeIORef (rsRenderedTree rs) (Just newTree)
+
+-- ---------------------------------------------------------------------------
+-- Event dispatch
+-- ---------------------------------------------------------------------------
 
 -- | Dispatch a native click event to the registered Haskell callback.
 -- Logs an error to stderr if the callbackId is not found.

--- a/src/HaskellMobile/Types.hs
+++ b/src/HaskellMobile/Types.hs
@@ -17,7 +17,7 @@ import HaskellMobile.Lifecycle (MobileContext)
 import HaskellMobile.Location (LocationState)
 import HaskellMobile.Permission (PermissionState)
 import HaskellMobile.SecureStorage (SecureStorageState)
-import HaskellMobile.Widget (Widget)
+import HaskellMobile.Widget (User, Widget)
 
 -- | State made available to the view function by the framework.
 -- Contains handles to platform subsystems that the user's UI code
@@ -38,5 +38,5 @@ data UserState = UserState
 -- and pass it to 'startMobileApp'.
 data MobileApp = MobileApp
   { maContext :: MobileContext
-  , maView    :: UserState -> IO Widget
+  , maView    :: UserState -> IO (Widget User)
   }

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -1,11 +1,25 @@
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | Declarative UI widget ADT.
 --
 -- Pure data describing the UI tree. Rendering is handled by
 -- "HaskellMobile.Render", which traverses this tree and issues
 -- FFI calls to the platform bridge.
+--
+-- Uses the Trees That Grow (TTG) pattern: 'Widget', 'ButtonConfig',
+-- 'TextInputConfig', and 'WebViewConfig' are parameterised over a
+-- phase type @p@. The 'User' phase carries real 'IO' callbacks;
+-- the @()@ phase replaces every callback with @()@, enabling a
+-- derived 'Eq' instance for structural diffing.
 module HaskellMobile.Widget
-  ( FontConfig(..)
+  ( -- * Phase types
+    User
+    -- * Callback type families
+  , ButtonCb
+  , TextChangeCb
+  , PageLoadCb
+    -- * Widget types
+  , FontConfig(..)
   , TextConfig(..)
   , ButtonConfig(..)
   , InputType(..)
@@ -22,6 +36,8 @@ module HaskellMobile.Widget
   , colorFromText
   , colorToHex
   , defaultStyle
+    -- * Phase conversion
+  , toUnit
   )
 where
 
@@ -30,6 +46,27 @@ import Data.Char (digitToInt, isHexDigit, intToDigit)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)
+
+-- | The user-facing phase: callbacks are real 'IO' actions.
+data User
+
+-- | Closed type family for button click callbacks.
+-- 'User' carries @IO ()@; any other phase @p@ carries @p@ itself.
+type family ButtonCb p where
+  ButtonCb User = IO ()
+  ButtonCb p    = p
+
+-- | Closed type family for text-change callbacks.
+-- 'User' carries @Text -> IO ()@; any other phase @p@ carries @p@ itself.
+type family TextChangeCb p where
+  TextChangeCb User = Text -> IO ()
+  TextChangeCb p    = p
+
+-- | Closed type family for page-load callbacks.
+-- 'User' carries @IO ()@; any other phase @p@ carries @p@ itself.
+type family PageLoadCb p where
+  PageLoadCb User = IO ()
+  PageLoadCb p    = p
 
 -- | Font configuration for text-bearing widgets.
 -- Only 'Text', 'Button', and 'TextInput' can carry a 'FontConfig'.
@@ -47,10 +84,12 @@ data TextConfig = TextConfig
   } deriving (Show, Eq)
 
 -- | Configuration for a tappable button.
-data ButtonConfig = ButtonConfig
+-- Parameterised over phase @p@: 'bcAction' is @IO ()@ for 'User',
+-- @()@ for the unit phase, etc.
+data ButtonConfig p = ButtonConfig
   { bcLabel      :: Text
     -- ^ The button's label text.
-  , bcAction     :: IO ()
+  , bcAction     :: ButtonCb p
     -- ^ Callback fired when the button is tapped.
   , bcFontConfig :: Maybe FontConfig
     -- ^ Optional font override.
@@ -64,14 +103,16 @@ data InputType
 
 -- | Configuration for a text input field.
 -- Follows a controlled-component pattern: Haskell owns the state.
-data TextInputConfig = TextInputConfig
+-- Parameterised over phase @p@: 'tiOnChange' is @Text -> IO ()@
+-- for 'User', @()@ for the unit phase, etc.
+data TextInputConfig p = TextInputConfig
   { tiInputType :: InputType
     -- ^ Which on-screen keyboard to present.
   , tiHint      :: Text
     -- ^ Placeholder text shown when the field is empty.
   , tiValue     :: Text
     -- ^ Current text value (controlled by Haskell).
-  , tiOnChange  :: Text -> IO ()
+  , tiOnChange  :: TextChangeCb p
     -- ^ Callback fired when the user edits the field.
   , tiFontConfig :: Maybe FontConfig
     -- ^ Optional font override.
@@ -175,30 +216,62 @@ data ImageConfig = ImageConfig
   } deriving (Show, Eq)
 
 -- | Configuration for an embedded web view.
-data WebViewConfig = WebViewConfig
+-- Parameterised over phase @p@: 'wvOnPageLoad' is @Maybe (IO ())@
+-- for 'User', @Maybe ()@ for the unit phase, etc.
+data WebViewConfig p = WebViewConfig
   { wvUrl        :: Text
     -- ^ URL to load in the web view.
-  , wvOnPageLoad :: Maybe (IO ())
+  , wvOnPageLoad :: Maybe (PageLoadCb p)
     -- ^ Optional callback fired when a page finishes loading.
   }
 
 -- | A declarative description of a UI element.
-data Widget
+-- Parameterised over phase @p@ via the Trees That Grow pattern.
+data Widget p
   = Text TextConfig
     -- ^ A read-only text label.
-  | Button ButtonConfig
+  | Button (ButtonConfig p)
     -- ^ A tappable button with a label and click handler.
-  | TextInput TextInputConfig
+  | TextInput (TextInputConfig p)
     -- ^ A text input field.
-  | Column [Widget]
+  | Column [Widget p]
     -- ^ A vertical container laying out children top-to-bottom.
-  | Row [Widget]
+  | Row [Widget p]
     -- ^ A horizontal container laying out children left-to-right.
-  | ScrollView [Widget]
+  | ScrollView [Widget p]
     -- ^ A vertically scrollable container.
   | Image ImageConfig
     -- ^ An image widget displaying resource, file, or raw data.
-  | WebView WebViewConfig
+  | WebView (WebViewConfig p)
     -- ^ An embedded web view loading a URL.
-  | Styled WidgetStyle Widget
+  | Styled WidgetStyle (Widget p)
     -- ^ Apply visual style overrides to a child widget.
+
+-- Eq and Show instances for the () phase (all callbacks become (), which has Eq/Show).
+deriving instance Eq (ButtonConfig ())
+deriving instance Eq (TextInputConfig ())
+deriving instance Eq (WebViewConfig ())
+deriving instance Eq (Widget ())
+deriving instance Show (ButtonConfig ())
+deriving instance Show (TextInputConfig ())
+deriving instance Show (WebViewConfig ())
+deriving instance Show (Widget ())
+
+-- | Strip all callbacks from a widget tree, replacing them with @()@.
+-- The resulting @Widget ()@ can be compared with derived 'Eq' for
+-- structural diffing. Compiler-verified: adding a field without
+-- updating 'toUnit' causes a compile error.
+toUnit :: Widget p -> Widget ()
+toUnit (Text config)        = Text config
+toUnit (Button config)      = Button ButtonConfig
+  { bcLabel = bcLabel config, bcAction = (), bcFontConfig = bcFontConfig config }
+toUnit (TextInput config)   = TextInput TextInputConfig
+  { tiInputType = tiInputType config, tiHint = tiHint config
+  , tiValue = tiValue config, tiOnChange = (), tiFontConfig = tiFontConfig config }
+toUnit (Column children)    = Column (map toUnit children)
+toUnit (Row children)       = Row (map toUnit children)
+toUnit (ScrollView children) = ScrollView (map toUnit children)
+toUnit (Image config)       = Image config
+toUnit (WebView config)     = WebView WebViewConfig
+  { wvUrl = wvUrl config, wvOnPageLoad = Nothing }
+toUnit (Styled style child) = Styled style (toUnit child)

--- a/test/AuthSessionDemoMain.hs
+++ b/test/AuthSessionDemoMain.hs
@@ -20,6 +20,7 @@ import HaskellMobile
 import HaskellMobile.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
+  , User
   , Widget(..)
   )
 
@@ -37,7 +38,7 @@ authSessionDemoApp = MobileApp
 
 -- | Builds a Column with a label and a "Start Login" button.
 -- The button starts an auth session with a demo URL.
-authSessionDemoView :: UserState -> IO Widget
+authSessionDemoView :: UserState -> IO (Widget User)
 authSessionDemoView userState = do
   pure $ Column
     [ Text TextConfig { tcLabel = "AuthSession Demo", tcFontConfig = Nothing }

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -22,7 +22,7 @@ import HaskellMobile
   , loggingMobileContext
   , AppContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -40,7 +40,7 @@ bleDemoApp = MobileApp
 -- | Builds a Column with a label, adapter check button, and scan buttons.
 -- The view itself is pure — all BLE FFI calls happen in button callbacks
 -- to avoid JNI reentrancy issues during rendering.
-bleDemoView :: UserState -> IO Widget
+bleDemoView :: UserState -> IO (Widget User)
 bleDemoView userState = pure $ Column
   [ Text TextConfig { tcLabel = "BLE Demo", tcFontConfig = Nothing }
   , Button ButtonConfig

--- a/test/BottomSheetDemoMain.hs
+++ b/test/BottomSheetDemoMain.hs
@@ -18,7 +18,7 @@ import HaskellMobile
   , showBottomSheet
   , loggingMobileContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -35,7 +35,7 @@ bottomSheetDemoApp = MobileApp
   }
 
 -- | Builds a Column with a label and a "Show Actions" button.
-bottomSheetDemoView :: UserState -> IO Widget
+bottomSheetDemoView :: UserState -> IO (Widget User)
 bottomSheetDemoView userState = pure $ Column
   [ Text TextConfig { tcLabel = "BottomSheet Demo", tcFontConfig = Nothing }
   , Button ButtonConfig

--- a/test/CameraDemoMain.hs
+++ b/test/CameraDemoMain.hs
@@ -25,6 +25,7 @@ import HaskellMobile
 import HaskellMobile.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
+  , User
   , Widget(..)
   )
 
@@ -42,7 +43,7 @@ cameraDemoApp = MobileApp
 
 -- | Builds a Column with a label and a "Capture Photo" button.
 -- The button captures a photo and logs the result.
-cameraDemoView :: UserState -> IO Widget
+cameraDemoView :: UserState -> IO (Widget User)
 cameraDemoView userState = do
   pure $ Column
     [ Text TextConfig { tcLabel = "Camera Demo", tcFontConfig = Nothing }

--- a/test/ConsumerDepsMain.hs
+++ b/test/ConsumerDepsMain.hs
@@ -10,7 +10,7 @@ module Main where
 
 import Foreign.Ptr (Ptr)
 import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
-import HaskellMobile.Widget (TextConfig(..), Widget(..))
+import HaskellMobile.Widget (TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do

--- a/test/CounterDemoMain.hs
+++ b/test/CounterDemoMain.hs
@@ -9,7 +9,7 @@ import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
 import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
-import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), TextAlignment(..), TextConfig(..), Widget(..), WidgetStyle(..))
+import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), TextAlignment(..), TextConfig(..), User, Widget(..), WidgetStyle(..))
 import System.IO.Unsafe (unsafePerformIO)
 
 main :: IO (Ptr AppContext)
@@ -30,7 +30,7 @@ counterState = unsafePerformIO (newIORef 0)
 {-# NOINLINE counterState #-}
 
 -- | Counter view: displays current count with styled label and +/- buttons.
-counterView :: IO Widget
+counterView :: IO (Widget User)
 counterView = do
   n <- readIORef counterState
   pure $ Column

--- a/test/DialogDemoMain.hs
+++ b/test/DialogDemoMain.hs
@@ -18,7 +18,7 @@ import HaskellMobile
   , showDialog
   , loggingMobileContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -35,7 +35,7 @@ dialogDemoApp = MobileApp
   }
 
 -- | Builds a Column with a label, a "Show Alert" button, and a "Show Confirm" button.
-dialogDemoView :: UserState -> IO Widget
+dialogDemoView :: UserState -> IO (Widget User)
 dialogDemoView userState = pure $ Column
   [ Text TextConfig { tcLabel = "Dialog Demo", tcFontConfig = Nothing }
   , Button ButtonConfig

--- a/test/ImageDemoMain.hs
+++ b/test/ImageDemoMain.hs
@@ -8,7 +8,7 @@ module Main where
 import Data.ByteString qualified as BS
 import Foreign.Ptr (Ptr)
 import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
-import HaskellMobile.Widget (ImageConfig(..), ImageSource(..), ResourceName(..), ScaleType(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ImageConfig(..), ImageSource(..), ResourceName(..), ScaleType(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -24,7 +24,7 @@ imageDemoApp = MobileApp
   }
 
 -- | Builds a Column with a label and three Image widgets (resource, data, file).
-imageDemoView :: IO Widget
+imageDemoView :: IO (Widget User)
 imageDemoView = pure $ Column
   [ Text TextConfig { tcLabel = "Image Demo", tcFontConfig = Nothing }
   , Image ImageConfig

--- a/test/LocationDemoMain.hs
+++ b/test/LocationDemoMain.hs
@@ -22,7 +22,7 @@ import HaskellMobile
   , AppContext
   )
 import HaskellMobile.Location (LocationData(..))
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -40,7 +40,7 @@ locationDemoApp = MobileApp
 -- | Builds a Column with a label and start/stop location buttons.
 -- The view itself is pure — all location FFI calls happen in button
 -- callbacks to avoid JNI reentrancy issues during rendering.
-locationDemoView :: UserState -> IO Widget
+locationDemoView :: UserState -> IO (Widget User)
 locationDemoView userState = pure $ Column
   [ Text TextConfig { tcLabel = "Location Demo", tcFontConfig = Nothing }
   , Button ButtonConfig

--- a/test/NodePoolTestMain.hs
+++ b/test/NodePoolTestMain.hs
@@ -10,10 +10,10 @@ import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile (MobileApp(..), UserState(..), startMobileApp, AppContext)
 import HaskellMobile.Lifecycle (loggingMobileContext)
-import HaskellMobile.Widget (TextConfig(..), Widget(..))
+import HaskellMobile.Widget (TextConfig(..), User, Widget(..))
 
 -- | Render 300 nodes: 1 Column parent + 299 Text children.
-nodePoolTestView :: UserState -> IO Widget
+nodePoolTestView :: UserState -> IO (Widget User)
 nodePoolTestView _userState = pure $ Column $
   map (\itemNumber -> Text TextConfig
     { tcLabel = "Item " <> pack (show (itemNumber :: Int))

--- a/test/PermissionDemoMain.hs
+++ b/test/PermissionDemoMain.hs
@@ -18,7 +18,7 @@ import HaskellMobile
   , loggingMobileContext
   , AppContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -35,7 +35,7 @@ permissionDemoApp = MobileApp
 
 -- | Builds a Column with a label and a "Request Camera" button.
 -- The button's callback ID is 0 (first registered), matching --autotest dispatch.
-permissionDemoView :: UserState -> IO Widget
+permissionDemoView :: UserState -> IO (Widget User)
 permissionDemoView userState = pure $ Column
   [ Text TextConfig { tcLabel = "Permission Demo", tcFontConfig = Nothing }
   , Button ButtonConfig

--- a/test/ScrollDemoMain.hs
+++ b/test/ScrollDemoMain.hs
@@ -8,7 +8,7 @@ module Main where
 import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
 import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -25,7 +25,7 @@ scrollDemoApp = MobileApp
 
 -- | Builds a ScrollView containing 20 text items followed by a button.
 -- The button's callback ID is 0 (first registered), matching the --autotest dispatch.
-scrollDemoView :: IO Widget
+scrollDemoView :: IO (Widget User)
 scrollDemoView = pure $ ScrollView
   [ Column
     ( map (\itemNumber -> Text TextConfig

--- a/test/SecureStorageDemoMain.hs
+++ b/test/SecureStorageDemoMain.hs
@@ -18,7 +18,7 @@ import HaskellMobile
   , secureStorageRead
   , loggingMobileContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -35,7 +35,7 @@ secureStorageDemoApp = MobileApp
   }
 
 -- | Builds a Column with a label, a "Store Token" button, and a "Read Token" button.
-secureStorageDemoView :: UserState -> IO Widget
+secureStorageDemoView :: UserState -> IO (Widget User)
 secureStorageDemoView userState = pure $ Column
   [ Text TextConfig { tcLabel = "SecureStorage Demo", tcFontConfig = Nothing }
   , Button ButtonConfig

--- a/test/THDemoMain.hs
+++ b/test/THDemoMain.hs
@@ -11,7 +11,7 @@ import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import THConsumer (thGreeting)
 import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
-import HaskellMobile.Widget (TextConfig(..), Widget(..))
+import HaskellMobile.Widget (TextConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -7,6 +7,7 @@ import Test.Tasty.HUnit
 import Data.ByteString qualified as BS
 import Data.Either (isLeft)
 import Data.List (isInfixOf, sort)
+import Data.Int (Int32)
 import Data.IntMap.Strict qualified as IntMap
 import Control.Exception (IOException, throwIO, try)
 import Data.IORef (newIORef, readIORef, modifyIORef', writeIORef)
@@ -49,7 +50,7 @@ import HaskellMobile.Lifecycle
   , lifecycleToInt
   , loggingMobileContext
   )
-import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorFromText, colorToHex, defaultStyle)
+import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), User, WebViewConfig(..), Widget(..), WidgetStyle(..), colorFromText, colorToHex, defaultStyle, toUnit)
 import HaskellMobile.Permission
   ( Permission(..)
   , PermissionStatus(..)
@@ -97,7 +98,7 @@ import HaskellMobile.Camera
   , dispatchVideoFrame
   , dispatchAudioChunk
   )
-import HaskellMobile.Render (newRenderState, renderWidget, dispatchEvent, dispatchTextEvent)
+import HaskellMobile.Render (RenderState(..), RenderedNode(..), newRenderState, renderWidget, dispatchEvent, dispatchTextEvent)
 import HaskellMobile.SecureStorage
   ( SecureStorageStatus(..)
   , SecureStorageState(..)
@@ -145,7 +146,7 @@ main = do
   defaultMain (tests (acPermissionState ffiAppCtx) (acSecureStorageState ffiAppCtx) (acDialogState ffiAppCtx) (acAuthSessionState ffiAppCtx) (acBottomSheetState ffiAppCtx))
 
 tests :: PermissionState -> SecureStorageState -> DialogState -> AuthSessionState -> BottomSheetState -> TestTree
-tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, appContextTests, exceptionHandlerTests]
+tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, appContextTests, exceptionHandlerTests, incrementalRenderTests]
 
 qcProps :: TestTree
 qcProps = testGroup "(checked by QuickCheck)"
@@ -287,17 +288,18 @@ uiTests = testGroup "UI"
       b' <- readIORef refB
       b' @?= True
 
-  , testCase "re-render resets callback IDs" $ do
+  , testCase "re-render with changed label creates new callback" $ do
       refOld <- newIORef False
       refNew <- newIORef False
       rs <- newRenderState
-      -- First render with old callback
+      -- First render with old callback (gets callback ID 0)
       renderWidget rs (Button ButtonConfig
         { bcLabel = "old", bcAction = modifyIORef' refOld (const True), bcFontConfig = Nothing })
-      -- Second render replaces it
+      -- Second render: different label → old node destroyed, new node created
+      -- with fresh callback ID (1, since rsNextId grows monotonically).
       renderWidget rs (Button ButtonConfig
         { bcLabel = "new", bcAction = modifyIORef' refNew (const True), bcFontConfig = Nothing })
-      dispatchEvent rs 0
+      dispatchEvent rs 1
       old <- readIORef refOld
       new <- readIORef refNew
       old @?= False
@@ -398,15 +400,16 @@ scrollViewTests = testGroup "ScrollView"
       fired <- readIORef ref
       fired @?= True
 
-  , testCase "re-render inside ScrollView resets callbacks" $ do
+  , testCase "re-render inside ScrollView with changed label creates new callback" $ do
       refOld <- newIORef False
       refNew <- newIORef False
       rs <- newRenderState
       renderWidget rs $ ScrollView [Button ButtonConfig
         { bcLabel = "old", bcAction = modifyIORef' refOld (const True), bcFontConfig = Nothing }]
+      -- Different label → old node destroyed, new node created with callback 1
       renderWidget rs $ ScrollView [Button ButtonConfig
         { bcLabel = "new", bcAction = modifyIORef' refNew (const True), bcFontConfig = Nothing }]
-      dispatchEvent rs 0
+      dispatchEvent rs 1
       old <- readIORef refOld
       new <- readIORef refNew
       old @?= False
@@ -468,7 +471,7 @@ textInputTests = testGroup "TextInput"
       click @?= True
       text  @?= show ("typed" :: String)
 
-  , testCase "re-render resets text callbacks" $ do
+  , testCase "re-render with changed hint creates new text callback" $ do
       refOld <- newIORef ("" :: String)
       refNew <- newIORef ("" :: String)
       rs <- newRenderState
@@ -476,11 +479,12 @@ textInputTests = testGroup "TextInput"
         { tiInputType = InputText, tiHint = "old", tiValue = ""
         , tiOnChange = \t -> modifyIORef' refOld (const (show t))
         , tiFontConfig = Nothing }
+      -- Different hint → old node destroyed, new node created with callback 1
       renderWidget rs $ TextInput TextInputConfig
         { tiInputType = InputText, tiHint = "new", tiValue = ""
         , tiOnChange = \t -> modifyIORef' refNew (const (show t))
         , tiFontConfig = Nothing }
-      dispatchTextEvent rs 0 "val"
+      dispatchTextEvent rs 1 "val"
       old <- readIORef refOld
       new <- readIORef refNew
       old @?= ""
@@ -666,7 +670,7 @@ styledTests = testGroup "Styled"
       renderWidget rs $ Styled defaultStyle
         (Button ButtonConfig
           { bcLabel = "new", bcAction = modifyIORef' refNew (const True), bcFontConfig = Nothing })
-      dispatchEvent rs 0
+      dispatchEvent rs 1
       old <- readIORef refOld
       new <- readIORef refNew
       old @?= False
@@ -1870,4 +1874,259 @@ exceptionHandlerTests = testGroup "ExceptionHandler"
         Left exc -> assertFailure ("haskellOnLifecycle should not throw, but got: " ++ show exc)
         Right () -> pure ()
       freeAppContext ctxPtr
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Incremental rendering tests
+-- ---------------------------------------------------------------------------
+
+-- | Helper to extract the rendered node ID from a RenderedNode.
+nodeIdOf :: RenderedNode -> Int32
+nodeIdOf (RenderedLeaf _ nodeId _)     = nodeId
+nodeIdOf (RenderedContainer _ nodeId _) = nodeId
+nodeIdOf (RenderedStyled _ _ child)     = nodeIdOf child
+
+-- | Helper to extract children from a RenderedContainer.
+childrenOf :: RenderedNode -> [RenderedNode]
+childrenOf (RenderedContainer _ _ children) = children
+childrenOf _                                = []
+
+incrementalRenderTests :: TestTree
+incrementalRenderTests = testGroup "Incremental rendering"
+  [ testGroup "toUnit"
+      [ testCase "same structure produces equal unit widgets" $ do
+          let widget1 :: Widget User
+              widget1 = Button ButtonConfig
+                { bcLabel = "X", bcAction = pure (), bcFontConfig = Nothing }
+              widget2 :: Widget User
+              widget2 = Button ButtonConfig
+                { bcLabel = "X", bcAction = putStrLn "different!", bcFontConfig = Nothing }
+          toUnit widget1 @?= toUnit widget2
+
+      , testCase "different label produces unequal unit widgets" $ do
+          let widget1 :: Widget User
+              widget1 = Button ButtonConfig
+                { bcLabel = "A", bcAction = pure (), bcFontConfig = Nothing }
+              widget2 :: Widget User
+              widget2 = Button ButtonConfig
+                { bcLabel = "B", bcAction = pure (), bcFontConfig = Nothing }
+          assertBool "toUnit should differ for different labels"
+            (toUnit widget1 /= toUnit widget2)
+
+      , testCase "nested containers compare structurally" $ do
+          let tree1 :: Widget User
+              tree1 = Column
+                [ Text TextConfig { tcLabel = "hi", tcFontConfig = Nothing }
+                , Button ButtonConfig { bcLabel = "go", bcAction = pure (), bcFontConfig = Nothing }
+                ]
+              tree2 :: Widget User
+              tree2 = Column
+                [ Text TextConfig { tcLabel = "hi", tcFontConfig = Nothing }
+                , Button ButtonConfig { bcLabel = "go", bcAction = putStrLn "other", bcFontConfig = Nothing }
+                ]
+          toUnit tree1 @?= toUnit tree2
+
+      , testCase "different child count produces unequal" $ do
+          let tree1 :: Widget User
+              tree1 = Column
+                [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing } ]
+              tree2 :: Widget User
+              tree2 = Column
+                [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+                ]
+          assertBool "different child count should differ"
+            (toUnit tree1 /= toUnit tree2)
+
+      , testCase "TextInput ignores callback for equality" $ do
+          let ti1 :: Widget User
+              ti1 = TextInput TextInputConfig
+                { tiInputType = InputText, tiHint = "h", tiValue = "v"
+                , tiOnChange = \_ -> pure (), tiFontConfig = Nothing }
+              ti2 :: Widget User
+              ti2 = TextInput TextInputConfig
+                { tiInputType = InputText, tiHint = "h", tiValue = "v"
+                , tiOnChange = \_ -> putStrLn "changed", tiFontConfig = Nothing }
+          toUnit ti1 @?= toUnit ti2
+
+      , testCase "WebView ignores callback for equality" $ do
+          let wv1 :: Widget User
+              wv1 = WebView WebViewConfig
+                { wvUrl = "https://example.com", wvOnPageLoad = Just (pure ()) }
+              wv2 :: Widget User
+              wv2 = WebView WebViewConfig
+                { wvUrl = "https://example.com", wvOnPageLoad = Just (putStrLn "loaded") }
+          toUnit wv1 @?= toUnit wv2
+      ]
+
+  , testGroup "Node reuse"
+      [ testCase "identical re-render retains same node ID" $ do
+          rs <- newRenderState
+          let widget = Text TextConfig { tcLabel = "static", tcFontConfig = Nothing }
+          renderWidget rs widget
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing -> -1
+          renderWidget rs widget
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing -> -2
+          nodeId1 @?= nodeId2
+
+      , testCase "single child change only changes that child's node ID" $ do
+          rs <- newRenderState
+          let widget1 = Column
+                [ Text TextConfig { tcLabel = "stable", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "will change", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          (child0Id1, child1Id1) <- case tree1 of
+            Just node -> case childrenOf node of
+              [c0, c1] -> pure (nodeIdOf c0, nodeIdOf c1)
+              _        -> assertFailure "expected 2 children" >> pure (-1, -1)
+            Nothing -> assertFailure "expected rendered tree" >> pure (-1, -1)
+          let widget2 = Column
+                [ Text TextConfig { tcLabel = "stable", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "changed!", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          (child0Id2, child1Id2) <- case tree2 of
+            Just node -> case childrenOf node of
+              [c0, c1] -> pure (nodeIdOf c0, nodeIdOf c1)
+              _        -> assertFailure "expected 2 children" >> pure (-1, -1)
+            Nothing -> assertFailure "expected rendered tree" >> pure (-1, -1)
+          -- First child (unchanged) keeps same node ID
+          child0Id1 @?= child0Id2
+          -- Second child (changed) gets a different node ID
+          assertBool "changed child should get new node ID"
+            (child1Id1 /= child1Id2)
+
+      , testCase "callback-only change reuses node and updates closure" $ do
+          ref <- newIORef ("none" :: String)
+          rs <- newRenderState
+          -- Render button with action1
+          let widget1 = Button ButtonConfig
+                { bcLabel = "same label", bcAction = writeIORef ref "action1", bcFontConfig = Nothing }
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing -> -1
+          -- Render same button label with action2
+          let widget2 = Button ButtonConfig
+                { bcLabel = "same label", bcAction = writeIORef ref "action2", bcFontConfig = Nothing }
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing -> -2
+              callbackId2 = case tree2 of
+                Just (RenderedLeaf _ _ (Just cbId)) -> cbId
+                _ -> -1
+          -- Same node ID (reused)
+          nodeId1 @?= nodeId2
+          -- Dispatch the callback — should fire action2, not action1
+          dispatchEvent rs callbackId2
+          result <- readIORef ref
+          result @?= "action2"
+
+      , testCase "adding a child to container" $ do
+          rs <- newRenderState
+          let widget1 = Column
+                [ Text TextConfig { tcLabel = "first", tcFontConfig = Nothing } ]
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          existingChildId <- case tree1 of
+            Just node -> case childrenOf node of
+              [c0] -> pure (nodeIdOf c0)
+              _    -> assertFailure "expected 1 child" >> pure (-1)
+            Nothing -> assertFailure "expected rendered tree" >> pure (-1)
+          let widget2 = Column
+                [ Text TextConfig { tcLabel = "first", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "second", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          case tree2 of
+            Just node -> case childrenOf node of
+              [c0, c1] -> do
+                -- First child retained
+                nodeIdOf c0 @?= existingChildId
+                -- Second child is new (different ID)
+                assertBool "new child should have different ID"
+                  (nodeIdOf c1 /= existingChildId)
+              _ -> assertFailure "expected 2 children"
+            Nothing -> assertFailure "expected rendered tree"
+
+      , testCase "removing a child from container" $ do
+          rs <- newRenderState
+          let widget1 = Column
+                [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget1
+          let widget2 = Column
+                [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing } ]
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let children2 = childrenOf (maybe (error "no tree") id tree2)
+          length children2 @?= 1
+
+      , testCase "root type change triggers new root node" $ do
+          rs <- newRenderState
+          let widget1 = Text TextConfig { tcLabel = "text", tcFontConfig = Nothing }
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing -> -1
+          let widget2 = Button ButtonConfig
+                { bcLabel = "button", bcAction = pure (), bcFontConfig = Nothing }
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing -> -2
+          assertBool "different widget type should produce new node ID"
+            (nodeId1 /= nodeId2)
+
+      , testCase "styled unchanged keeps same node ID" $ do
+          rs <- newRenderState
+          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing
+              widget = Styled style (Text TextConfig { tcLabel = "styled", tcFontConfig = Nothing })
+          renderWidget rs widget
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing -> -1
+          renderWidget rs widget
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing -> -2
+          nodeId1 @?= nodeId2
+
+      , testCase "styled child change updates child, keeps style" $ do
+          rs <- newRenderState
+          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing
+              widget1 = Styled style (Text TextConfig { tcLabel = "before", tcFontConfig = Nothing })
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing -> -1
+          let widget2 = Styled style (Text TextConfig { tcLabel = "after", tcFontConfig = Nothing })
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing -> -2
+          -- Child changed, so node should be different
+          assertBool "changed styled child should get new node"
+            (nodeId1 /= nodeId2)
+      ]
   ]

--- a/test/TextInputDemoMain.hs
+++ b/test/TextInputDemoMain.hs
@@ -7,7 +7,7 @@ module Main where
 
 import Foreign.Ptr (Ptr)
 import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
-import HaskellMobile.Widget (InputType(..), TextConfig(..), TextInputConfig(..), Widget(..))
+import HaskellMobile.Widget (InputType(..), TextConfig(..), TextInputConfig(..), User, Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
@@ -23,7 +23,7 @@ textInputDemoApp = MobileApp
   }
 
 -- | Builds a Column with a label and two TextInputs of different InputType.
-textInputDemoView :: IO Widget
+textInputDemoView :: IO (Widget User)
 textInputDemoView = pure $ Column
   [ Text TextConfig { tcLabel = "TextInput Demo", tcFontConfig = Nothing }
   , TextInput TextInputConfig

--- a/test/WebViewDemoMain.hs
+++ b/test/WebViewDemoMain.hs
@@ -20,6 +20,7 @@ import HaskellMobile.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
   , WebViewConfig(..)
+  , User
   , Widget(..)
   )
 
@@ -38,7 +39,7 @@ webViewDemoApp urlRef = MobileApp
   }
 
 -- | Builds a Column with a WebView, a status label, and a URL-switch button.
-webViewDemoView :: IORef String -> UserState -> IO Widget
+webViewDemoView :: IORef String -> UserState -> IO (Widget User)
 webViewDemoView urlRef _userState = do
   currentUrl <- readIORef urlRef
   pure $ Column


### PR DESCRIPTION
## Summary

- **Trees That Grow (TTG) pattern**: `Widget`, `ButtonConfig`, `TextInputConfig`, `WebViewConfig` parameterised over a phase type `p` with closed type families. `Widget User` carries real IO callbacks; `Widget ()` has all callbacks as `()` enabling derived `Eq` for structural diffing.
- **Incremental diff algorithm**: `RenderedNode` retained tree + `diffRenderNode` compares `toUnit old == toUnit new`. Unchanged nodes reuse native views, changed leaves get destroy+create, container children are diffed individually. Callback IDs monotonically increase.
- **Dynamic node pool**: `dynamicNodePool` defaults to `true` since we no longer call `clear()`.
- 14 new tests (6 toUnit + 8 node reuse/diff), all 177 tests pass.

Closes #97

## Test plan

- [x] All 177 unit tests pass (`cabal test`)
- [x] `nix-build nix/ci.nix` passes for x86_64 and aarch64 targets
- [x] toUnit structural equality verified (same structure equal, different structure unequal)
- [x] Node reuse: identical re-render retains same node ID
- [x] Single child change: only changed child gets new node ID
- [x] Callback-only change: node reused, closure updated (dispatches new action)
- [x] Add/remove children: correct native node lifecycle
- [x] Root type change triggers new root node
- [x] Styled unchanged/changed: correct node retention and style reapplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)