### PR TITLE
Replace IO callbacks with opaque Action/OnChange handles

### DIFF
--- a/haskell-mobile.cabal
+++ b/haskell-mobile.cabal
@@ -61,6 +61,7 @@ library
   import: common-options
   exposed-modules:
       HaskellMobile
+      HaskellMobile.Action
       HaskellMobile.AppContext
       HaskellMobile.Types
       HaskellMobile.Lifecycle

--- a/haskell-mobile.cabal
+++ b/haskell-mobile.cabal
@@ -84,7 +84,8 @@ library
   build-depends:
       text,
       containers,
-      bytestring
+      bytestring,
+      transformers
   c-sources:
       cbits/android_stubs.c
       cbits/platform_log.c

--- a/src/HaskellMobile.hs
+++ b/src/HaskellMobile.hs
@@ -4,6 +4,15 @@ module HaskellMobile
   ( MobileApp(..)
   , UserState(..)
   , startMobileApp
+  -- Action handles
+  , Action(..)
+  , OnChange(..)
+  , ActionState
+  , ActionM
+  , createAction
+  , createOnChange
+  , newActionState
+  , runActionM
   -- FFI exports
   , haskellGreet
   , haskellRenderUI
@@ -113,6 +122,16 @@ import Data.Text (Text, pack)
 import Foreign.C.String (CString, newCString, peekCString)
 import Foreign.C.Types (CDouble(..), CInt(..))
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import HaskellMobile.Action
+  ( Action(..)
+  , OnChange(..)
+  , ActionState
+  , ActionM
+  , createAction
+  , createOnChange
+  , newActionState
+  , runActionM
+  )
 import HaskellMobile.AppContext (AppContext(..), newAppContext, freeAppContext, derefAppContext)
 import HaskellMobile.AuthSession
   ( AuthSessionResult(..)
@@ -223,18 +242,23 @@ withExceptionHandler ctxPtr action =
 
 -- | Handle an uncaught exception from an FFI entry point.
 -- Overwrites the context's view function with an error widget so
--- that subsequent renders show the error on screen. The error widget
--- includes a dismiss button that restores the original view.
+-- that subsequent renders show the error on screen. The dismiss
+-- button uses a pre-registered 'Action' handle; we write the real
+-- restore logic into 'acDismissRef'.
 -- Also logs via 'platformLog' and best-effort fires 'onError'.
 handleException :: Ptr AppContext -> SomeException -> IO ()
 handleException ctxPtr exc = do
   appCtx <- derefAppContext ctxPtr
   originalView <- readIORef (acViewFunction appCtx)
+  let dismissAction = acDismissAction appCtx
+  -- Write the real dismiss logic: restore the original view function.
+  writeIORef (acDismissRef appCtx)
+    (writeIORef (acViewFunction appCtx) originalView)
   writeIORef (acViewFunction appCtx)
-    (\_userState -> pure (errorWidget ctxPtr originalView exc))
+    (\_userState -> pure (errorWidget dismissAction exc))
   platformLog ("Uncaught exception: " <> pack (show exc))
   renderWidget (acRenderState appCtx)
-    (errorWidget ctxPtr originalView exc)
+    (errorWidget dismissAction exc)
   fireUserErrorCallback appCtx exc
 
 -- | Best-effort: read the context's 'onError' callback and fire it.
@@ -267,9 +291,10 @@ renderView ctxPtr = do
   renderWidget (acRenderState appCtx) widget
 
 -- | A widget that displays an error message with a dismiss button.
--- The dismiss button restores the original view via a closure.
-errorWidget :: Ptr AppContext -> (UserState -> IO Widget) -> SomeException -> Widget
-errorWidget ctxPtr originalView exc = Column
+-- The dismiss button uses a pre-registered 'Action' handle whose
+-- closure is populated by the exception handler.
+errorWidget :: Action -> SomeException -> Widget
+errorWidget dismissAction exc = Column
   [ Text TextConfig
       { tcLabel      = "An error occurred"
       , tcFontConfig = Just (FontConfig 20.0)
@@ -280,9 +305,7 @@ errorWidget ctxPtr originalView exc = Column
       }
   , Button ButtonConfig
       { bcLabel      = "Dismiss"
-      , bcAction     = do
-          appCtx <- derefAppContext ctxPtr
-          writeIORef (acViewFunction appCtx) originalView
+      , bcAction     = dismissAction
       , bcFontConfig = Nothing
       }
   ]

--- a/src/HaskellMobile/Action.hs
+++ b/src/HaskellMobile/Action.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 -- | Opaque callback handles for the widget system.
 --
@@ -31,6 +33,8 @@ module HaskellMobile.Action
   )
 where
 
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Reader (ReaderT(..))
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import Data.Int (Int32)
 import Data.IntMap.Strict (IntMap)
@@ -40,12 +44,12 @@ import Data.Text (Text)
 -- | An opaque handle to a click / tap callback.
 -- Carries only an 'Int32' identifier, so it derives 'Eq' and 'Show'.
 newtype Action = Action { actionId :: Int32 }
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 -- | An opaque handle to a text-change callback.
 -- Carries only an 'Int32' identifier, so it derives 'Eq' and 'Show'.
 newtype OnChange = OnChange { onChangeId :: Int32 }
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 -- | Mutable callback storage shared between 'ActionM' (creation)
 -- and the render/dispatch engine (lookup).
@@ -74,24 +78,9 @@ newActionState = do
 -- The constructor is hidden so that users cannot construct arbitrary
 -- 'ActionM' values — they must go through 'createAction' and
 -- 'createOnChange'.
-newtype ActionM a = ActionM { unActionM :: ActionState -> IO a }
-
-instance Functor ActionM where
-  fmap f (ActionM g) = ActionM (\state -> fmap f (g state))
-
-instance Applicative ActionM where
-  pure x = ActionM (\_state -> pure x)
-  ActionM mf <*> ActionM mx = ActionM (\state -> mf state <*> mx state)
-
-instance Monad ActionM where
-  ActionM mx >>= f = ActionM (\state -> do
-    x <- mx state
-    unActionM (f x) state)
-
--- | Lift an arbitrary 'IO' action into 'ActionM'.
--- Useful for creating 'IORef's in init blocks.
-liftIO :: IO a -> ActionM a
-liftIO action = ActionM (\_state -> action)
+newtype ActionM a = ActionM (ActionState -> IO a)
+  deriving (Functor, Applicative, Monad, MonadIO)
+    via (ReaderT ActionState IO)
 
 -- | Register a click/tap callback and return its opaque handle.
 createAction :: IO () -> ActionM Action

--- a/src/HaskellMobile/Action.hs
+++ b/src/HaskellMobile/Action.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+-- | Opaque callback handles for the widget system.
+--
+-- Instead of embedding raw @IO ()@ closures inside widget configs,
+-- the framework uses typed handles ('Action', 'OnChange') that
+-- reference entries in a shared 'ActionState' registry.  Because
+-- the handles are plain 'Int32' newtypes they derive 'Eq', which
+-- lets 'Widget' derive 'Eq' naturally — enabling O(1) "skip if
+-- unchanged" diff in the render engine.
+--
+-- Users create handles once at init time via the restricted 'ActionM'
+-- monad, then embed them in widget configs.  The callback 'IntMap's
+-- are never cleared during rendering, eliminating the atomicity gap
+-- of the old clear-and-rebuild strategy.
+module HaskellMobile.Action
+  ( -- * Handles
+    Action(..)
+  , OnChange(..)
+    -- * Callback registry
+  , ActionState(..)
+    -- * Restricted construction monad
+  , ActionM
+  , createAction
+  , createOnChange
+  , liftIO
+    -- * Framework-internal
+  , newActionState
+  , runActionM
+  , lookupAction
+  , lookupTextAction
+  )
+where
+
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
+import Data.Int (Int32)
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Data.Text (Text)
+
+-- | An opaque handle to a click / tap callback.
+-- Carries only an 'Int32' identifier, so it derives 'Eq' and 'Show'.
+newtype Action = Action { actionId :: Int32 }
+  deriving (Eq, Show)
+
+-- | An opaque handle to a text-change callback.
+-- Carries only an 'Int32' identifier, so it derives 'Eq' and 'Show'.
+newtype OnChange = OnChange { onChangeId :: Int32 }
+  deriving (Eq, Show)
+
+-- | Mutable callback storage shared between 'ActionM' (creation)
+-- and the render/dispatch engine (lookup).
+data ActionState = ActionState
+  { asCallbacks     :: IORef (IntMap (IO ()))
+    -- ^ Click/tap callbacks keyed by handle ID.
+  , asTextCallbacks :: IORef (IntMap (Text -> IO ()))
+    -- ^ Text-change callbacks keyed by handle ID.
+  , asNextId        :: IORef Int32
+    -- ^ Monotonically increasing counter for the next handle ID.
+  }
+
+-- | Create a fresh empty 'ActionState'.
+newActionState :: IO ActionState
+newActionState = do
+  callbacks     <- newIORef IntMap.empty
+  textCallbacks <- newIORef IntMap.empty
+  nextId        <- newIORef 0
+  pure ActionState
+    { asCallbacks     = callbacks
+    , asTextCallbacks = textCallbacks
+    , asNextId        = nextId
+    }
+
+-- | A restricted monad for creating callback handles.
+-- The constructor is hidden so that users cannot construct arbitrary
+-- 'ActionM' values — they must go through 'createAction' and
+-- 'createOnChange'.
+newtype ActionM a = ActionM { unActionM :: ActionState -> IO a }
+
+instance Functor ActionM where
+  fmap f (ActionM g) = ActionM (\state -> fmap f (g state))
+
+instance Applicative ActionM where
+  pure x = ActionM (\_state -> pure x)
+  ActionM mf <*> ActionM mx = ActionM (\state -> mf state <*> mx state)
+
+instance Monad ActionM where
+  ActionM mx >>= f = ActionM (\state -> do
+    x <- mx state
+    unActionM (f x) state)
+
+-- | Lift an arbitrary 'IO' action into 'ActionM'.
+-- Useful for creating 'IORef's in init blocks.
+liftIO :: IO a -> ActionM a
+liftIO action = ActionM (\_state -> action)
+
+-- | Register a click/tap callback and return its opaque handle.
+createAction :: IO () -> ActionM Action
+createAction callback = ActionM $ \state -> do
+  handleId <- readIORef (asNextId state)
+  modifyIORef' (asCallbacks state) (IntMap.insert (fromIntegral handleId) callback)
+  modifyIORef' (asNextId state) (+ 1)
+  pure (Action handleId)
+
+-- | Register a text-change callback and return its opaque handle.
+createOnChange :: (Text -> IO ()) -> ActionM OnChange
+createOnChange callback = ActionM $ \state -> do
+  handleId <- readIORef (asNextId state)
+  modifyIORef' (asTextCallbacks state) (IntMap.insert (fromIntegral handleId) callback)
+  modifyIORef' (asNextId state) (+ 1)
+  pure (OnChange handleId)
+
+-- | Run an 'ActionM' computation against a given 'ActionState'.
+runActionM :: ActionState -> ActionM a -> IO a
+runActionM state (ActionM f) = f state
+
+-- | Look up a click/tap callback by handle ID.
+-- Returns 'Nothing' if the ID is not registered.
+lookupAction :: ActionState -> Int32 -> IO (Maybe (IO ()))
+lookupAction state handleId = do
+  callbacks <- readIORef (asCallbacks state)
+  pure (IntMap.lookup (fromIntegral handleId) callbacks)
+
+-- | Look up a text-change callback by handle ID.
+-- Returns 'Nothing' if the ID is not registered.
+lookupTextAction :: ActionState -> Int32 -> IO (Maybe (Text -> IO ()))
+lookupTextAction state handleId = do
+  callbacks <- readIORef (asTextCallbacks state)
+  pure (IntMap.lookup (fromIntegral handleId) callbacks)

--- a/src/HaskellMobile/AppContext.hs
+++ b/src/HaskellMobile/AppContext.hs
@@ -11,9 +11,10 @@ module HaskellMobile.AppContext
   )
 where
 
-import Data.IORef (IORef, newIORef, writeIORef)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Foreign.Ptr (Ptr, castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, newStablePtr, deRefStablePtr, freeStablePtr)
+import HaskellMobile.Action (Action, ActionState, runActionM, createAction)
 import HaskellMobile.AuthSession (AuthSessionState(..), newAuthSessionState)
 import HaskellMobile.Ble (BleState(..), newBleState)
 import HaskellMobile.Camera (CameraState(..), newCameraState)
@@ -45,6 +46,13 @@ data AppContext = AppContext
   , acBottomSheetState    :: BottomSheetState
   , acHttpState           :: HttpState
   , acViewFunction        :: IORef (UserState -> IO Widget)
+  , acDismissAction       :: Action
+    -- ^ Pre-registered dismiss action for the error widget.
+  , acDismissRef          :: IORef (IO ())
+    -- ^ Mutable slot written by the exception handler with the
+    -- real dismiss logic. The 'acDismissAction' closure reads this.
+  , acActionState         :: ActionState
+    -- ^ Shared callback registry (from 'maActionState').
   }
 
 -- | Create a fresh 'AppContext' from a 'MobileApp', allocating a new
@@ -52,7 +60,8 @@ data AppContext = AppContext
 -- suitable for passing through the C FFI (C sees @void *@).
 newAppContext :: MobileApp -> IO (Ptr AppContext)
 newAppContext mobileApp = do
-  renderState        <- newRenderState
+  let actionState = maActionState mobileApp
+  renderState        <- newRenderState actionState
   permissionState    <- newPermissionState
   secureStorageState <- newSecureStorageState
   bleState           <- newBleState
@@ -63,6 +72,11 @@ newAppContext mobileApp = do
   bottomSheetState   <- newBottomSheetState
   httpState          <- newHttpState
   viewRef            <- newIORef (maView mobileApp)
+  -- Pre-register a dismiss action that reads from an IORef.
+  -- The real dismiss logic is written by handleException at exception time.
+  dismissRef         <- newIORef (pure ())
+  dismissAction      <- runActionM actionState
+                           (createAction (do dismissIO <- readIORef dismissRef; dismissIO))
   let appContext = AppContext
         { acMobileContext      = maContext mobileApp
         , acRenderState        = renderState
@@ -76,6 +90,9 @@ newAppContext mobileApp = do
         , acBottomSheetState   = bottomSheetState
         , acHttpState          = httpState
         , acViewFunction       = viewRef
+        , acDismissAction      = dismissAction
+        , acDismissRef         = dismissRef
+        , acActionState        = actionState
         }
   ptr <- castPtr . castStablePtrToPtr <$> newStablePtr appContext
   -- Write context pointers back so bridges can pass them to C.

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -2,12 +2,17 @@
 -- | Rendering engine that converts a 'Widget' tree into native UI
 -- via the C bridge.
 --
--- Uses a full clear-and-rebuild strategy on every render.
+-- Uses an incremental diff strategy: on each render, the new widget
+-- tree is compared (via derived 'Eq') against the previously rendered
+-- tree.  Only changed subtrees are destroyed and recreated; unchanged
+-- nodes keep their native views.
+--
 -- Callbacks are stored in a shared 'ActionState' registry that is
 -- never cleared during rendering — handles inside widget configs
 -- reference stable entries in the registry.
 module HaskellMobile.Render
   ( RenderState(..)
+  , RenderedNode(..)
   , newRenderState
   , renderWidget
   , dispatchEvent
@@ -15,6 +20,7 @@ module HaskellMobile.Render
   )
 where
 
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Int (Int32)
 import Data.Text (Text, pack)
 import HaskellMobile.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
@@ -22,19 +28,64 @@ import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), 
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
+-- ---------------------------------------------------------------------------
+-- Rendered tree: retained structure for incremental diffing
+-- ---------------------------------------------------------------------------
+
+-- | A snapshot of a rendered widget, retaining the widget value
+-- (for equality comparison) and native node IDs.
+data RenderedNode
+  = RenderedLeaf
+      Widget         -- ^ Widget value for equality comparison.
+      Int32          -- ^ Native node ID from the platform bridge.
+  | RenderedContainer
+      Widget         -- ^ Widget value (Column/Row/ScrollView with children).
+      Int32          -- ^ Native node ID.
+      [RenderedNode] -- ^ Rendered children.
+  | RenderedStyled
+      Widget         -- ^ Widget value (Styled wrapper).
+      WidgetStyle    -- ^ Applied style (for change detection).
+      RenderedNode   -- ^ Child (Styled doesn't own a native node).
+
+-- | Get the native node ID for a rendered node.
+-- 'RenderedStyled' follows through to its child's node ID.
+renderedNodeId :: RenderedNode -> Int32
+renderedNodeId (RenderedLeaf _ nodeId)         = nodeId
+renderedNodeId (RenderedContainer _ nodeId _)  = nodeId
+renderedNodeId (RenderedStyled _ _ child)      = renderedNodeId child
+
+-- | Get the widget value for a rendered node.
+renderedWidget :: RenderedNode -> Widget
+renderedWidget (RenderedLeaf widget _)        = widget
+renderedWidget (RenderedContainer widget _ _) = widget
+renderedWidget (RenderedStyled widget _ _)    = widget
+
+-- ---------------------------------------------------------------------------
+-- Render state
+-- ---------------------------------------------------------------------------
+
 -- | Mutable state for the rendering engine.
--- Holds a reference to the shared 'ActionState' callback registry.
+-- Holds a reference to the shared 'ActionState' callback registry
+-- and the previously rendered tree for incremental diffing.
 data RenderState = RenderState
-  { rsActionState :: ActionState
+  { rsActionState  :: ActionState
     -- ^ Shared callback registry (never cleared during rendering).
+  , rsRenderedTree :: IORef (Maybe RenderedNode)
+    -- ^ The previously rendered tree, or 'Nothing' for the first render.
   }
 
 -- | Create a fresh 'RenderState' wrapping the given 'ActionState'.
 newRenderState :: ActionState -> IO RenderState
-newRenderState actionState =
+newRenderState actionState = do
+  renderedTree <- newIORef Nothing
   pure RenderState
-    { rsActionState = actionState
+    { rsActionState  = actionState
+    , rsRenderedTree = renderedTree
     }
+
+-- ---------------------------------------------------------------------------
+-- Bridge helpers
+-- ---------------------------------------------------------------------------
 
 -- | Map an 'InputType' to the numeric code sent to the platform bridge.
 inputTypeToInt :: InputType -> Int32
@@ -46,67 +97,6 @@ applyFontConfig :: Int32 -> Maybe FontConfig -> IO ()
 applyFontConfig nodeId (Just (FontConfig size)) =
   Bridge.setNumProp nodeId Bridge.PropFontSize size
 applyFontConfig _nodeId Nothing = pure ()
-
--- | Render a single 'Widget' node, returning its native node ID.
-renderNode :: Widget -> IO Int32
-renderNode (Text config) = do
-  nodeId <- Bridge.createNode Bridge.NodeText
-  Bridge.setStrProp nodeId Bridge.PropText (tcLabel config)
-  applyFontConfig nodeId (tcFontConfig config)
-  pure nodeId
-renderNode (Button config) = do
-  nodeId <- Bridge.createNode Bridge.NodeButton
-  Bridge.setStrProp nodeId Bridge.PropText (bcLabel config)
-  Bridge.setHandler nodeId Bridge.EventClick (actionId (bcAction config))
-  applyFontConfig nodeId (bcFontConfig config)
-  pure nodeId
-renderNode (TextInput config) = do
-  nodeId <- Bridge.createNode Bridge.NodeTextInput
-  Bridge.setStrProp nodeId Bridge.PropText (tiValue config)
-  Bridge.setStrProp nodeId Bridge.PropHint (tiHint config)
-  Bridge.setNumProp nodeId Bridge.PropInputType (fromIntegral (inputTypeToInt (tiInputType config)))
-  Bridge.setHandler nodeId Bridge.EventTextChange (onChangeId (tiOnChange config))
-  applyFontConfig nodeId (tiFontConfig config)
-  pure nodeId
-renderNode (Column children) = do
-  nodeId <- Bridge.createNode Bridge.NodeColumn
-  renderChildren nodeId children
-  pure nodeId
-renderNode (Row children) = do
-  nodeId <- Bridge.createNode Bridge.NodeRow
-  renderChildren nodeId children
-  pure nodeId
-renderNode (ScrollView children) = do
-  nodeId <- Bridge.createNode Bridge.NodeScrollView
-  renderChildren nodeId children
-  pure nodeId
-renderNode (Image config) = do
-  nodeId <- Bridge.createNode Bridge.NodeImage
-  case icSource config of
-    ImageResource (ResourceName name) -> Bridge.setStrProp nodeId Bridge.PropImageResource name
-    ImageData bytes                   -> Bridge.setImageData nodeId bytes
-    ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
-  Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
-  pure nodeId
-renderNode (WebView config) = do
-  nodeId <- Bridge.createNode Bridge.NodeWebView
-  Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
-  case wvOnPageLoad config of
-    Just action -> Bridge.setHandler nodeId Bridge.EventClick (actionId action)
-    Nothing     -> pure ()
-  pure nodeId
-renderNode (Styled style child) = do
-  nodeId <- renderNode child
-  applyStyle nodeId style
-  pure nodeId
-
--- | Render a list of children and add them to a parent container.
-renderChildren :: Int32 -> [Widget] -> IO ()
-renderChildren parentId children =
-  mapM_ (\child -> do
-    childId <- renderNode child
-    Bridge.addChild parentId childId
-  ) children
 
 -- | Map a 'ScaleType' to the numeric code sent to the platform bridge.
 scaleTypeToDouble :: ScaleType -> Double
@@ -137,15 +127,209 @@ applyStyle nodeId style = do
     Just color -> Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex color)
     Nothing    -> pure ()
 
--- | Full render: clear the screen, build the widget tree, and set
--- the root node.  Callback registries are /not/ cleared — handles
--- in the widget tree reference stable entries in the shared
--- 'ActionState'.
+-- ---------------------------------------------------------------------------
+-- Creating rendered nodes from scratch
+-- ---------------------------------------------------------------------------
+
+-- | Create a native node from a 'Widget', returning a 'RenderedNode'
+-- snapshot. Used for fresh creation (no old node to diff against).
+createRenderedNode :: Widget -> IO RenderedNode
+createRenderedNode widget@(Text config) = do
+  nodeId <- Bridge.createNode Bridge.NodeText
+  Bridge.setStrProp nodeId Bridge.PropText (tcLabel config)
+  applyFontConfig nodeId (tcFontConfig config)
+  pure (RenderedLeaf widget nodeId)
+createRenderedNode widget@(Button config) = do
+  nodeId <- Bridge.createNode Bridge.NodeButton
+  Bridge.setStrProp nodeId Bridge.PropText (bcLabel config)
+  Bridge.setHandler nodeId Bridge.EventClick (actionId (bcAction config))
+  applyFontConfig nodeId (bcFontConfig config)
+  pure (RenderedLeaf widget nodeId)
+createRenderedNode widget@(TextInput config) = do
+  nodeId <- Bridge.createNode Bridge.NodeTextInput
+  Bridge.setStrProp nodeId Bridge.PropText (tiValue config)
+  Bridge.setStrProp nodeId Bridge.PropHint (tiHint config)
+  Bridge.setNumProp nodeId Bridge.PropInputType (fromIntegral (inputTypeToInt (tiInputType config)))
+  Bridge.setHandler nodeId Bridge.EventTextChange (onChangeId (tiOnChange config))
+  applyFontConfig nodeId (tiFontConfig config)
+  pure (RenderedLeaf widget nodeId)
+createRenderedNode widget@(Column children) = do
+  nodeId <- Bridge.createNode Bridge.NodeColumn
+  childNodes <- mapM (\child -> do
+    childNode <- createRenderedNode child
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure childNode
+    ) children
+  pure (RenderedContainer widget nodeId childNodes)
+createRenderedNode widget@(Row children) = do
+  nodeId <- Bridge.createNode Bridge.NodeRow
+  childNodes <- mapM (\child -> do
+    childNode <- createRenderedNode child
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure childNode
+    ) children
+  pure (RenderedContainer widget nodeId childNodes)
+createRenderedNode widget@(ScrollView children) = do
+  nodeId <- Bridge.createNode Bridge.NodeScrollView
+  childNodes <- mapM (\child -> do
+    childNode <- createRenderedNode child
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure childNode
+    ) children
+  pure (RenderedContainer widget nodeId childNodes)
+createRenderedNode widget@(Image config) = do
+  nodeId <- Bridge.createNode Bridge.NodeImage
+  case icSource config of
+    ImageResource (ResourceName name) -> Bridge.setStrProp nodeId Bridge.PropImageResource name
+    ImageData bytes                   -> Bridge.setImageData nodeId bytes
+    ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
+  Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
+  pure (RenderedLeaf widget nodeId)
+createRenderedNode widget@(WebView config) = do
+  nodeId <- Bridge.createNode Bridge.NodeWebView
+  Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
+  case wvOnPageLoad config of
+    Just action -> Bridge.setHandler nodeId Bridge.EventClick (actionId action)
+    Nothing     -> pure ()
+  pure (RenderedLeaf widget nodeId)
+createRenderedNode widget@(Styled style child) = do
+  childNode <- createRenderedNode child
+  applyStyle (renderedNodeId childNode) style
+  pure (RenderedStyled widget style childNode)
+
+-- ---------------------------------------------------------------------------
+-- Destroying rendered subtrees
+-- ---------------------------------------------------------------------------
+
+-- | Recursively destroy all native nodes in a rendered subtree.
+destroyRenderedSubtree :: RenderedNode -> IO ()
+destroyRenderedSubtree (RenderedLeaf _ nodeId) =
+  Bridge.destroyNode nodeId
+destroyRenderedSubtree (RenderedContainer _ nodeId children) = do
+  mapM_ destroyRenderedSubtree children
+  Bridge.destroyNode nodeId
+destroyRenderedSubtree (RenderedStyled _ _ child) =
+  destroyRenderedSubtree child
+
+-- ---------------------------------------------------------------------------
+-- Incremental diff algorithm
+-- ---------------------------------------------------------------------------
+
+-- | Check whether two widgets use the same constructor (node type).
+-- Does not compare contents — just the outermost constructor tag.
+sameNodeType :: Widget -> Widget -> Bool
+sameNodeType (Text _)        (Text _)        = True
+sameNodeType (Button _)      (Button _)      = True
+sameNodeType (TextInput _)   (TextInput _)   = True
+sameNodeType (Column _)      (Column _)      = True
+sameNodeType (Row _)         (Row _)         = True
+sameNodeType (ScrollView _)  (ScrollView _)  = True
+sameNodeType (Image _)       (Image _)       = True
+sameNodeType (WebView _)     (WebView _)     = True
+sameNodeType (Styled _ _)    (Styled _ _)    = True
+sameNodeType _               _               = False
+
+-- | Diff the old rendered tree against a new 'Widget' and produce
+-- an updated 'RenderedNode', emitting only the necessary bridge calls.
+--
+-- Cases:
+-- 1. No old node -> create from scratch.
+-- 2. @newWidget == renderedWidget oldNode@ -> reuse native node entirely (zero work).
+-- 3. Same container type, children differ -> keep container, diff children.
+-- 4. Same Styled, diff child recursively, re-apply style if changed.
+-- 5. Same leaf type but properties differ -> destroy old, create new.
+-- 6. Different node type -> destroy old subtree, create new.
+diffRenderNode :: Maybe RenderedNode -> Widget -> IO RenderedNode
+-- Case 1: No previous node — create from scratch.
+diffRenderNode Nothing newWidget =
+  createRenderedNode newWidget
+
+-- Case 2: Exact match — reuse native node entirely.
+diffRenderNode (Just oldNode) newWidget
+  | newWidget == renderedWidget oldNode =
+    pure oldNode
+
+-- Case 4: Both are Styled — diff child recursively.
+diffRenderNode (Just (RenderedStyled _ oldStyle oldChild)) (Styled newStyle newChild) = do
+  diffedChild <- diffRenderNode (Just oldChild) newChild
+  if newStyle /= oldStyle
+    then applyStyle (renderedNodeId diffedChild) newStyle
+    else pure ()
+  pure (RenderedStyled (Styled newStyle newChild) newStyle diffedChild)
+
+-- Case 3: Same container type, children may differ — keep container, diff children.
+diffRenderNode (Just oldNode@(RenderedContainer _ containerNodeId oldChildren)) newWidget
+  | sameNodeType (renderedWidget oldNode) newWidget =
+    case newWidget of
+      Column newChildren     -> diffContainer containerNodeId oldChildren newChildren newWidget
+      Row newChildren        -> diffContainer containerNodeId oldChildren newChildren newWidget
+      ScrollView newChildren -> diffContainer containerNodeId oldChildren newChildren newWidget
+      -- Non-container but same type at container level shouldn't happen,
+      -- but fall through to destroy+create for safety.
+      _ -> replaceNode oldNode newWidget
+
+-- Case 5/6: Same leaf type with different properties, or completely different
+-- node types — destroy old and create new.
+diffRenderNode (Just oldNode) newWidget =
+  replaceNode oldNode newWidget
+
+-- | Diff container children: remove all children from parent, diff each
+-- individually, then re-add all in correct order.
+diffContainer :: Int32 -> [RenderedNode] -> [Widget]
+              -> Widget -> IO RenderedNode
+diffContainer containerNodeId oldChildren newChildren newWidget = do
+  -- Remove all children from the container (order may change).
+  mapM_ (\oldChild -> Bridge.removeChild containerNodeId (renderedNodeId oldChild)) oldChildren
+  -- Diff each child position, pairing old children with new where available.
+  let paired = zipPadded oldChildren newChildren
+  diffedChildren <- mapM (\(maybeOld, newChild) ->
+    diffRenderNode maybeOld newChild
+    ) paired
+  -- Destroy any excess old children that weren't paired.
+  let excessOld = drop (length newChildren) oldChildren
+  mapM_ destroyRenderedSubtree excessOld
+  -- Re-add all children in the correct order.
+  mapM_ (\child -> Bridge.addChild containerNodeId (renderedNodeId child)) diffedChildren
+  pure (RenderedContainer newWidget containerNodeId diffedChildren)
+
+-- | Zip two lists, padding the shorter one with 'Nothing'.
+-- Returns @(Maybe old, new)@ pairs covering all new elements.
+zipPadded :: [a] -> [b] -> [(Maybe a, b)]
+zipPadded [] newItems           = map (\new -> (Nothing, new)) newItems
+zipPadded _ []                  = []
+zipPadded (old:olds) (new:news) = (Just old, new) : zipPadded olds news
+
+-- | Destroy an old node and create a fresh replacement.
+replaceNode :: RenderedNode -> Widget -> IO RenderedNode
+replaceNode oldNode newWidget = do
+  destroyRenderedSubtree oldNode
+  createRenderedNode newWidget
+
+-- ---------------------------------------------------------------------------
+-- Top-level render entry point
+-- ---------------------------------------------------------------------------
+
+-- | Incremental render: diffs the new widget tree against the previously
+-- rendered tree and emits only the necessary bridge operations.
+--
+-- On the first call (no previous tree), performs a full creation.
+-- On subsequent calls, reuses unchanged native nodes.
 renderWidget :: RenderState -> Widget -> IO ()
-renderWidget _rs widget = do
-  Bridge.clear
-  rootId <- renderNode widget
-  Bridge.setRoot rootId
+renderWidget rs widget = do
+  oldTree <- readIORef (rsRenderedTree rs)
+  newTree <- diffRenderNode oldTree widget
+  -- Set root if this is the first render or the root node changed.
+  case oldTree of
+    Nothing -> Bridge.setRoot (renderedNodeId newTree)
+    Just old
+      | renderedNodeId old /= renderedNodeId newTree ->
+          Bridge.setRoot (renderedNodeId newTree)
+      | otherwise -> pure ()
+  writeIORef (rsRenderedTree rs) (Just newTree)
+
+-- ---------------------------------------------------------------------------
+-- Event dispatch
+-- ---------------------------------------------------------------------------
 
 -- | Dispatch a native click event to the registered Haskell callback.
 -- Logs an error to stderr if the callbackId is not found.

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -3,8 +3,9 @@
 -- via the C bridge.
 --
 -- Uses a full clear-and-rebuild strategy on every render.
--- Maintains callback registries so native button presses and text
--- changes can be dispatched back to Haskell 'IO' actions.
+-- Callbacks are stored in a shared 'ActionState' registry that is
+-- never cleared during rendering — handles inside widget configs
+-- reference stable entries in the registry.
 module HaskellMobile.Render
   ( RenderState(..)
   , newRenderState
@@ -14,60 +15,26 @@ module HaskellMobile.Render
   )
 where
 
-import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
 import Data.Int (Int32)
-import Data.IntMap.Strict (IntMap)
-import Data.IntMap.Strict qualified as IntMap
 import Data.Text (Text, pack)
+import HaskellMobile.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
 import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
 -- | Mutable state for the rendering engine.
--- Holds the callback registries and next callback ID counter.
+-- Holds a reference to the shared 'ActionState' callback registry.
 data RenderState = RenderState
-  { rsCallbacks     :: IORef (IntMap (IO ()))
-    -- ^ Map from callbackId -> IO action (for clicks)
-  , rsTextCallbacks :: IORef (IntMap (Text -> IO ()))
-    -- ^ Map from callbackId -> text change handler
-  , rsNextId        :: IORef Int32
-    -- ^ Next available callback ID
+  { rsActionState :: ActionState
+    -- ^ Shared callback registry (never cleared during rendering).
   }
 
--- | Create a fresh 'RenderState' with no registered callbacks.
-newRenderState :: IO RenderState
-newRenderState = do
-  callbacks     <- newIORef IntMap.empty
-  textCallbacks <- newIORef IntMap.empty
-  nextId        <- newIORef 0
+-- | Create a fresh 'RenderState' wrapping the given 'ActionState'.
+newRenderState :: ActionState -> IO RenderState
+newRenderState actionState =
   pure RenderState
-    { rsCallbacks     = callbacks
-    , rsTextCallbacks = textCallbacks
-    , rsNextId        = nextId
+    { rsActionState = actionState
     }
-
--- | Register a click callback and return its ID.
-registerCallback :: RenderState -> IO () -> IO Int32
-registerCallback rs action = do
-  cid <- readIORef (rsNextId rs)
-  modifyIORef' (rsCallbacks rs) (IntMap.insert (fromIntegral cid) action)
-  writeIORef (rsNextId rs) (cid + 1)
-  pure cid
-
--- | Register a text-change callback and return its ID.
-registerTextCallback :: RenderState -> (Text -> IO ()) -> IO Int32
-registerTextCallback rs action = do
-  cid <- readIORef (rsNextId rs)
-  modifyIORef' (rsTextCallbacks rs) (IntMap.insert (fromIntegral cid) action)
-  writeIORef (rsNextId rs) (cid + 1)
-  pure cid
-
--- | Reset both callback registries (called before each re-render).
-resetCallbacks :: RenderState -> IO ()
-resetCallbacks rs = do
-  writeIORef (rsCallbacks rs) IntMap.empty
-  writeIORef (rsTextCallbacks rs) IntMap.empty
-  writeIORef (rsNextId rs) 0
 
 -- | Map an 'InputType' to the numeric code sent to the platform bridge.
 inputTypeToInt :: InputType -> Int32
@@ -81,41 +48,39 @@ applyFontConfig nodeId (Just (FontConfig size)) =
 applyFontConfig _nodeId Nothing = pure ()
 
 -- | Render a single 'Widget' node, returning its native node ID.
-renderNode :: RenderState -> Widget -> IO Int32
-renderNode _rs (Text config) = do
+renderNode :: Widget -> IO Int32
+renderNode (Text config) = do
   nodeId <- Bridge.createNode Bridge.NodeText
   Bridge.setStrProp nodeId Bridge.PropText (tcLabel config)
   applyFontConfig nodeId (tcFontConfig config)
   pure nodeId
-renderNode rs (Button config) = do
+renderNode (Button config) = do
   nodeId <- Bridge.createNode Bridge.NodeButton
   Bridge.setStrProp nodeId Bridge.PropText (bcLabel config)
-  callbackId <- registerCallback rs (bcAction config)
-  Bridge.setHandler nodeId Bridge.EventClick callbackId
+  Bridge.setHandler nodeId Bridge.EventClick (actionId (bcAction config))
   applyFontConfig nodeId (bcFontConfig config)
   pure nodeId
-renderNode rs (TextInput config) = do
+renderNode (TextInput config) = do
   nodeId <- Bridge.createNode Bridge.NodeTextInput
   Bridge.setStrProp nodeId Bridge.PropText (tiValue config)
   Bridge.setStrProp nodeId Bridge.PropHint (tiHint config)
   Bridge.setNumProp nodeId Bridge.PropInputType (fromIntegral (inputTypeToInt (tiInputType config)))
-  callbackId <- registerTextCallback rs (tiOnChange config)
-  Bridge.setHandler nodeId Bridge.EventTextChange callbackId
+  Bridge.setHandler nodeId Bridge.EventTextChange (onChangeId (tiOnChange config))
   applyFontConfig nodeId (tiFontConfig config)
   pure nodeId
-renderNode rs (Column children) = do
+renderNode (Column children) = do
   nodeId <- Bridge.createNode Bridge.NodeColumn
-  renderChildren rs nodeId children
+  renderChildren nodeId children
   pure nodeId
-renderNode rs (Row children) = do
+renderNode (Row children) = do
   nodeId <- Bridge.createNode Bridge.NodeRow
-  renderChildren rs nodeId children
+  renderChildren nodeId children
   pure nodeId
-renderNode rs (ScrollView children) = do
+renderNode (ScrollView children) = do
   nodeId <- Bridge.createNode Bridge.NodeScrollView
-  renderChildren rs nodeId children
+  renderChildren nodeId children
   pure nodeId
-renderNode _rs (Image config) = do
+renderNode (Image config) = do
   nodeId <- Bridge.createNode Bridge.NodeImage
   case icSource config of
     ImageResource (ResourceName name) -> Bridge.setStrProp nodeId Bridge.PropImageResource name
@@ -123,25 +88,23 @@ renderNode _rs (Image config) = do
     ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
   Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
   pure nodeId
-renderNode rs (WebView config) = do
+renderNode (WebView config) = do
   nodeId <- Bridge.createNode Bridge.NodeWebView
   Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
   case wvOnPageLoad config of
-    Just action -> do
-      callbackId <- registerCallback rs action
-      Bridge.setHandler nodeId Bridge.EventClick callbackId
-    Nothing -> pure ()
+    Just action -> Bridge.setHandler nodeId Bridge.EventClick (actionId action)
+    Nothing     -> pure ()
   pure nodeId
-renderNode rs (Styled style child) = do
-  nodeId <- renderNode rs child
+renderNode (Styled style child) = do
+  nodeId <- renderNode child
   applyStyle nodeId style
   pure nodeId
 
 -- | Render a list of children and add them to a parent container.
-renderChildren :: RenderState -> Int32 -> [Widget] -> IO ()
-renderChildren rs parentId children =
+renderChildren :: Int32 -> [Widget] -> IO ()
+renderChildren parentId children =
   mapM_ (\child -> do
-    childId <- renderNode rs child
+    childId <- renderNode child
     Bridge.addChild parentId childId
   ) children
 
@@ -174,21 +137,22 @@ applyStyle nodeId style = do
     Just color -> Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex color)
     Nothing    -> pure ()
 
--- | Full render: clear the screen, reset callbacks, build the widget
--- tree, and set the root node.
+-- | Full render: clear the screen, build the widget tree, and set
+-- the root node.  Callback registries are /not/ cleared — handles
+-- in the widget tree reference stable entries in the shared
+-- 'ActionState'.
 renderWidget :: RenderState -> Widget -> IO ()
-renderWidget rs widget = do
+renderWidget _rs widget = do
   Bridge.clear
-  resetCallbacks rs
-  rootId <- renderNode rs widget
+  rootId <- renderNode widget
   Bridge.setRoot rootId
 
 -- | Dispatch a native click event to the registered Haskell callback.
 -- Logs an error to stderr if the callbackId is not found.
 dispatchEvent :: RenderState -> Int32 -> IO ()
 dispatchEvent rs callbackId = do
-  callbacks <- readIORef (rsCallbacks rs)
-  case IntMap.lookup (fromIntegral callbackId) callbacks of
+  maybeAction <- lookupAction (rsActionState rs) callbackId
+  case maybeAction of
     Just action -> action
     Nothing     -> hPutStrLn stderr $
       "dispatchEvent: unknown callback ID " ++ show callbackId
@@ -198,8 +162,8 @@ dispatchEvent rs callbackId = do
 -- Logs an error to stderr if the callbackId is not found.
 dispatchTextEvent :: RenderState -> Int32 -> Text -> IO ()
 dispatchTextEvent rs callbackId newText = do
-  callbacks <- readIORef (rsTextCallbacks rs)
-  case IntMap.lookup (fromIntegral callbackId) callbacks of
+  maybeAction <- lookupTextAction (rsActionState rs) callbackId
+  case maybeAction of
     Just action -> action newText
     Nothing     -> hPutStrLn stderr $
       "dispatchTextEvent: unknown callback ID " ++ show callbackId

--- a/src/HaskellMobile/Types.hs
+++ b/src/HaskellMobile/Types.hs
@@ -8,6 +8,7 @@ module HaskellMobile.Types
   )
 where
 
+import HaskellMobile.Action (ActionState)
 import HaskellMobile.AuthSession (AuthSessionState)
 import HaskellMobile.Ble (BleState)
 import HaskellMobile.Camera (CameraState)
@@ -39,6 +40,8 @@ data UserState = UserState
 -- | Application definition record. Downstream apps create one of these
 -- and pass it to 'startMobileApp'.
 data MobileApp = MobileApp
-  { maContext :: MobileContext
-  , maView    :: UserState -> IO Widget
+  { maContext     :: MobileContext
+  , maView        :: UserState -> IO Widget
+  , maActionState :: ActionState
+    -- ^ Shared callback registry for 'Action' / 'OnChange' handles.
   }

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -4,6 +4,11 @@
 -- Pure data describing the UI tree. Rendering is handled by
 -- "HaskellMobile.Render", which traverses this tree and issues
 -- FFI calls to the platform bridge.
+--
+-- Callback fields carry opaque 'Action' \/ 'OnChange' handles
+-- (from "HaskellMobile.Action") rather than raw @IO ()@ closures.
+-- This lets 'Widget' derive 'Eq', enabling O(1) "skip if unchanged"
+-- in the render diff.
 module HaskellMobile.Widget
   ( FontConfig(..)
   , TextConfig(..)
@@ -30,6 +35,7 @@ import Data.Char (digitToInt, isHexDigit, intToDigit)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)
+import HaskellMobile.Action (Action, OnChange)
 
 -- | Font configuration for text-bearing widgets.
 -- Only 'Text', 'Button', and 'TextInput' can carry a 'FontConfig'.
@@ -50,11 +56,11 @@ data TextConfig = TextConfig
 data ButtonConfig = ButtonConfig
   { bcLabel      :: Text
     -- ^ The button's label text.
-  , bcAction     :: IO ()
-    -- ^ Callback fired when the button is tapped.
+  , bcAction     :: Action
+    -- ^ Handle for the callback fired when the button is tapped.
   , bcFontConfig :: Maybe FontConfig
     -- ^ Optional font override.
-  }
+  } deriving (Show, Eq)
 
 -- | The kind of on-screen keyboard to show for a 'TextInput'.
 data InputType
@@ -71,11 +77,11 @@ data TextInputConfig = TextInputConfig
     -- ^ Placeholder text shown when the field is empty.
   , tiValue     :: Text
     -- ^ Current text value (controlled by Haskell).
-  , tiOnChange  :: Text -> IO ()
-    -- ^ Callback fired when the user edits the field.
+  , tiOnChange  :: OnChange
+    -- ^ Handle for the callback fired when the user edits the field.
   , tiFontConfig :: Maybe FontConfig
     -- ^ Optional font override.
-  }
+  } deriving (Show, Eq)
 
 -- | Horizontal text alignment for text-bearing widgets.
 data TextAlignment
@@ -178,9 +184,9 @@ data ImageConfig = ImageConfig
 data WebViewConfig = WebViewConfig
   { wvUrl        :: Text
     -- ^ URL to load in the web view.
-  , wvOnPageLoad :: Maybe (IO ())
-    -- ^ Optional callback fired when a page finishes loading.
-  }
+  , wvOnPageLoad :: Maybe Action
+    -- ^ Optional handle for a callback fired when a page finishes loading.
+  } deriving (Show, Eq)
 
 -- | A declarative description of a UI element.
 data Widget
@@ -202,3 +208,4 @@ data Widget
     -- ^ An embedded web view loading a URL.
   | Styled WidgetStyle Widget
     -- ^ Apply visual style overrides to a child widget.
+  deriving (Show, Eq)

--- a/test/AuthSessionDemoMain.hs
+++ b/test/AuthSessionDemoMain.hs
@@ -5,18 +5,24 @@
 -- Starts directly in auth-session-demo mode so no runtime switching is needed.
 module Main where
 
-import Data.Text (pack)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
+  , AuthSessionResult(..)
+  , AuthSessionState(..)
   , startMobileApp
+  , derefAppContext
   , platformLog
   , loggingMobileContext
   , AppContext
-  , AuthSessionResult(..)
   , startAuthSession
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
@@ -26,35 +32,38 @@ import HaskellMobile.Widget
 main :: IO (Ptr AppContext)
 main = do
   platformLog "AuthSession demo app registered"
-  startMobileApp authSessionDemoApp
-
--- | AuthSession demo: button starts an auth session, logs the result.
-authSessionDemoApp :: MobileApp
-authSessionDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = authSessionDemoView
-  }
+  actionState <- newActionState
+  authStateRef <- newIORef (Nothing :: Maybe AuthSessionState)
+  onStartLogin <- runActionM actionState $
+    createAction $ do
+      Just authState <- readIORef authStateRef
+      startAuthSession authState
+        "https://example.com/auth?client_id=demo&redirect_uri=haskellmobile://callback"
+        "haskellmobile"
+        (\result -> case result of
+          AuthSessionSuccess redirectUrl ->
+            platformLog ("AuthSession success: " <> redirectUrl)
+          AuthSessionCancelled ->
+            platformLog "AuthSession cancelled"
+          AuthSessionError errorMsg ->
+            platformLog ("AuthSession error: " <> errorMsg)
+        )
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> authSessionDemoView onStartLogin
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef authStateRef (Just (acAuthSessionState appCtx))
+  pure ctxPtr
 
 -- | Builds a Column with a label and a "Start Login" button.
--- The button starts an auth session with a demo URL.
-authSessionDemoView :: UserState -> IO Widget
-authSessionDemoView userState = do
-  pure $ Column
-    [ Text TextConfig { tcLabel = "AuthSession Demo", tcFontConfig = Nothing }
-    , Button ButtonConfig
-        { bcLabel = "Start Login"
-        , bcAction = startAuthSession
-            (userAuthSessionState userState)
-            "https://example.com/auth?client_id=demo&redirect_uri=haskellmobile://callback"
-            "haskellmobile"
-            (\result -> case result of
-              AuthSessionSuccess redirectUrl ->
-                platformLog ("AuthSession success: " <> redirectUrl)
-              AuthSessionCancelled ->
-                platformLog "AuthSession cancelled"
-              AuthSessionError errorMsg ->
-                platformLog ("AuthSession error: " <> errorMsg)
-            )
-        , bcFontConfig = Nothing
-        }
-    ]
+authSessionDemoView :: Action -> IO Widget
+authSessionDemoView onStartLogin = pure $ Column
+  [ Text TextConfig { tcLabel = "AuthSession Demo", tcFontConfig = Nothing }
+  , Button ButtonConfig
+      { bcLabel      = "Start Login"
+      , bcAction     = onStartLogin
+      , bcFontConfig = Nothing
+      }
+  ]

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -9,60 +9,64 @@
 -- button press instead.
 module Main where
 
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
+  , BleState(..)
   , startMobileApp
+  , derefAppContext
   , platformLog
   , checkBleAdapter
   , startBleScan
   , stopBleScan
   , loggingMobileContext
   , AppContext
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "BLE demo app registered"
-  startMobileApp bleDemoApp
-
--- | BLE demo: provides adapter check and scan start/stop buttons.
--- Used by integration tests to verify the BLE FFI bridge end-to-end.
-bleDemoApp :: MobileApp
-bleDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = bleDemoView
-  }
+  actionState <- newActionState
+  bleStateRef <- newIORef (Nothing :: Maybe BleState)
+  (onCheckAdapter, onStartScan, onStopScan) <- runActionM actionState $ do
+    check <- createAction $ do
+      adapterStatus <- checkBleAdapter
+      platformLog ("BLE adapter: " <> pack (show adapterStatus))
+    start <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      startBleScan bleState $ \scanResult ->
+        platformLog ("BLE scan result: " <> pack (show scanResult))
+      platformLog "BLE scan started"
+    stop <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      stopBleScan bleState
+      platformLog "BLE scan stopped"
+    pure (check, start, stop)
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> bleDemoView onCheckAdapter onStartScan onStopScan
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef bleStateRef (Just (acBleState appCtx))
+  pure ctxPtr
 
 -- | Builds a Column with a label, adapter check button, and scan buttons.
--- The view itself is pure — all BLE FFI calls happen in button callbacks
--- to avoid JNI reentrancy issues during rendering.
-bleDemoView :: UserState -> IO Widget
-bleDemoView userState = pure $ Column
+bleDemoView :: Action -> Action -> Action -> IO Widget
+bleDemoView onCheckAdapter onStartScan onStopScan = pure $ Column
   [ Text TextConfig { tcLabel = "BLE Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Check Adapter"
-      , bcAction = do
-          adapterStatus <- checkBleAdapter
-          platformLog ("BLE adapter: " <> pack (show adapterStatus))
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Check Adapter", bcAction = onCheckAdapter, bcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Start Scan"
-      , bcAction = do
-          startBleScan (userBleState userState) $ \scanResult ->
-            platformLog ("BLE scan result: " <> pack (show scanResult))
-          platformLog "BLE scan started"
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Start Scan", bcAction = onStartScan, bcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Stop Scan"
-      , bcAction = do
-          stopBleScan (userBleState userState)
-          platformLog "BLE scan stopped"
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Stop Scan", bcAction = onStopScan, bcFontConfig = Nothing }
   ]

--- a/test/BottomSheetDemoMain.hs
+++ b/test/BottomSheetDemoMain.hs
@@ -5,47 +5,57 @@
 -- Starts directly in bottom-sheet-demo mode so no runtime switching is needed.
 module Main where
 
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
-  , BottomSheetAction(..)
+  , Action
   , BottomSheetConfig(..)
+  , BottomSheetState(..)
   , AppContext
   , startMobileApp
+  , derefAppContext
   , platformLog
   , showBottomSheet
   , loggingMobileContext
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
-  ctxPtr <- startMobileApp bottomSheetDemoApp
+  actionState <- newActionState
+  bssRef <- newIORef (Nothing :: Maybe BottomSheetState)
+  onShowActions <- runActionM actionState $
+    createAction $ do
+      Just bottomSheetState <- readIORef bssRef
+      showBottomSheet bottomSheetState
+        BottomSheetConfig
+          { bscTitle = "Choose Action"
+          , bscItems = ["Edit", "Delete", "Share"]
+          }
+        (\action -> platformLog ("BottomSheet result: " <> pack (show action)))
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> bottomSheetDemoView onShowActions
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef bssRef (Just (acBottomSheetState appCtx))
   platformLog "BottomSheet demo app registered"
   pure ctxPtr
 
--- | Bottom sheet demo: shows action menu on button tap.
--- Used by integration tests to verify the bottom sheet FFI bridge end-to-end.
-bottomSheetDemoApp :: MobileApp
-bottomSheetDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = bottomSheetDemoView
-  }
-
 -- | Builds a Column with a label and a "Show Actions" button.
-bottomSheetDemoView :: UserState -> IO Widget
-bottomSheetDemoView userState = pure $ Column
+bottomSheetDemoView :: Action -> IO Widget
+bottomSheetDemoView onShowActions = pure $ Column
   [ Text TextConfig { tcLabel = "BottomSheet Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Show Actions"
-      , bcAction = showBottomSheet (userBottomSheetState userState)
-          BottomSheetConfig
-            { bscTitle = "Choose Action"
-            , bscItems = ["Edit", "Delete", "Share"]
-            }
-          (\action -> platformLog ("BottomSheet result: " <> pack (show action)))
+      { bcLabel      = "Show Actions"
+      , bcAction     = onShowActions
       , bcFontConfig = Nothing
       }
   ]

--- a/test/CameraDemoMain.hs
+++ b/test/CameraDemoMain.hs
@@ -8,20 +8,27 @@
 module Main where
 
 import qualified Data.ByteString as BS
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
+  , CameraResult(..)
+  , CameraStatus(..)
+  , CameraState(..)
+  , Picture(..)
   , startMobileApp
+  , derefAppContext
   , platformLog
   , loggingMobileContext
   , AppContext
-  , CameraResult(..)
-  , CameraStatus(..)
-  , Picture(..)
   , capturePhoto
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
@@ -31,40 +38,41 @@ import HaskellMobile.Widget
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Camera demo app registered"
-  startMobileApp cameraDemoApp
-
--- | Camera demo: button captures a photo, logs the result.
-cameraDemoApp :: MobileApp
-cameraDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = cameraDemoView
-  }
+  actionState <- newActionState
+  cameraStateRef <- newIORef (Nothing :: Maybe CameraState)
+  onCapturePhoto <- runActionM actionState $
+    createAction $ do
+      Just cameraState <- readIORef cameraStateRef
+      capturePhoto cameraState $ \result -> case crStatus result of
+        CameraSuccess -> case crPicture result of
+          Just picture ->
+            platformLog ("Camera success: " <> pack (show (BS.length (pictureData picture))) <> " bytes")
+          Nothing ->
+            platformLog "Camera success: no picture data"
+        CameraCancelled ->
+          platformLog "Camera cancelled"
+        CameraPermissionDenied ->
+          platformLog "Camera permission denied"
+        CameraUnavailable ->
+          platformLog "Camera unavailable"
+        CameraError ->
+          platformLog "Camera error"
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> cameraDemoView onCapturePhoto
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef cameraStateRef (Just (acCameraState appCtx))
+  pure ctxPtr
 
 -- | Builds a Column with a label and a "Capture Photo" button.
--- The button captures a photo and logs the result.
-cameraDemoView :: UserState -> IO Widget
-cameraDemoView userState = do
-  pure $ Column
-    [ Text TextConfig { tcLabel = "Camera Demo", tcFontConfig = Nothing }
-    , Button ButtonConfig
-        { bcLabel = "Capture Photo"
-        , bcAction = capturePhoto
-            (userCameraState userState)
-            (\result -> case crStatus result of
-              CameraSuccess -> case crPicture result of
-                Just picture ->
-                  platformLog ("Camera success: " <> pack (show (BS.length (pictureData picture))) <> " bytes")
-                Nothing ->
-                  platformLog "Camera success: no picture data"
-              CameraCancelled ->
-                platformLog "Camera cancelled"
-              CameraPermissionDenied ->
-                platformLog "Camera permission denied"
-              CameraUnavailable ->
-                platformLog "Camera unavailable"
-              CameraError ->
-                platformLog "Camera error"
-            )
-        , bcFontConfig = Nothing
-        }
-    ]
+cameraDemoView :: Action -> IO Widget
+cameraDemoView onCapturePhoto = pure $ Column
+  [ Text TextConfig { tcLabel = "Camera Demo", tcFontConfig = Nothing }
+  , Button ButtonConfig
+      { bcLabel      = "Capture Photo"
+      , bcAction     = onCapturePhoto
+      , bcFontConfig = Nothing
+      }
+  ]

--- a/test/ConsumerDepsMain.hs
+++ b/test/ConsumerDepsMain.hs
@@ -9,17 +9,15 @@
 module Main where
 
 import Foreign.Ptr (Ptr)
-import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
 import HaskellMobile.Widget (TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Consumer deps test app registered"
-  startMobileApp consumerDepsApp
-
--- | Minimal app for link-dependency verification.
-consumerDepsApp :: MobileApp
-consumerDepsApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> pure (Text TextConfig { tcLabel = "consumer-deps", tcFontConfig = Nothing })
-  }
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "consumer-deps", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }

--- a/test/CounterDemoMain.hs
+++ b/test/CounterDemoMain.hs
@@ -8,30 +8,27 @@ module Main where
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
-import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState, runActionM, createAction, Action)
 import HaskellMobile.Widget (ButtonConfig(..), Color(..), FontConfig(..), TextAlignment(..), TextConfig(..), Widget(..), WidgetStyle(..))
-import System.IO.Unsafe (unsafePerformIO)
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Counter demo app registered"
-  startMobileApp counterDemoApp
-
--- | Counter demo: logs every lifecycle event and shows a counter with +/- buttons.
-counterDemoApp :: MobileApp
-counterDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> counterView
-  }
-
--- | Global counter state for the demo app.
-counterState :: IORef Int
-counterState = unsafePerformIO (newIORef 0)
-{-# NOINLINE counterState #-}
+  actionState <- newActionState
+  counterState <- newIORef (0 :: Int)
+  (onIncrement, onDecrement) <- runActionM actionState $ do
+    inc <- createAction (modifyIORef' counterState (+ 1))
+    dec <- createAction (modifyIORef' counterState (subtract 1))
+    pure (inc, dec)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> counterView counterState onIncrement onDecrement
+    , maActionState = actionState
+    }
 
 -- | Counter view: displays current count with styled label and +/- buttons.
-counterView :: IO Widget
-counterView = do
+counterView :: IORef Int -> Action -> Action -> IO Widget
+counterView counterState onIncrement onDecrement = do
   n <- readIORef counterState
   pure $ Column
     [ Styled (WidgetStyle (Just 16.0) (Just AlignCenter) (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)))
@@ -40,8 +37,8 @@ counterView = do
           , tcFontConfig = Just (FontConfig 24.0)
           })
     , Row [ Button ButtonConfig
-              { bcLabel = "+", bcAction = modifyIORef' counterState (+ 1), bcFontConfig = Nothing }
+              { bcLabel = "+", bcAction = onIncrement, bcFontConfig = Nothing }
           , Button ButtonConfig
-              { bcLabel = "-", bcAction = modifyIORef' counterState (subtract 1), bcFontConfig = Nothing }
+              { bcLabel = "-", bcAction = onDecrement, bcFontConfig = Nothing }
           ]
     ]

--- a/test/DialogDemoMain.hs
+++ b/test/DialogDemoMain.hs
@@ -5,63 +5,81 @@
 -- Starts directly in dialog-demo mode so no runtime switching is needed.
 module Main where
 
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
   , DialogAction(..)
   , DialogConfig(..)
+  , DialogState(..)
   , AppContext
   , startMobileApp
+  , derefAppContext
   , platformLog
   , showDialog
   , loggingMobileContext
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
-  ctxPtr <- startMobileApp dialogDemoApp
+  actionState <- newActionState
+  -- IORef indirection: actions are created before the AppContext exists,
+  -- but the real DialogState is only available after startMobileApp.
+  dialogStateRef <- newIORef (Nothing :: Maybe DialogState)
+  (onShowAlert, onShowConfirm) <- runActionM actionState $ do
+    alert <- createAction $ do
+      Just dialogState <- readIORef dialogStateRef
+      showDialog dialogState
+        DialogConfig
+          { dcTitle   = "Alert Title"
+          , dcMessage = "This is a test alert"
+          , dcButton1 = "OK"
+          , dcButton2 = Nothing
+          , dcButton3 = Nothing
+          }
+        (\action -> platformLog ("Dialog alert result: " <> pack (show action)))
+    confirm <- createAction $ do
+      Just dialogState <- readIORef dialogStateRef
+      showDialog dialogState
+        DialogConfig
+          { dcTitle   = "Confirm Title"
+          , dcMessage = "Do you confirm?"
+          , dcButton1 = "Yes"
+          , dcButton2 = Just "No"
+          , dcButton3 = Nothing
+          }
+        (\action -> platformLog ("Dialog confirm result: " <> pack (show action)))
+    pure (alert, confirm)
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> dialogDemoView onShowAlert onShowConfirm
+    , maActionState = actionState
+    }
+  -- Populate the IORef now that the AppContext exists.
+  appCtx <- derefAppContext ctxPtr
+  writeIORef dialogStateRef (Just (acDialogState appCtx))
   platformLog "Dialog demo app registered"
   pure ctxPtr
 
--- | Dialog demo: shows alert and confirm dialogs on button taps.
--- Used by integration tests to verify the dialog FFI bridge end-to-end.
-dialogDemoApp :: MobileApp
-dialogDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = dialogDemoView
-  }
-
 -- | Builds a Column with a label, a "Show Alert" button, and a "Show Confirm" button.
-dialogDemoView :: UserState -> IO Widget
-dialogDemoView userState = pure $ Column
+dialogDemoView :: Action -> Action -> IO Widget
+dialogDemoView onShowAlert onShowConfirm = pure $ Column
   [ Text TextConfig { tcLabel = "Dialog Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Show Alert"
-      , bcAction = showDialog (userDialogState userState)
-          DialogConfig
-            { dcTitle   = "Alert Title"
-            , dcMessage = "This is a test alert"
-            , dcButton1 = "OK"
-            , dcButton2 = Nothing
-            , dcButton3 = Nothing
-            }
-          (\action -> platformLog ("Dialog alert result: " <> pack (show action)))
+      { bcLabel      = "Show Alert"
+      , bcAction     = onShowAlert
       , bcFontConfig = Nothing
       }
   , Button ButtonConfig
-      { bcLabel = "Show Confirm"
-      , bcAction = showDialog (userDialogState userState)
-          DialogConfig
-            { dcTitle   = "Confirm Title"
-            , dcMessage = "Do you confirm?"
-            , dcButton1 = "Yes"
-            , dcButton2 = Just "No"
-            , dcButton3 = Nothing
-            }
-          (\action -> platformLog ("Dialog confirm result: " <> pack (show action)))
+      { bcLabel      = "Show Confirm"
+      , bcAction     = onShowConfirm
       , bcFontConfig = Nothing
       }
   ]

--- a/test/HttpDemoMain.hs
+++ b/test/HttpDemoMain.hs
@@ -7,21 +7,28 @@
 module Main where
 
 import qualified Data.ByteString as BS
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
   , startMobileApp
+  , derefAppContext
   , platformLog
   , loggingMobileContext
   , AppContext
+  , HttpState(..)
   , HttpRequest(..)
   , HttpResponse(..)
   , HttpMethod(..)
   , HttpError(..)
   , performRequest
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
@@ -31,39 +38,44 @@ import HaskellMobile.Widget
 main :: IO (Ptr AppContext)
 main = do
   platformLog "HTTP demo app registered"
-  startMobileApp httpDemoApp
-
--- | HTTP demo: a button fires a GET request and logs the result.
-httpDemoApp :: MobileApp
-httpDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = httpDemoView
-  }
+  actionState <- newActionState
+  httpStateRef <- newIORef (Nothing :: Maybe HttpState)
+  onSendRequest <- runActionM actionState $
+    createAction $ do
+      Just httpState <- readIORef httpStateRef
+      performRequest httpState
+        HttpRequest
+          { hrMethod  = HttpGet
+          , hrUrl     = "http://localhost:8765/"
+          , hrHeaders = []
+          , hrBody    = BS.empty
+          }
+        (\result -> case result of
+          Right response ->
+            platformLog ("HTTP response: " <> pack (show (hrStatusCode response)))
+          Left (HttpNetworkError errorMsg) ->
+            platformLog ("HTTP error: " <> errorMsg)
+          Left HttpTimeout ->
+            platformLog "HTTP error: timeout"
+        )
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> httpDemoView onSendRequest
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef httpStateRef (Just (acHttpState appCtx))
+  pure ctxPtr
 
 -- | Builds a Column with a label and a "Send Request" button.
 -- The button fires a GET request to http://localhost:8765/
-httpDemoView :: UserState -> IO Widget
-httpDemoView userState = do
+httpDemoView :: Action -> IO Widget
+httpDemoView onSendRequest = do
   pure $ Column
     [ Text TextConfig { tcLabel = "HTTP Demo", tcFontConfig = Nothing }
     , Button ButtonConfig
         { bcLabel = "Send Request"
-        , bcAction = performRequest
-            (userHttpState userState)
-            HttpRequest
-              { hrMethod  = HttpGet
-              , hrUrl     = "http://localhost:8765/"
-              , hrHeaders = []
-              , hrBody    = BS.empty
-              }
-            (\result -> case result of
-              Right response ->
-                platformLog ("HTTP response: " <> pack (show (hrStatusCode response)))
-              Left (HttpNetworkError errorMsg) ->
-                platformLog ("HTTP error: " <> errorMsg)
-              Left HttpTimeout ->
-                platformLog "HTTP error: timeout"
-            )
+        , bcAction = onSendRequest
         , bcFontConfig = Nothing
         }
     ]

--- a/test/ImageDemoMain.hs
+++ b/test/ImageDemoMain.hs
@@ -7,21 +7,18 @@ module Main where
 
 import Data.ByteString qualified as BS
 import Foreign.Ptr (Ptr)
-import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
 import HaskellMobile.Widget (ImageConfig(..), ImageSource(..), ResourceName(..), ScaleType(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Image demo app registered"
-  startMobileApp imageDemoApp
-
--- | Image demo: displays images from all three source types.
--- Exercises every ImageSource constructor and every ScaleType variant.
-imageDemoApp :: MobileApp
-imageDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> imageDemoView
-  }
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> imageDemoView
+    , maActionState = actionState
+    }
 
 -- | Builds a Column with a label and three Image widgets (resource, data, file).
 imageDemoView :: IO Widget

--- a/test/LocationDemoMain.hs
+++ b/test/LocationDemoMain.hs
@@ -9,56 +9,62 @@
 -- button press instead.
 module Main where
 
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
+  , LocationState(..)
   , startMobileApp
+  , derefAppContext
   , platformLog
   , startLocationUpdates
   , stopLocationUpdates
   , loggingMobileContext
   , AppContext
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Location (LocationData(..))
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Location demo app registered"
-  startMobileApp locationDemoApp
-
--- | Location demo: provides start/stop location update buttons.
--- Used by integration tests to verify the location FFI bridge end-to-end.
-locationDemoApp :: MobileApp
-locationDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = locationDemoView
-  }
+  actionState <- newActionState
+  locStateRef <- newIORef (Nothing :: Maybe LocationState)
+  (onStartLocation, onStopLocation) <- runActionM actionState $ do
+    start <- createAction $ do
+      Just locationState <- readIORef locStateRef
+      startLocationUpdates locationState $ \locationData ->
+        platformLog ("Location: " <> pack (show (ldLatitude locationData))
+                    <> "," <> pack (show (ldLongitude locationData))
+                    <> " alt=" <> pack (show (ldAltitude locationData))
+                    <> " acc=" <> pack (show (ldAccuracy locationData)))
+      platformLog "Location updates started"
+    stop <- createAction $ do
+      Just locationState <- readIORef locStateRef
+      stopLocationUpdates locationState
+      platformLog "Location updates stopped"
+    pure (start, stop)
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> locationDemoView onStartLocation onStopLocation
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef locStateRef (Just (acLocationState appCtx))
+  pure ctxPtr
 
 -- | Builds a Column with a label and start/stop location buttons.
--- The view itself is pure — all location FFI calls happen in button
--- callbacks to avoid JNI reentrancy issues during rendering.
-locationDemoView :: UserState -> IO Widget
-locationDemoView userState = pure $ Column
+locationDemoView :: Action -> Action -> IO Widget
+locationDemoView onStartLocation onStopLocation = pure $ Column
   [ Text TextConfig { tcLabel = "Location Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Start Location"
-      , bcAction = do
-          startLocationUpdates (userLocationState userState) $ \locationData ->
-            platformLog ("Location: " <> pack (show (ldLatitude locationData))
-                        <> "," <> pack (show (ldLongitude locationData))
-                        <> " alt=" <> pack (show (ldAltitude locationData))
-                        <> " acc=" <> pack (show (ldAccuracy locationData)))
-          platformLog "Location updates started"
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Start Location", bcAction = onStartLocation, bcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Stop Location"
-      , bcAction = do
-          stopLocationUpdates (userLocationState userState)
-          platformLog "Location updates stopped"
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Stop Location", bcAction = onStopLocation, bcFontConfig = Nothing }
   ]

--- a/test/NodePoolTestMain.hs
+++ b/test/NodePoolTestMain.hs
@@ -8,7 +8,7 @@ module Main where
 
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
-import HaskellMobile (MobileApp(..), UserState(..), startMobileApp, AppContext)
+import HaskellMobile (MobileApp(..), UserState(..), startMobileApp, AppContext, newActionState)
 import HaskellMobile.Lifecycle (loggingMobileContext)
 import HaskellMobile.Widget (TextConfig(..), Widget(..))
 
@@ -21,7 +21,10 @@ nodePoolTestView _userState = pure $ Column $
     }) [1..299]
 
 main :: IO (Ptr AppContext)
-main = startMobileApp MobileApp
-  { maContext = loggingMobileContext
-  , maView    = nodePoolTestView
-  }
+main = do
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = nodePoolTestView
+    , maActionState = actionState
+    }

--- a/test/PermissionDemoMain.hs
+++ b/test/PermissionDemoMain.hs
@@ -5,43 +5,53 @@
 -- Starts directly in permission-demo mode so no runtime switching is needed.
 module Main where
 
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , Action
   , Permission(..)
-  , PermissionStatus(..)
+  , PermissionState(..)
   , startMobileApp
+  , derefAppContext
   , platformLog
   , requestPermission
   , loggingMobileContext
   , AppContext
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Permission demo app registered"
-  startMobileApp permissionDemoApp
-
--- | Permission demo: requests camera permission on button tap.
--- Used by integration tests to verify the permission FFI bridge end-to-end.
-permissionDemoApp :: MobileApp
-permissionDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = permissionDemoView
-  }
+  actionState <- newActionState
+  permStateRef <- newIORef (Nothing :: Maybe PermissionState)
+  onRequestCamera <- runActionM actionState $
+    createAction $ do
+      Just permState <- readIORef permStateRef
+      requestPermission permState PermissionCamera $ \status ->
+        platformLog ("Permission result: " <> pack (show status))
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> permissionDemoView onRequestCamera
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef permStateRef (Just (acPermissionState appCtx))
+  pure ctxPtr
 
 -- | Builds a Column with a label and a "Request Camera" button.
--- The button's callback ID is 0 (first registered), matching --autotest dispatch.
-permissionDemoView :: UserState -> IO Widget
-permissionDemoView userState = pure $ Column
+permissionDemoView :: Action -> IO Widget
+permissionDemoView onRequestCamera = pure $ Column
   [ Text TextConfig { tcLabel = "Permission Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Request Camera"
-      , bcAction = requestPermission (userPermissionState userState) PermissionCamera $ \status ->
-          platformLog ("Permission result: " <> pack (show status))
+      { bcLabel      = "Request Camera"
+      , bcAction     = onRequestCamera
       , bcFontConfig = Nothing
       }
   ]

--- a/test/ScrollDemoMain.hs
+++ b/test/ScrollDemoMain.hs
@@ -7,30 +7,28 @@ module Main where
 
 import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
-import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState, runActionM, createAction, Action)
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "Scroll demo app registered"
-  startMobileApp scrollDemoApp
-
--- | Scroll demo: 20 text items + a button at the bottom inside a ScrollView.
--- Used by integration tests to verify the ScrollView FFI binding end-to-end.
-scrollDemoApp :: MobileApp
-scrollDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> scrollDemoView
-  }
+  actionState <- newActionState
+  onReachedBottom <- runActionM actionState $
+    createAction (pure ())
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> scrollDemoView onReachedBottom
+    , maActionState = actionState
+    }
 
 -- | Builds a ScrollView containing 20 text items followed by a button.
--- The button's callback ID is 0 (first registered), matching the --autotest dispatch.
-scrollDemoView :: IO Widget
-scrollDemoView = pure $ ScrollView
+scrollDemoView :: Action -> IO Widget
+scrollDemoView onReachedBottom = pure $ ScrollView
   [ Column
     ( map (\itemNumber -> Text TextConfig
         { tcLabel = "Item " <> Text.pack (show (itemNumber :: Int)), tcFontConfig = Nothing }) [1..20]
     ++ [Button ButtonConfig
-        { bcLabel = "Reached Bottom", bcAction = pure (), bcFontConfig = Nothing }]
+        { bcLabel = "Reached Bottom", bcAction = onReachedBottom, bcFontConfig = Nothing }]
     )
   ]

--- a/test/SecureStorageDemoMain.hs
+++ b/test/SecureStorageDemoMain.hs
@@ -5,49 +5,57 @@
 -- Starts directly in secure-storage-demo mode so no runtime switching is needed.
 module Main where
 
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
-  , SecureStorageStatus(..)
+  , Action
+  , SecureStorageState(..)
   , AppContext
   , startMobileApp
+  , derefAppContext
   , platformLog
   , secureStorageWrite
   , secureStorageRead
   , loggingMobileContext
+  , newActionState
+  , runActionM
+  , createAction
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
-  ctxPtr <- startMobileApp secureStorageDemoApp
+  actionState <- newActionState
+  ssRef <- newIORef (Nothing :: Maybe SecureStorageState)
+  (onStoreToken, onReadToken) <- runActionM actionState $ do
+    store <- createAction $ do
+      Just secureStorageState <- readIORef ssRef
+      secureStorageWrite secureStorageState "oauth_token" "test-token-12345" $ \status ->
+        platformLog ("SecureStorage write result: " <> pack (show status))
+    readTok <- createAction $ do
+      Just secureStorageState <- readIORef ssRef
+      secureStorageRead secureStorageState "oauth_token" $ \status maybeValue ->
+        platformLog ("SecureStorage read result: " <> pack (show status) <> " value=" <> pack (show maybeValue))
+    pure (store, readTok)
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> secureStorageDemoView onStoreToken onReadToken
+    , maActionState = actionState
+    }
+  appCtx <- derefAppContext ctxPtr
+  writeIORef ssRef (Just (acSecureStorageState appCtx))
   platformLog "SecureStorage demo app registered"
   pure ctxPtr
 
--- | SecureStorage demo: writes and reads an OAuth token on button taps.
--- Used by integration tests to verify the secure storage FFI bridge end-to-end.
-secureStorageDemoApp :: MobileApp
-secureStorageDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = secureStorageDemoView
-  }
-
 -- | Builds a Column with a label, a "Store Token" button, and a "Read Token" button.
-secureStorageDemoView :: UserState -> IO Widget
-secureStorageDemoView userState = pure $ Column
+secureStorageDemoView :: Action -> Action -> IO Widget
+secureStorageDemoView onStoreToken onReadToken = pure $ Column
   [ Text TextConfig { tcLabel = "SecureStorage Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Store Token"
-      , bcAction = secureStorageWrite (userSecureStorageState userState) "oauth_token" "test-token-12345" $ \status ->
-          platformLog ("SecureStorage write result: " <> pack (show status))
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Store Token", bcAction = onStoreToken, bcFontConfig = Nothing }
   , Button ButtonConfig
-      { bcLabel = "Read Token"
-      , bcAction = secureStorageRead (userSecureStorageState userState) "oauth_token" $ \status maybeValue ->
-          platformLog ("SecureStorage read result: " <> pack (show status) <> " value=" <> pack (show maybeValue))
-      , bcFontConfig = Nothing
-      }
+      { bcLabel = "Read Token", bcAction = onReadToken, bcFontConfig = Nothing }
   ]

--- a/test/THDemoMain.hs
+++ b/test/THDemoMain.hs
@@ -10,17 +10,15 @@ module Main where
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import THConsumer (thGreeting)
-import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
 import HaskellMobile.Widget (TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog ("TH test app: " <> pack thGreeting)
-  startMobileApp thDemoApp
-
--- | Minimal app for Template Haskell cross-compilation verification.
-thDemoApp :: MobileApp
-thDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> pure (Text TextConfig { tcLabel = "th-demo", tcFontConfig = Nothing })
-  }
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "th-demo", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -104,7 +104,8 @@ import HaskellMobile.Camera
   , dispatchVideoFrame
   , dispatchAudioChunk
   )
-import HaskellMobile.Render (RenderState, newRenderState, renderWidget, dispatchEvent, dispatchTextEvent)
+import Data.Int (Int32)
+import HaskellMobile.Render (RenderState(..), RenderedNode(..), newRenderState, renderWidget, dispatchEvent, dispatchTextEvent)
 import HaskellMobile.SecureStorage
   ( SecureStorageStatus(..)
   , SecureStorageState(..)
@@ -175,7 +176,7 @@ main = do
   defaultMain (tests (acPermissionState ffiAppCtx) (acSecureStorageState ffiAppCtx) (acDialogState ffiAppCtx) (acAuthSessionState ffiAppCtx) (acBottomSheetState ffiAppCtx) (acHttpState ffiAppCtx))
 
 tests :: PermissionState -> SecureStorageState -> DialogState -> AuthSessionState -> BottomSheetState -> HttpState -> TestTree
-tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState ffiHttpState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, httpTests ffiHttpState, appContextTests, exceptionHandlerTests, actionTests, widgetEqTests]
+tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState ffiHttpState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, httpTests ffiHttpState, appContextTests, exceptionHandlerTests, actionTests, widgetEqTests, incrementalRenderTests]
 
 qcProps :: TestTree
 qcProps = testGroup "(checked by QuickCheck)"
@@ -2073,4 +2074,221 @@ widgetEqTests = testGroup "WidgetEq"
           widgetC = Column [Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }]
       widgetA @?= widgetB
       assertBool "different children means different Column" (widgetA /= widgetC)
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Incremental rendering tests
+-- ---------------------------------------------------------------------------
+
+-- | Helper to extract the rendered node ID from a RenderedNode.
+nodeIdOf :: RenderedNode -> Int32
+nodeIdOf (RenderedLeaf _ nodeId)         = nodeId
+nodeIdOf (RenderedContainer _ nodeId _)  = nodeId
+nodeIdOf (RenderedStyled _ _ child)      = nodeIdOf child
+
+-- | Helper to extract children from a RenderedContainer.
+childrenOf :: RenderedNode -> [RenderedNode]
+childrenOf (RenderedContainer _ _ children) = children
+childrenOf (RenderedLeaf _ _)              = []
+childrenOf (RenderedStyled _ _ _)          = []
+
+incrementalRenderTests :: TestTree
+incrementalRenderTests = testGroup "Incremental rendering"
+  [ testGroup "Node reuse"
+      [ testCase "identical re-render retains same node ID" $ do
+          ((), rs) <- withActions (pure ())
+          let widget = Text TextConfig { tcLabel = "static", tcFontConfig = Nothing }
+          renderWidget rs widget
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing   -> -1
+          renderWidget rs widget
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing   -> -2
+          nodeId1 @?= nodeId2
+
+      , testCase "single child change only changes that child's node ID" $ do
+          ((), rs) <- withActions (pure ())
+          let widget1 = Column
+                [ Text TextConfig { tcLabel = "stable", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "will change", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          (child0Id1, child1Id1) <- case tree1 of
+            Just node -> case childrenOf node of
+              [c0, c1] -> pure (nodeIdOf c0, nodeIdOf c1)
+              _        -> assertFailure "expected 2 children" >> pure (-1, -1)
+            Nothing -> assertFailure "expected rendered tree" >> pure (-1, -1)
+          let widget2 = Column
+                [ Text TextConfig { tcLabel = "stable", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "changed!", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          (child0Id2, child1Id2) <- case tree2 of
+            Just node -> case childrenOf node of
+              [c0, c1] -> pure (nodeIdOf c0, nodeIdOf c1)
+              _        -> assertFailure "expected 2 children" >> pure (-1, -1)
+            Nothing -> assertFailure "expected rendered tree" >> pure (-1, -1)
+          -- First child (unchanged) keeps same node ID
+          child0Id1 @?= child0Id2
+          -- Second child (changed) gets a different node ID
+          assertBool "changed child should get new node ID"
+            (child1Id1 /= child1Id2)
+
+      , testCase "callback-only handle change triggers new node" $ do
+          ref <- newIORef ("none" :: String)
+          ((handle1, handle2), rs) <- withActions $ do
+            h1 <- createAction (writeIORef ref "action1")
+            h2 <- createAction (writeIORef ref "action2")
+            pure (h1, h2)
+          -- Render button with handle1
+          let widget1 = Button ButtonConfig
+                { bcLabel = "same label", bcAction = handle1, bcFontConfig = Nothing }
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing   -> -1
+          -- Render same label but with handle2 (different Eq)
+          let widget2 = Button ButtonConfig
+                { bcLabel = "same label", bcAction = handle2, bcFontConfig = Nothing }
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing   -> -2
+          -- Different handle means different Widget (Eq), so new node
+          assertBool "different handle should produce new node ID"
+            (nodeId1 /= nodeId2)
+          -- Dispatch handle2 — should fire action2
+          dispatchEvent rs (actionId handle2)
+          result <- readIORef ref
+          result @?= "action2"
+
+      , testCase "same handle reuses node" $ do
+          ref <- newIORef ("none" :: String)
+          (handle, rs) <- withActions $
+            createAction (writeIORef ref "fired")
+          -- Render button with handle
+          let widget1 = Button ButtonConfig
+                { bcLabel = "same label", bcAction = handle, bcFontConfig = Nothing }
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing   -> -1
+          -- Re-render identical widget
+          renderWidget rs widget1
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing   -> -2
+          -- Same handle, same label → reused node
+          nodeId1 @?= nodeId2
+          -- Dispatch still works
+          dispatchEvent rs (actionId handle)
+          result <- readIORef ref
+          result @?= "fired"
+
+      , testCase "adding a child to container" $ do
+          ((), rs) <- withActions (pure ())
+          let widget1 = Column
+                [ Text TextConfig { tcLabel = "first", tcFontConfig = Nothing } ]
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          existingChildId <- case tree1 of
+            Just node -> case childrenOf node of
+              [c0] -> pure (nodeIdOf c0)
+              _    -> assertFailure "expected 1 child" >> pure (-1)
+            Nothing -> assertFailure "expected rendered tree" >> pure (-1)
+          let widget2 = Column
+                [ Text TextConfig { tcLabel = "first", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "second", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          case tree2 of
+            Just node -> case childrenOf node of
+              [c0, c1] -> do
+                -- First child retained
+                nodeIdOf c0 @?= existingChildId
+                -- Second child is new (different ID)
+                assertBool "new child should have different ID"
+                  (nodeIdOf c1 /= existingChildId)
+              _ -> assertFailure "expected 2 children"
+            Nothing -> assertFailure "expected rendered tree"
+
+      , testCase "removing a child from container" $ do
+          ((), rs) <- withActions (pure ())
+          let widget1 = Column
+                [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+                , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+                ]
+          renderWidget rs widget1
+          let widget2 = Column
+                [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing } ]
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let children2 = childrenOf (maybe (error "no tree") id tree2)
+          length children2 @?= 1
+
+      , testCase "root type change triggers new root node" $ do
+          (handle, rs) <- withActions $
+            createAction (pure ())
+          let widget1 = Text TextConfig { tcLabel = "text", tcFontConfig = Nothing }
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing   -> -1
+          let widget2 = Button ButtonConfig
+                { bcLabel = "button", bcAction = handle, bcFontConfig = Nothing }
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing   -> -2
+          assertBool "different widget type should produce new node ID"
+            (nodeId1 /= nodeId2)
+
+      , testCase "styled unchanged keeps same node ID" $ do
+          ((), rs) <- withActions (pure ())
+          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing
+              widget = Styled style (Text TextConfig { tcLabel = "styled", tcFontConfig = Nothing })
+          renderWidget rs widget
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing   -> -1
+          renderWidget rs widget
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing   -> -2
+          nodeId1 @?= nodeId2
+
+      , testCase "styled child change updates child" $ do
+          ((), rs) <- withActions (pure ())
+          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing
+              widget1 = Styled style (Text TextConfig { tcLabel = "before", tcFontConfig = Nothing })
+          renderWidget rs widget1
+          tree1 <- readIORef (rsRenderedTree rs)
+          let nodeId1 = case tree1 of
+                Just node -> nodeIdOf node
+                Nothing   -> -1
+          let widget2 = Styled style (Text TextConfig { tcLabel = "after", tcFontConfig = Nothing })
+          renderWidget rs widget2
+          tree2 <- readIORef (rsRenderedTree rs)
+          let nodeId2 = case tree2 of
+                Just node -> nodeIdOf node
+                Nothing   -> -2
+          -- Child changed, so node should be different
+          assertBool "changed styled child should get new node"
+            (nodeId1 /= nodeId2)
+      ]
   ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -18,6 +18,13 @@ import Foreign.Ptr (Ptr, nullPtr)
 import HaskellMobile
   ( MobileApp(..)
   , UserState(..)
+  , Action(..)
+  , OnChange(..)
+  , ActionM
+  , createAction
+  , createOnChange
+  , newActionState
+  , runActionM
   , startMobileApp
   , haskellGreet
   , haskellRenderUI
@@ -97,7 +104,7 @@ import HaskellMobile.Camera
   , dispatchVideoFrame
   , dispatchAudioChunk
   )
-import HaskellMobile.Render (newRenderState, renderWidget, dispatchEvent, dispatchTextEvent)
+import HaskellMobile.Render (RenderState, newRenderState, renderWidget, dispatchEvent, dispatchTextEvent)
 import HaskellMobile.SecureStorage
   ( SecureStorageStatus(..)
   , SecureStorageState(..)
@@ -148,17 +155,27 @@ import HaskellMobile.Http
   , dispatchHttpResult
   )
 
+-- | Helper: create an ActionState, register actions via ActionM, and
+-- build a RenderState.  Returns the registered value together with the
+-- RenderState so tests can dispatch by handle ID.
+withActions :: ActionM a -> IO (a, RenderState)
+withActions actionM = do
+  actionState <- newActionState
+  result <- runActionM actionState actionM
+  rs <- newRenderState actionState
+  pure (result, rs)
+
 main :: IO ()
 main = do
   -- Create a single FFI context for permission round-trip tests.
   -- The C desktop stub uses a process-wide g_permission_ctx, so only
   -- one context can be active for FFI permission dispatch.
-  ffiCtxPtr <- startMobileApp testApp
+  ffiCtxPtr <- startMobileApp =<< testApp
   ffiAppCtx <- derefAppContext ffiCtxPtr
   defaultMain (tests (acPermissionState ffiAppCtx) (acSecureStorageState ffiAppCtx) (acDialogState ffiAppCtx) (acAuthSessionState ffiAppCtx) (acBottomSheetState ffiAppCtx) (acHttpState ffiAppCtx))
 
 tests :: PermissionState -> SecureStorageState -> DialogState -> AuthSessionState -> BottomSheetState -> HttpState -> TestTree
-tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState ffiHttpState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, httpTests ffiHttpState, appContextTests, exceptionHandlerTests]
+tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiBottomSheetState ffiHttpState = testGroup "Tests" [qcProps, unitTests, lifecycleTests, uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests, registrationTests, localeTests, i18nTests, permissionTests ffiPermState, secureStorageTests ffiSecureStorageState, bleTests, dialogTests ffiDialogState, locationTests, cameraTests, authSessionTests ffiAuthSessionState, bottomSheetTests ffiBottomSheetState, httpTests ffiHttpState, appContextTests, exceptionHandlerTests, actionTests, widgetEqTests]
 
 qcProps :: TestTree
 qcProps = testGroup "(checked by QuickCheck)"
@@ -173,6 +190,16 @@ qcProps = testGroup "(checked by QuickCheck)"
 
 oneTwoThree :: [Int]
 oneTwoThree = [1, 2, 3]
+
+-- | Trivial test app with loggingMobileContext and a simple Text view.
+testApp :: IO MobileApp
+testApp = do
+  actionState <- newActionState
+  pure MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "test", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }
 
 unitTests :: TestTree
 unitTests = testGroup "Unit tests"
@@ -210,20 +237,19 @@ withAppContext app action = do
 -- | Helper: create an 'AppContext' with the given lifecycle callback,
 -- run an action with the typed 'Ptr AppContext', then free the context.
 withContext :: (LifecycleEvent -> IO ()) -> (Ptr AppContext -> IO a) -> IO a
-withContext callback action = withAppContext dummyApp action
-  where
-    dummyApp = MobileApp
-      { maContext = MobileContext { onLifecycle = callback, onError = \_ -> pure () }
-      , maView    = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-      }
+withContext callback action = do
+  dummyApp <- makeDummyApp callback
+  withAppContext dummyApp action
 
--- | Trivial test app with loggingMobileContext and a simple Text view.
--- Replaces the old App.mobileApp that used unsafePerformIO global state.
-testApp :: MobileApp
-testApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> pure (Text TextConfig { tcLabel = "test", tcFontConfig = Nothing })
-  }
+-- | Create a dummy MobileApp with the given lifecycle callback.
+makeDummyApp :: (LifecycleEvent -> IO ()) -> IO MobileApp
+makeDummyApp callback = do
+  actionState <- newActionState
+  pure MobileApp
+    { maContext     = MobileContext { onLifecycle = callback, onError = \_ -> pure () }
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }
 
 allEvents :: [LifecycleEvent]
 allEvents = [Create, Start, Resume, Pause, Stop, Destroy, LowMemory]
@@ -261,79 +287,84 @@ lifecycleTests = testGroup "Lifecycle"
       received @?= allEvents
   , testCase "loggingMobileContext handles all events without throwing" $
       mapM_ (onLifecycle loggingMobileContext) allEvents
-  , testCase "testApp context handles all events without throwing" $
-      mapM_ (onLifecycle (maContext testApp)) allEvents
+  , testCase "testApp context handles all events without throwing" $ do
+      app <- testApp
+      mapM_ (onLifecycle (maContext app)) allEvents
   ]
 
 uiTests :: TestTree
 uiTests = testGroup "UI"
   [ testCase "callback dispatch fires registered action" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       let widget = Button ButtonConfig
-            { bcLabel = "click me", bcAction = modifyIORef' ref (+ 1), bcFontConfig = Nothing }
+            { bcLabel = "click me", bcAction = clickHandle, bcFontConfig = Nothing }
       renderWidget rs widget
-      -- After rendering, callback 0 should be the button's handler
-      dispatchEvent rs 0
+      dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
   , testCase "multiple callbacks each fire independently" $ do
       refA <- newIORef False
       refB <- newIORef False
-      rs <- newRenderState
+      ((handleA, handleB), rs) <- withActions $ do
+        hA <- createAction (modifyIORef' refA (const True))
+        hB <- createAction (modifyIORef' refB (const True))
+        pure (hA, hB)
       let widget = Row
             [ Button ButtonConfig
-                { bcLabel = "A", bcAction = modifyIORef' refA (const True), bcFontConfig = Nothing }
+                { bcLabel = "A", bcAction = handleA, bcFontConfig = Nothing }
             , Button ButtonConfig
-                { bcLabel = "B", bcAction = modifyIORef' refB (const True), bcFontConfig = Nothing }
+                { bcLabel = "B", bcAction = handleB, bcFontConfig = Nothing }
             ]
       renderWidget rs widget
-      -- Only fire callback 0 (button A)
-      dispatchEvent rs 0
+      -- Only fire A
+      dispatchEvent rs (actionId handleA)
       a <- readIORef refA
       b <- readIORef refB
       a @?= True
       b @?= False
-      -- Now fire callback 1 (button B)
-      dispatchEvent rs 1
+      -- Now fire B
+      dispatchEvent rs (actionId handleB)
       b' <- readIORef refB
       b' @?= True
 
-  , testCase "re-render resets callback IDs" $ do
-      refOld <- newIORef False
-      refNew <- newIORef False
-      rs <- newRenderState
-      -- First render with old callback
+  , testCase "re-render preserves callback handles" $ do
+      ref <- newIORef (0 :: Int)
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
+      -- First render
       renderWidget rs (Button ButtonConfig
-        { bcLabel = "old", bcAction = modifyIORef' refOld (const True), bcFontConfig = Nothing })
-      -- Second render replaces it
+        { bcLabel = "old", bcAction = clickHandle, bcFontConfig = Nothing })
+      -- Second render (same handle)
       renderWidget rs (Button ButtonConfig
-        { bcLabel = "new", bcAction = modifyIORef' refNew (const True), bcFontConfig = Nothing })
-      dispatchEvent rs 0
-      old <- readIORef refOld
-      new <- readIORef refNew
-      old @?= False
-      new @?= True
+        { bcLabel = "new", bcAction = clickHandle, bcFontConfig = Nothing })
+      dispatchEvent rs (actionId clickHandle)
+      count <- readIORef ref
+      count @?= 1
 
   , testCase "dispatching unknown callback ID logs error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs (Text TextConfig { tcLabel = "no buttons", tcFontConfig = Nothing })
       -- Should not throw (logs to stderr)
       dispatchEvent rs 42
       dispatchEvent rs 999
 
   , testCase "nested widget tree renders without error" $ do
-      rs <- newRenderState
+      ((handleA, handleB), rs) <- withActions $ do
+        hA <- createAction (pure ())
+        hB <- createAction (pure ())
+        pure (hA, hB)
       let widget = Column
             [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
             , Row
               [ Button ButtonConfig
-                  { bcLabel = "a", bcAction = pure (), bcFontConfig = Nothing }
+                  { bcLabel = "a", bcAction = handleA, bcFontConfig = Nothing }
               , Column
                 [ Text TextConfig { tcLabel = "nested", tcFontConfig = Nothing }
                 , Button ButtonConfig
-                    { bcLabel = "b", bcAction = pure (), bcFontConfig = Nothing }
+                    { bcLabel = "b", bcAction = handleB, bcFontConfig = Nothing }
                 ]
               ]
             , Text TextConfig { tcLabel = "footer", tcFontConfig = Nothing }
@@ -362,7 +393,8 @@ uiTests = testGroup "UI"
             , userBottomSheetState   = dummyBottomSheetState
             , userHttpState          = dummyHttpState
             }
-      widget <- maView testApp dummyUserState
+      app <- testApp
+      widget <- maView app dummyUserState
       -- testApp returns a Text widget
       case widget of
         Text _          -> pure ()
@@ -383,7 +415,7 @@ uiTests = testGroup "UI"
 scrollViewTests :: TestTree
 scrollViewTests = testGroup "ScrollView"
   [ testCase "ScrollView renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs (ScrollView
         [ Text TextConfig { tcLabel = "item 1", tcFontConfig = Nothing }
         , Text TextConfig { tcLabel = "item 2", tcFontConfig = Nothing }
@@ -391,72 +423,73 @@ scrollViewTests = testGroup "ScrollView"
 
   , testCase "button inside ScrollView fires its callback" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ ScrollView
         [ Button ButtonConfig
-            { bcLabel = "press me", bcAction = modifyIORef' ref (+ 1), bcFontConfig = Nothing } ]
-      dispatchEvent rs 0
+            { bcLabel = "press me", bcAction = clickHandle, bcFontConfig = Nothing } ]
+      dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
   , testCase "ScrollView with nested Column renders and dispatches correctly" $ do
       ref <- newIORef False
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (const True))
       renderWidget rs $ ScrollView
         [ Column
           [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
           , Button ButtonConfig
-              { bcLabel = "action", bcAction = modifyIORef' ref (const True), bcFontConfig = Nothing }
+              { bcLabel = "action", bcAction = clickHandle, bcFontConfig = Nothing }
           ]
         ]
-      dispatchEvent rs 0
+      dispatchEvent rs (actionId clickHandle)
       fired <- readIORef ref
       fired @?= True
 
-  , testCase "re-render inside ScrollView resets callbacks" $ do
-      refOld <- newIORef False
-      refNew <- newIORef False
-      rs <- newRenderState
+  , testCase "re-render inside ScrollView preserves callbacks" $ do
+      ref <- newIORef (0 :: Int)
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ ScrollView [Button ButtonConfig
-        { bcLabel = "old", bcAction = modifyIORef' refOld (const True), bcFontConfig = Nothing }]
+        { bcLabel = "old", bcAction = clickHandle, bcFontConfig = Nothing }]
       renderWidget rs $ ScrollView [Button ButtonConfig
-        { bcLabel = "new", bcAction = modifyIORef' refNew (const True), bcFontConfig = Nothing }]
-      dispatchEvent rs 0
-      old <- readIORef refOld
-      new <- readIORef refNew
-      old @?= False
-      new @?= True
+        { bcLabel = "new", bcAction = clickHandle, bcFontConfig = Nothing }]
+      dispatchEvent rs (actionId clickHandle)
+      count <- readIORef ref
+      count @?= 1
   ]
 
 textInputTests :: TestTree
 textInputTests = testGroup "TextInput"
   [ testCase "text callback fires with correct value" $ do
       ref <- newIORef ("" :: String)
-      rs <- newRenderState
+      (changeHandle, rs) <- withActions $
+        createOnChange (\t -> modifyIORef' ref (const (show t)))
       let widget = TextInput TextInputConfig
             { tiInputType = InputText, tiHint = "hint", tiValue = ""
-            , tiOnChange = \t -> modifyIORef' ref (const (show t))
+            , tiOnChange = changeHandle
             , tiFontConfig = Nothing }
       renderWidget rs widget
-      -- Callback 0 is the text change handler
-      dispatchTextEvent rs 0 "hello"
+      dispatchTextEvent rs (onChangeId changeHandle) "hello"
       val <- readIORef ref
       val @?= show ("hello" :: String)
 
   , testCase "text callback receives updated value" $ do
       ref <- newIORef ("" :: String)
-      rs <- newRenderState
+      (changeHandle, rs) <- withActions $
+        createOnChange (\t -> modifyIORef' ref (const (show t)))
       let widget = TextInput TextInputConfig
             { tiInputType = InputText, tiHint = "enter weight", tiValue = "80"
-            , tiOnChange = \t -> modifyIORef' ref (const (show t))
+            , tiOnChange = changeHandle
             , tiFontConfig = Nothing }
       renderWidget rs widget
-      dispatchTextEvent rs 0 "95.5"
+      dispatchTextEvent rs (onChangeId changeHandle) "95.5"
       val <- readIORef ref
       val @?= show ("95.5" :: String)
 
   , testCase "dispatchTextEvent with unknown ID does not crash" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs (Text TextConfig { tcLabel = "no inputs", tcFontConfig = Nothing })
       -- Should not throw
       dispatchTextEvent rs 42 "ignored"
@@ -465,72 +498,75 @@ textInputTests = testGroup "TextInput"
   , testCase "text and click callbacks share ID space without collision" $ do
       clickRef <- newIORef False
       textRef  <- newIORef ("" :: String)
-      rs <- newRenderState
+      ((clickHandle, changeHandle), rs) <- withActions $ do
+        ch <- createAction (modifyIORef' clickRef (const True))
+        th <- createOnChange (\t -> modifyIORef' textRef (const (show t)))
+        pure (ch, th)
       let widget = Column
             [ Button ButtonConfig
-                { bcLabel = "ok", bcAction = modifyIORef' clickRef (const True), bcFontConfig = Nothing }
+                { bcLabel = "ok", bcAction = clickHandle, bcFontConfig = Nothing }
             , TextInput TextInputConfig
                 { tiInputType = InputText, tiHint = "hint", tiValue = ""
-                , tiOnChange = \t -> modifyIORef' textRef (const (show t))
+                , tiOnChange = changeHandle
                 , tiFontConfig = Nothing }
             ]
       renderWidget rs widget
-      -- Button gets callback 0, TextInput gets callback 1
-      dispatchEvent rs 0
-      dispatchTextEvent rs 1 "typed"
+      dispatchEvent rs (actionId clickHandle)
+      dispatchTextEvent rs (onChangeId changeHandle) "typed"
       click <- readIORef clickRef
       text  <- readIORef textRef
       click @?= True
       text  @?= show ("typed" :: String)
 
-  , testCase "re-render resets text callbacks" $ do
-      refOld <- newIORef ("" :: String)
-      refNew <- newIORef ("" :: String)
-      rs <- newRenderState
+  , testCase "re-render preserves text callbacks" $ do
+      ref <- newIORef ("" :: String)
+      (changeHandle, rs) <- withActions $
+        createOnChange (\t -> modifyIORef' ref (const (show t)))
       renderWidget rs $ TextInput TextInputConfig
         { tiInputType = InputText, tiHint = "old", tiValue = ""
-        , tiOnChange = \t -> modifyIORef' refOld (const (show t))
+        , tiOnChange = changeHandle
         , tiFontConfig = Nothing }
       renderWidget rs $ TextInput TextInputConfig
         { tiInputType = InputText, tiHint = "new", tiValue = ""
-        , tiOnChange = \t -> modifyIORef' refNew (const (show t))
+        , tiOnChange = changeHandle
         , tiFontConfig = Nothing }
-      dispatchTextEvent rs 0 "val"
-      old <- readIORef refOld
-      new <- readIORef refNew
-      old @?= ""
-      new @?= show ("val" :: String)
+      dispatchTextEvent rs (onChangeId changeHandle) "val"
+      val <- readIORef ref
+      val @?= show ("val" :: String)
 
   , testCase "InputNumber callback fires correctly" $ do
       ref <- newIORef ("" :: String)
-      rs <- newRenderState
+      (changeHandle, rs) <- withActions $
+        createOnChange (\t -> modifyIORef' ref (const (show t)))
       let widget = TextInput TextInputConfig
             { tiInputType = InputNumber, tiHint = "weight", tiValue = ""
-            , tiOnChange = \t -> modifyIORef' ref (const (show t))
+            , tiOnChange = changeHandle
             , tiFontConfig = Nothing }
       renderWidget rs widget
-      dispatchTextEvent rs 0 "72.5"
+      dispatchTextEvent rs (onChangeId changeHandle) "72.5"
       val <- readIORef ref
       val @?= show ("72.5" :: String)
 
   , testCase "InputText and InputNumber coexist with independent callbacks" $ do
       textRef   <- newIORef ("" :: String)
       numberRef <- newIORef ("" :: String)
-      rs <- newRenderState
+      ((textHandle, numberHandle), rs) <- withActions $ do
+        th <- createOnChange (\t -> modifyIORef' textRef (const (show t)))
+        nh <- createOnChange (\t -> modifyIORef' numberRef (const (show t)))
+        pure (th, nh)
       let widget = Column
             [ TextInput TextInputConfig
                 { tiInputType = InputText, tiHint = "name", tiValue = ""
-                , tiOnChange = \t -> modifyIORef' textRef (const (show t))
+                , tiOnChange = textHandle
                 , tiFontConfig = Nothing }
             , TextInput TextInputConfig
                 { tiInputType = InputNumber, tiHint = "weight", tiValue = ""
-                , tiOnChange = \t -> modifyIORef' numberRef (const (show t))
+                , tiOnChange = numberHandle
                 , tiFontConfig = Nothing }
             ]
       renderWidget rs widget
-      -- TextInput gets callback 0, InputNumber gets callback 1
-      dispatchTextEvent rs 0 "Alice"
-      dispatchTextEvent rs 1 "60.0"
+      dispatchTextEvent rs (onChangeId textHandle) "Alice"
+      dispatchTextEvent rs (onChangeId numberHandle) "60.0"
       tVal <- readIORef textRef
       nVal <- readIORef numberRef
       tVal @?= show ("Alice" :: String)
@@ -541,23 +577,23 @@ textInputTests = testGroup "TextInput"
 imageTests :: TestTree
 imageTests = testGroup "Image"
   [ testCase "Image with resource renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Image ImageConfig
         { icSource = ImageResource (ResourceName "ic_launcher"), icScaleType = ScaleFit }
 
   , testCase "Image with ByteString data renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       let bytes = BS.pack [0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00, 0x00]
       renderWidget rs $ Image ImageConfig
         { icSource = ImageData bytes, icScaleType = ScaleFill }
 
   , testCase "Image with file path renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Image ImageConfig
         { icSource = ImageFile "/nonexistent/test.png", icScaleType = ScaleNone }
 
   , testCase "Image inside Column renders" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Column
         [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
         , Image ImageConfig
@@ -565,23 +601,23 @@ imageTests = testGroup "Image"
         ]
 
   , testCase "Styled Image renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled defaultStyle
         (Image ImageConfig
           { icSource = ImageResource (ResourceName "icon"), icScaleType = ScaleNone })
 
   , testCase "ScaleFit renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Image ImageConfig
         { icSource = ImageResource (ResourceName "fit_test"), icScaleType = ScaleFit }
 
   , testCase "ScaleFill renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Image ImageConfig
         { icSource = ImageResource (ResourceName "fill_test"), icScaleType = ScaleFill }
 
   , testCase "ScaleNone renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Image ImageConfig
         { icSource = ImageResource (ResourceName "none_test"), icScaleType = ScaleNone }
   ]
@@ -590,31 +626,31 @@ imageTests = testGroup "Image"
 webViewTests :: TestTree
 webViewTests = testGroup "WebView"
   [ testCase "WebView renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ WebView WebViewConfig
         { wvUrl = "https://example.com", wvOnPageLoad = Nothing }
 
   , testCase "WebView with callback registers handler and fires" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (pageLoadHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ WebView WebViewConfig
         { wvUrl = "https://example.com"
-        , wvOnPageLoad = Just (modifyIORef' ref (+ 1))
+        , wvOnPageLoad = Just pageLoadHandle
         }
-      -- Callback 0 is registered for the page-load event
-      dispatchEvent rs 0
+      dispatchEvent rs (actionId pageLoadHandle)
       count <- readIORef ref
       count @?= 1
 
   , testCase "WebView without callback does not register handler" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ WebView WebViewConfig
         { wvUrl = "https://example.com", wvOnPageLoad = Nothing }
       -- No callbacks registered, dispatching should log error but not crash
       dispatchEvent rs 0
 
   , testCase "WebView inside Column renders" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Column
         [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
         , WebView WebViewConfig
@@ -622,7 +658,7 @@ webViewTests = testGroup "WebView"
         ]
 
   , testCase "Styled WebView renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled defaultStyle
         (WebView WebViewConfig
           { wvUrl = "https://example.com", wvOnPageLoad = Nothing })
@@ -632,77 +668,78 @@ webViewTests = testGroup "WebView"
 styledTests :: TestTree
 styledTests = testGroup "Styled"
   [ testCase "Styled Text renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled (WidgetStyle (Just 8.0) Nothing Nothing Nothing)
         (Text TextConfig { tcLabel = "styled", tcFontConfig = Just (FontConfig 20.0) })
 
   , testCase "Styled Button fires callback" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ Styled (WidgetStyle Nothing Nothing Nothing Nothing)
         (Button ButtonConfig
-          { bcLabel = "tap", bcAction = modifyIORef' ref (+ 1)
+          { bcLabel = "tap", bcAction = clickHandle
           , bcFontConfig = Just (FontConfig 16.0) })
-      dispatchEvent rs 0
+      dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
   , testCase "Styled Column renders children and dispatches" $ do
       ref <- newIORef False
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (const True))
       renderWidget rs $ Styled defaultStyle
         (Column [ Text TextConfig { tcLabel = "info", tcFontConfig = Nothing }
                 , Button ButtonConfig
-                    { bcLabel = "go", bcAction = modifyIORef' ref (const True), bcFontConfig = Nothing }
+                    { bcLabel = "go", bcAction = clickHandle, bcFontConfig = Nothing }
                 ])
-      dispatchEvent rs 0
+      dispatchEvent rs (actionId clickHandle)
       fired <- readIORef ref
       fired @?= True
 
   , testCase "nested Styled applies both styles" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $
         Styled (WidgetStyle (Just 12.0) Nothing Nothing Nothing)
           (Styled (WidgetStyle Nothing Nothing Nothing Nothing)
             (Text TextConfig { tcLabel = "double styled", tcFontConfig = Just (FontConfig 18.0) }))
 
   , testCase "defaultStyle is a no-op" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled defaultStyle
         (Text TextConfig { tcLabel = "plain", tcFontConfig = Nothing })
 
-  , testCase "re-render resets callbacks through Styled" $ do
-      refOld <- newIORef False
-      refNew <- newIORef False
-      rs <- newRenderState
+  , testCase "re-render preserves callbacks through Styled" $ do
+      ref <- newIORef (0 :: Int)
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ Styled defaultStyle
         (Button ButtonConfig
-          { bcLabel = "old", bcAction = modifyIORef' refOld (const True), bcFontConfig = Nothing })
+          { bcLabel = "old", bcAction = clickHandle, bcFontConfig = Nothing })
       renderWidget rs $ Styled defaultStyle
         (Button ButtonConfig
-          { bcLabel = "new", bcAction = modifyIORef' refNew (const True), bcFontConfig = Nothing })
-      dispatchEvent rs 0
-      old <- readIORef refOld
-      new <- readIORef refNew
-      old @?= False
-      new @?= True
+          { bcLabel = "new", bcAction = clickHandle, bcFontConfig = Nothing })
+      dispatchEvent rs (actionId clickHandle)
+      count <- readIORef ref
+      count @?= 1
   ]
 
 -- | Tests for TextAlignment support in Styled widgets.
 textAlignTests :: TestTree
 textAlignTests = testGroup "TextAlignment"
   [ testCase "Styled with AlignCenter renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignCenter) Nothing Nothing)
         (Text TextConfig { tcLabel = "centered", tcFontConfig = Nothing })
 
   , testCase "Styled with AlignCenter on Button fires callback" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignCenter) Nothing Nothing)
         (Button ButtonConfig
-          { bcLabel = "tap", bcAction = modifyIORef' ref (+ 1), bcFontConfig = Nothing })
-      dispatchEvent rs 0
+          { bcLabel = "tap", bcAction = clickHandle, bcFontConfig = Nothing })
+      dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
@@ -710,7 +747,7 @@ textAlignTests = testGroup "TextAlignment"
       wsTextAlign defaultStyle @?= Nothing
 
   , testCase "Styled with AlignEnd renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignEnd) Nothing Nothing)
         (Text TextConfig { tcLabel = "end aligned", tcFontConfig = Nothing })
   ]
@@ -720,26 +757,28 @@ colorTests :: TestTree
 colorTests = testGroup "Colors"
   [ testCase "Styled with textColor renders and callback fires" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) Nothing)
         (Button ButtonConfig
-          { bcLabel = "red", bcAction = modifyIORef' ref (+ 1), bcFontConfig = Nothing })
-      dispatchEvent rs 0
+          { bcLabel = "red", bcAction = clickHandle, bcFontConfig = Nothing })
+      dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
   , testCase "Styled with backgroundColor renders without error" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $ Styled (WidgetStyle Nothing Nothing Nothing (Just (Color 0 255 0 255)))
         (Text TextConfig { tcLabel = "green bg", tcFontConfig = Nothing })
 
   , testCase "both textColor and backgroundColor together" $ do
       ref <- newIORef (0 :: Int)
-      rs <- newRenderState
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (+ 1))
       renderWidget rs $ Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)))
         (Button ButtonConfig
-          { bcLabel = "colored", bcAction = modifyIORef' ref (+ 1), bcFontConfig = Nothing })
-      dispatchEvent rs 0
+          { bcLabel = "colored", bcAction = clickHandle, bcFontConfig = Nothing })
+      dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
@@ -748,7 +787,7 @@ colorTests = testGroup "Colors"
       wsBackgroundColor defaultStyle @?= Nothing
 
   , testCase "nested Styled with different colors renders" $ do
-      rs <- newRenderState
+      ((), rs) <- withActions (pure ())
       renderWidget rs $
         Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) Nothing)
           (Styled (WidgetStyle Nothing Nothing Nothing (Just (Color 0 0 255 255)))
@@ -773,21 +812,34 @@ colorTests = testGroup "Colors"
       colorFromText (colorToHex color) @?= Just color
   ]
 
+-- | Helper: make a simple MobileApp with default context.
+makeSimpleApp :: (UserState -> IO Widget) -> IO MobileApp
+makeSimpleApp viewFn = do
+  actionState <- newActionState
+  pure MobileApp
+    { maContext     = defaultMobileContext
+    , maView        = viewFn
+    , maActionState = actionState
+    }
+
 -- | Tests for the AppContext-based registration.
 -- Each test creates its own context, so no shared global state.
 registrationTests :: TestTree
 registrationTests = testGroup "Registration"
   [ testCase "startMobileApp returns working context" $ do
-      ctxPtr <- startMobileApp testApp
+      app <- testApp
+      ctxPtr <- startMobileApp app
       appCtx <- derefAppContext ctxPtr
       -- Verify the context has a working lifecycle callback
       mapM_ (onLifecycle (acMobileContext appCtx)) [Create, Destroy]
       freeAppContext ctxPtr
 
   , testCase "view function produces a widget through AppContext" $ do
+      actionState <- newActionState
       let customApp = MobileApp
-            { maContext = MobileContext { onLifecycle = \_ -> pure (), onError = \_ -> pure () }
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "custom", tcFontConfig = Nothing })
+            { maContext     = MobileContext { onLifecycle = \_ -> pure (), onError = \_ -> pure () }
+            , maView        = \_userState -> pure (Text TextConfig { tcLabel = "custom", tcFontConfig = Nothing })
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext customApp
       appCtx <- derefAppContext ctxPtr
@@ -819,13 +871,17 @@ registrationTests = testGroup "Registration"
       freeAppContext ctxPtr
 
   , testCase "two contexts are independent" $ do
+      actionStateA <- newActionState
+      actionStateB <- newActionState
       let appA = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "A", tcFontConfig = Nothing })
+            { maContext     = defaultMobileContext
+            , maView        = \_userState -> pure (Text TextConfig { tcLabel = "A", tcFontConfig = Nothing })
+            , maActionState = actionStateA
             }
           appB = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "B", tcFontConfig = Nothing })
+            { maContext     = defaultMobileContext
+            , maView        = \_userState -> pure (Text TextConfig { tcLabel = "B", tcFontConfig = Nothing })
+            , maActionState = actionStateB
             }
       ctxPtrA <- newAppContext appA
       ctxPtrB <- newAppContext appB
@@ -939,8 +995,6 @@ i18nTests = testGroup "I18n"
 permissionTests :: PermissionState -> TestTree
 permissionTests ffiPermState = sequentialTestGroup "Permission" AllFinish
   [ testCase "requestPermission fires callback with PermissionGranted on desktop" $ do
-      -- Uses the shared FFI context because the C desktop stub dispatches
-      -- via haskellOnPermissionResult(g_permission_ctx, ...).
       ref <- newIORef (Nothing :: Maybe PermissionStatus)
       requestPermission ffiPermState PermissionCamera
         (\status -> modifyIORef' ref (const (Just status)))
@@ -988,7 +1042,6 @@ permissionTests ffiPermState = sequentialTestGroup "Permission" AllFinish
       count @?= 0
 
   , testCase "multiple simultaneous pending requests dispatch independently" $ do
-      -- Uses the shared FFI context for the desktop stub round-trip
       refA <- newIORef (Nothing :: Maybe PermissionStatus)
       refB <- newIORef (Nothing :: Maybe PermissionStatus)
       requestPermission ffiPermState PermissionCamera
@@ -1057,15 +1110,12 @@ secureStorageTests ffiSecureStorageState = sequentialTestGroup "SecureStorage" A
   , testCase "delete then read returns StorageNotFound" $ do
       statusRef <- newIORef (Nothing :: Maybe SecureStorageStatus)
       valueRef  <- newIORef (Nothing :: Maybe Text.Text)
-      -- Write a key first
       secureStorageWrite ffiSecureStorageState "delete_me" "some_value"
         (\_ -> pure ())
-      -- Delete it
       secureStorageDelete ffiSecureStorageState "delete_me"
         (\status -> modifyIORef' statusRef (const (Just status)))
       deleteStatus <- readIORef statusRef
       deleteStatus @?= Just StorageSuccess
-      -- Read it back — should be gone
       secureStorageRead ffiSecureStorageState "delete_me"
         (\status maybeVal -> do
           modifyIORef' statusRef (const (Just status))
@@ -1125,8 +1175,6 @@ secureStorageTests ffiSecureStorageState = sequentialTestGroup "SecureStorage" A
   ]
 
 -- | BLE scanning tests.
--- The desktop stub reports adapter as ON and start/stop scan are no-ops,
--- so we can exercise the Haskell logic without native code.
 bleTests :: TestTree
 bleTests = testGroup "BLE"
   [ testCase "bleAdapterStatusFromInt roundtrips all constructors" $ do
@@ -1247,12 +1295,7 @@ bleTests = testGroup "BLE"
           bsrDeviceAddress scanResult @?= "FF:EE:DD:CC:BB:AA"
   ]
 
--- | Dialog tests.  The @ffiDialogState@ parameter is the 'DialogState'
--- from a context created once in 'main' via 'startMobileApp'.  This
--- ensures the C desktop stub's context pointer is valid for FFI round-trip
--- tests.
--- Uses 'sequentialTestGroup' because these tests share mutable state
--- (the Haskell callback registry and the C global context pointer).
+-- | Dialog tests.
 dialogTests :: DialogState -> TestTree
 dialogTests ffiDialogState = sequentialTestGroup "Dialog" AllFinish
   [ testCase "showDialog registers callback and desktop stub fires button1" $ do
@@ -1374,7 +1417,6 @@ authSessionTests ffiAuthSessionState = sequentialTestGroup "AuthSession" AllFini
       dispatchAuthSessionResult authState 0 0 (Just "myapp://cb") Nothing
       count1 <- readIORef ref
       count1 @?= 1
-      -- Second dispatch for same ID should be a no-op (callback removed)
       dispatchAuthSessionResult authState 0 0 (Just "myapp://cb") Nothing
       count2 <- readIORef ref
       count2 @?= 1
@@ -1391,7 +1433,6 @@ authSessionTests ffiAuthSessionState = sequentialTestGroup "AuthSession" AllFini
 
   , testCase "unknown requestId does not crash" $ do
       authState <- newAuthSessionState
-      -- Should not throw (logs to stderr)
       dispatchAuthSessionResult authState 999 0 (Just "url") Nothing
 
   , testCase "unknown status code does not fire callback" $ do
@@ -1407,10 +1448,7 @@ authSessionTests ffiAuthSessionState = sequentialTestGroup "AuthSession" AllFini
 locationTests :: TestTree
 locationTests = testGroup "Location"
   [ testCase "desktop stub dispatches fixed location on startLocationUpdates" $ do
-      let app = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-            }
+      app <- makeSimpleApp (\_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing }))
       ctxPtr <- newAppContext app
       appCtx <- derefAppContext ctxPtr
       let locationState = acLocationState appCtx
@@ -1420,7 +1458,6 @@ locationTests = testGroup "Location"
       case result of
         Nothing -> assertFailure "callback should have been fired by desktop stub"
         Just loc -> do
-          -- Desktop stub dispatches lat=52.37, lon=4.90, alt=0.0, acc=10.0
           ldLatitude loc @?= 52.37
           ldLongitude loc @?= 4.90
           ldAltitude loc @?= 0.0
@@ -1443,14 +1480,10 @@ locationTests = testGroup "Location"
 
   , testCase "dispatchLocationUpdate with no active listener is no-op" $ do
       locationState <- newLocationState
-      -- Should not throw or crash
       dispatchLocationUpdate locationState 0.0 0.0 0.0 0.0
 
   , testCase "stopLocationUpdates clears callback" $ do
-      let app = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-            }
+      app <- makeSimpleApp (\_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing }))
       ctxPtr <- newAppContext app
       appCtx <- derefAppContext ctxPtr
       let locationState = acLocationState appCtx
@@ -1463,23 +1496,17 @@ locationTests = testGroup "Location"
       freeAppContext ctxPtr
 
   , testCase "startLocationUpdates replaces existing callback" $ do
-      let app = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-            }
+      app <- makeSimpleApp (\_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing }))
       ctxPtr <- newAppContext app
       appCtx <- derefAppContext ctxPtr
       let locationState = acLocationState appCtx
       refOld <- newIORef (0 :: Int)
       refNew <- newIORef (0 :: Int)
       writeIORef (lsUpdateCallback locationState) (Just (\_ -> modifyIORef' refOld (+ 1)))
-      -- Replace with new callback (startLocationUpdates calls stop first on the C side,
-      -- then installs new callback, then calls start which dispatches stub location)
       startLocationUpdates locationState (\_ -> modifyIORef' refNew (+ 1))
       oldCount <- readIORef refOld
       newCount <- readIORef refNew
       oldCount @?= 0
-      -- Desktop stub dispatches one location on start, so newCount should be 1
       newCount @?= 1
       freeAppContext ctxPtr
   ]
@@ -1502,7 +1529,7 @@ bottomSheetTests ffiBottomSheetState = sequentialTestGroup "BottomSheet" AllFini
       bottomSheetState <- newBottomSheetState
       modifyIORef' (bssCallbacks bottomSheetState) (\_ ->
         IntMap.singleton 0 (\action -> writeIORef ref (Just action)))
-      dispatchBottomSheetResult bottomSheetState 0 2  -- item index 2
+      dispatchBottomSheetResult bottomSheetState 0 2
       result <- readIORef ref
       result @?= Just (BottomSheetItemSelected 2)
 
@@ -1511,7 +1538,7 @@ bottomSheetTests ffiBottomSheetState = sequentialTestGroup "BottomSheet" AllFini
       bottomSheetState <- newBottomSheetState
       modifyIORef' (bssCallbacks bottomSheetState) (\_ ->
         IntMap.singleton 0 (\action -> writeIORef ref (Just action)))
-      dispatchBottomSheetResult bottomSheetState 0 (-1)  -- dismissed
+      dispatchBottomSheetResult bottomSheetState 0 (-1)
       result <- readIORef ref
       result @?= Just BottomSheetDismissed
 
@@ -1523,7 +1550,6 @@ bottomSheetTests ffiBottomSheetState = sequentialTestGroup "BottomSheet" AllFini
       dispatchBottomSheetResult bottomSheetState 0 0
       count1 <- readIORef ref
       count1 @?= 1
-      -- Second dispatch for same ID should be a no-op (callback removed)
       dispatchBottomSheetResult bottomSheetState 0 0
       count2 <- readIORef ref
       count2 @?= 1
@@ -1540,7 +1566,6 @@ bottomSheetTests ffiBottomSheetState = sequentialTestGroup "BottomSheet" AllFini
 
   , testCase "unknown requestId does not crash" $ do
       bottomSheetState <- newBottomSheetState
-      -- Should not throw (logs to stderr)
       dispatchBottomSheetResult bottomSheetState 999 0
   ]
 
@@ -1548,10 +1573,7 @@ bottomSheetTests ffiBottomSheetState = sequentialTestGroup "BottomSheet" AllFini
 cameraTests :: TestTree
 cameraTests = testGroup "Camera"
   [ testCase "desktop stub dispatches success with picture on capturePhoto" $ do
-      let app = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-            }
+      app <- makeSimpleApp (\_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing }))
       ctxPtr <- newAppContext app
       appCtx <- derefAppContext ctxPtr
       let cameraState = acCameraState appCtx
@@ -1572,10 +1594,7 @@ cameraTests = testGroup "Camera"
       freeAppContext ctxPtr
 
   , testCase "desktop stub dispatches success on startVideoCapture with frame/audio callbacks" $ do
-      let app = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-            }
+      app <- makeSimpleApp (\_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing }))
       ctxPtr <- newAppContext app
       appCtx <- derefAppContext ctxPtr
       let cameraState = acCameraState appCtx
@@ -1586,7 +1605,6 @@ cameraTests = testGroup "Camera"
         (\_ -> modifyIORef' frameCount (+ 1))
         (\_ -> modifyIORef' audioCount (+ 1))
         (\result -> writeIORef completionRef (Just result))
-      -- Desktop stub fires 2 frames, 1 audio chunk, then completion
       frames <- readIORef frameCount
       frames @?= 2
       audio <- readIORef audioCount
@@ -1649,7 +1667,6 @@ cameraTests = testGroup "Camera"
 
   , testCase "dispatchCameraResult with no callback is no-op" $ do
       cameraState <- newCameraState
-      -- Should not throw or crash
       dispatchCameraResult cameraState 99 0 Nothing 0 0
 
   , testCase "dispatchVideoFrame fires frame callback" $ do
@@ -1688,7 +1705,6 @@ cameraTests = testGroup "Camera"
       modifyIORef' (csAudioCallbacks cameraState)
         (IntMap.insert 0 (\_ -> pure ()))
       dispatchCameraResult cameraState 0 0 Nothing 0 0
-      -- After dispatch, all callbacks for requestId 0 should be gone
       callbacks <- readIORef (csCallbacks cameraState)
       IntMap.member 0 callbacks @?= False
       frameCallbacks <- readIORef (csFrameCallbacks cameraState)
@@ -1697,16 +1713,12 @@ cameraTests = testGroup "Camera"
       IntMap.member 0 audioCallbacks @?= False
 
   , testCase "capturePhoto assigns incremental request IDs" $ do
-      let app = MobileApp
-            { maContext = defaultMobileContext
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
-            }
+      app <- makeSimpleApp (\_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing }))
       ctxPtr <- newAppContext app
       appCtx <- derefAppContext ctxPtr
       let cameraState = acCameraState appCtx
       idsBefore <- readIORef (csNextId cameraState)
       idsBefore @?= 0
-      -- Register two captures — each should increment the ID
       capturePhoto cameraState (\_ -> pure ())
       idsAfter1 <- readIORef (csNextId cameraState)
       idsAfter1 @?= 1
@@ -1730,7 +1742,6 @@ cameraTests = testGroup "Camera"
 
   , testCase "stopCameraSession is safe when no session active" $ do
       cameraState <- newCameraState
-      -- Should not throw or crash
       stopCameraSession cameraState
   ]
 
@@ -1822,9 +1833,11 @@ appContextTests :: TestTree
 appContextTests = testGroup "AppContext"
   [ testCase "newAppContext produces working lifecycle context" $ do
       ref <- newIORef ([] :: [LifecycleEvent])
+      actionState <- newActionState
       let app = MobileApp
-            { maContext = MobileContext { onLifecycle = \event -> modifyIORef' ref (++ [event]), onError = \_ -> pure () }
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
+            { maContext     = MobileContext { onLifecycle = \event -> modifyIORef' ref (++ [event]), onError = \_ -> pure () }
+            , maView        = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext app
       haskellOnLifecycle ctxPtr 0  -- Create
@@ -1870,9 +1883,11 @@ viewIsErrorWidget ctxPtr = do
 exceptionHandlerTests :: TestTree
 exceptionHandlerTests = testGroup "ExceptionHandler"
   [ testCase "exception in view is caught and view replaced with error widget" $ do
+      actionState <- newActionState
       let crashingApp = MobileApp
-            { maContext = defaultMobileContext
-            , maView    = \_userState -> throwIO (userError "test-boom")
+            { maContext     = defaultMobileContext
+            , maView        = \_userState -> throwIO (userError "test-boom")
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext crashingApp
       haskellRenderUI ctxPtr
@@ -1881,19 +1896,23 @@ exceptionHandlerTests = testGroup "ExceptionHandler"
       freeAppContext ctxPtr
 
   , testCase "exception in button callback is caught" $ do
+      actionState <- newActionState
+      crashHandle <- runActionM actionState $
+        createAction (throwIO (userError "button-boom"))
       let crashingApp = MobileApp
-            { maContext = defaultMobileContext
-            , maView    = \_userState -> pure $ Button ButtonConfig
+            { maContext     = defaultMobileContext
+            , maView        = \_userState -> pure $ Button ButtonConfig
                 { bcLabel  = "crash"
-                , bcAction = throwIO (userError "button-boom")
+                , bcAction = crashHandle
                 , bcFontConfig = Nothing
                 }
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext crashingApp
       -- First render to register the button callback
       haskellRenderUI ctxPtr
       -- Dispatch the button, which throws — handler overwrites view
-      haskellOnUIEvent ctxPtr 0
+      haskellOnUIEvent ctxPtr (fromIntegral (actionId crashHandle))
       isError <- viewIsErrorWidget ctxPtr
       assertBool "view should be error widget after button callback exception" isError
       freeAppContext ctxPtr
@@ -1901,6 +1920,7 @@ exceptionHandlerTests = testGroup "ExceptionHandler"
   , testCase "dismiss restores original view after transient error" $ do
       -- Transient error: throws once, then succeeds
       shouldThrow <- newIORef True
+      actionState <- newActionState
       let transientView _userState = do
             throwing <- readIORef shouldThrow
             if throwing
@@ -1909,30 +1929,34 @@ exceptionHandlerTests = testGroup "ExceptionHandler"
                 throwIO (userError "transient-error")
               else pure $ Text TextConfig { tcLabel = "recovered", tcFontConfig = Nothing }
           transientApp = MobileApp
-            { maContext = defaultMobileContext
-            , maView    = transientView
+            { maContext     = defaultMobileContext
+            , maView        = transientView
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext transientApp
       -- First render throws, error widget shown, flag cleared
       haskellRenderUI ctxPtr
       isError <- viewIsErrorWidget ctxPtr
       assertBool "should show error widget" isError
-      -- Dispatch callback 0 (the dismiss button in the error widget).
-      -- This restores the original transientView, which now succeeds.
-      haskellOnUIEvent ctxPtr 0
+      -- Dispatch the dismiss action (pre-registered during newAppContext).
+      appCtx <- derefAppContext ctxPtr
+      let dismissId = actionId (acDismissAction appCtx)
+      haskellOnUIEvent ctxPtr (fromIntegral dismissId)
       isStillError <- viewIsErrorWidget ctxPtr
       assertBool "should no longer show error widget after dismiss" (not isStillError)
       freeAppContext ctxPtr
 
   , testCase "onError callback fires on exception" $ do
       ref <- newIORef (Nothing :: Maybe String)
+      actionState <- newActionState
       let ctx = MobileContext
             { onLifecycle = \_ -> pure ()
             , onError     = \exc -> writeIORef ref (Just (show exc))
             }
           crashingApp = MobileApp
-            { maContext = ctx
-            , maView    = \_userState -> throwIO (userError "onError-test")
+            { maContext     = ctx
+            , maView        = \_userState -> throwIO (userError "onError-test")
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext crashingApp
       haskellRenderUI ctxPtr
@@ -1943,13 +1967,15 @@ exceptionHandlerTests = testGroup "ExceptionHandler"
       freeAppContext ctxPtr
 
   , testCase "exception in onError does not crash" $ do
+      actionState <- newActionState
       let ctx = MobileContext
             { onLifecycle = \_ -> pure ()
             , onError     = \_ -> throwIO (userError "secondary-boom")
             }
           crashingApp = MobileApp
-            { maContext = ctx
-            , maView    = \_userState -> throwIO (userError "primary-boom")
+            { maContext     = ctx
+            , maView        = \_userState -> throwIO (userError "primary-boom")
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext crashingApp
       -- Should not crash despite both view and onError throwing
@@ -1960,18 +1986,91 @@ exceptionHandlerTests = testGroup "ExceptionHandler"
       freeAppContext ctxPtr
 
   , testCase "exception in lifecycle handler is caught" $ do
+      actionState <- newActionState
       let crashingApp = MobileApp
-            { maContext = MobileContext
+            { maContext     = MobileContext
                 { onLifecycle = \_ -> throwIO (userError "lifecycle-boom")
                 , onError     = \_ -> pure ()
                 }
-            , maView = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
+            , maView        = \_userState -> pure (Text TextConfig { tcLabel = "dummy", tcFontConfig = Nothing })
+            , maActionState = actionState
             }
       ctxPtr <- newAppContext crashingApp
-      -- Should not crash
       result <- try @IOException (haskellOnLifecycle ctxPtr 0)
       case result of
         Left exc -> assertFailure ("haskellOnLifecycle should not throw, but got: " ++ show exc)
         Right () -> pure ()
       freeAppContext ctxPtr
+  ]
+
+-- | Tests for Action/OnChange handle equality and creation.
+actionTests :: TestTree
+actionTests = testGroup "Action"
+  [ testCase "createAction produces unique IDs" $ do
+      actionState <- newActionState
+      (handleA, handleB) <- runActionM actionState $ do
+        hA <- createAction (pure ())
+        hB <- createAction (pure ())
+        pure (hA, hB)
+      assertBool "different actions should have different IDs" (handleA /= handleB)
+
+  , testCase "createOnChange produces unique IDs" $ do
+      actionState <- newActionState
+      (handleA, handleB) <- runActionM actionState $ do
+        hA <- createOnChange (\_ -> pure ())
+        hB <- createOnChange (\_ -> pure ())
+        pure (hA, hB)
+      assertBool "different onChange handles should have different IDs" (handleA /= handleB)
+
+  , testCase "Action and OnChange share ID space" $ do
+      actionState <- newActionState
+      (actionHandle, changeHandle) <- runActionM actionState $ do
+        ah <- createAction (pure ())
+        ch <- createOnChange (\_ -> pure ())
+        pure (ah, ch)
+      assertBool "action and onChange should have different IDs"
+        (actionId actionHandle /= onChangeId changeHandle)
+
+  , testCase "same Action handle equals itself" $ do
+      actionState <- newActionState
+      handle <- runActionM actionState $ createAction (pure ())
+      handle @?= handle
+  ]
+
+-- | Tests for Widget Eq instance (enabled by opaque handles).
+widgetEqTests :: TestTree
+widgetEqTests = testGroup "WidgetEq"
+  [ testCase "same widget with same handle is equal" $ do
+      actionState <- newActionState
+      handle <- runActionM actionState $ createAction (pure ())
+      let widgetA = Button ButtonConfig { bcLabel = "tap", bcAction = handle, bcFontConfig = Nothing }
+          widgetB = Button ButtonConfig { bcLabel = "tap", bcAction = handle, bcFontConfig = Nothing }
+      widgetA @?= widgetB
+
+  , testCase "same widget with different handles is not equal" $ do
+      actionState <- newActionState
+      (handleA, handleB) <- runActionM actionState $ do
+        hA <- createAction (pure ())
+        hB <- createAction (pure ())
+        pure (hA, hB)
+      let widgetA = Button ButtonConfig { bcLabel = "tap", bcAction = handleA, bcFontConfig = Nothing }
+          widgetB = Button ButtonConfig { bcLabel = "tap", bcAction = handleB, bcFontConfig = Nothing }
+      assertBool "different handles means different widgets" (widgetA /= widgetB)
+
+  , testCase "Text widgets with same content are equal" $ do
+      let widgetA = Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing }
+          widgetB = Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing }
+      widgetA @?= widgetB
+
+  , testCase "Text widgets with different content are not equal" $ do
+      let widgetA = Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing }
+          widgetB = Text TextConfig { tcLabel = "world", tcFontConfig = Nothing }
+      assertBool "different labels means different widgets" (widgetA /= widgetB)
+
+  , testCase "Column equality is structural" $ do
+      let widgetA = Column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
+          widgetB = Column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
+          widgetC = Column [Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }]
+      widgetA @?= widgetB
+      assertBool "different children means different Column" (widgetA /= widgetC)
   ]

--- a/test/TextInputDemoMain.hs
+++ b/test/TextInputDemoMain.hs
@@ -6,38 +6,39 @@
 module Main where
 
 import Foreign.Ptr (Ptr)
-import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState, runActionM, createOnChange, OnChange)
 import HaskellMobile.Widget (InputType(..), TextConfig(..), TextInputConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)
 main = do
   platformLog "TextInput demo app registered"
-  startMobileApp textInputDemoApp
-
--- | TextInput demo: renders numeric and text inputs side by side.
--- Used by integration tests to verify InputType FFI binding end-to-end.
-textInputDemoApp :: MobileApp
-textInputDemoApp = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = \_userState -> textInputDemoView
-  }
+  actionState <- newActionState
+  (onWeightChange, onNameChange) <- runActionM actionState $ do
+    wc <- createOnChange (\_ -> pure ())
+    nc <- createOnChange (\_ -> pure ())
+    pure (wc, nc)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> textInputDemoView onWeightChange onNameChange
+    , maActionState = actionState
+    }
 
 -- | Builds a Column with a label and two TextInputs of different InputType.
-textInputDemoView :: IO Widget
-textInputDemoView = pure $ Column
+textInputDemoView :: OnChange -> OnChange -> IO Widget
+textInputDemoView onWeightChange onNameChange = pure $ Column
   [ Text TextConfig { tcLabel = "TextInput Demo", tcFontConfig = Nothing }
   , TextInput TextInputConfig
       { tiInputType  = InputNumber
       , tiHint       = "enter weight (kg)"
       , tiValue      = ""
-      , tiOnChange   = \_ -> pure ()
+      , tiOnChange   = onWeightChange
       , tiFontConfig = Nothing
       }
   , TextInput TextInputConfig
       { tiInputType  = InputText
       , tiHint       = "enter name"
       , tiValue      = ""
-      , tiOnChange   = \_ -> pure ()
+      , tiOnChange   = onNameChange
       , tiFontConfig = Nothing
       }
   ]

--- a/test/WebViewDemoMain.hs
+++ b/test/WebViewDemoMain.hs
@@ -10,11 +10,15 @@ import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
-  , UserState(..)
+  , UserState
+  , Action
   , startMobileApp
   , platformLog
   , loggingMobileContext
   , AppContext
+  , newActionState
+  , runActionM
+  , createAction
   )
 import HaskellMobile.Widget
   ( ButtonConfig(..)
@@ -26,30 +30,33 @@ import HaskellMobile.Widget
 main :: IO (Ptr AppContext)
 main = do
   platformLog "WebView demo app registered"
+  actionState <- newActionState
   urlRef <- newIORef ("https://example.com" :: String)
-  startMobileApp (webViewDemoApp urlRef)
-
--- | WebView demo: loads a URL and logs when page finishes loading.
--- A button switches to a second URL to test navigation.
-webViewDemoApp :: IORef String -> MobileApp
-webViewDemoApp urlRef = MobileApp
-  { maContext = loggingMobileContext
-  , maView    = webViewDemoView urlRef
-  }
+  (onPageLoad, onLoadExampleOrg) <- runActionM actionState $ do
+    pl <- createAction (do
+      currentUrl <- readIORef urlRef
+      platformLog ("WebView page loaded: " <> pack currentUrl))
+    sw <- createAction (writeIORef urlRef "https://example.org")
+    pure (pl, sw)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = webViewDemoView urlRef onPageLoad onLoadExampleOrg
+    , maActionState = actionState
+    }
 
 -- | Builds a Column with a WebView, a status label, and a URL-switch button.
-webViewDemoView :: IORef String -> UserState -> IO Widget
-webViewDemoView urlRef _userState = do
+webViewDemoView :: IORef String -> Action -> Action -> UserState -> IO Widget
+webViewDemoView urlRef onPageLoad onLoadExampleOrg _userState = do
   currentUrl <- readIORef urlRef
   pure $ Column
     [ Text TextConfig { tcLabel = "WebView Demo", tcFontConfig = Nothing }
     , WebView WebViewConfig
         { wvUrl = pack currentUrl
-        , wvOnPageLoad = Just (platformLog ("WebView page loaded: " <> pack currentUrl))
+        , wvOnPageLoad = Just onPageLoad
         }
     , Button ButtonConfig
         { bcLabel = "Load example.org"
-        , bcAction = writeIORef urlRef "https://example.org"
+        , bcAction = onLoadExampleOrg
         , bcFontConfig = Nothing
         }
     ]


### PR DESCRIPTION
## Summary
- Introduces `HaskellMobile.Action` module with opaque `Action`/`OnChange` handle types (newtypes over `Int32`) and a restricted `ActionM` monad for callback registration at init time
- Widget configs now use these handles instead of `IO ()` closures, enabling `Widget` to derive `Eq` naturally — no phase parameter, no type families, no `toUnit`
- Render engine uses shared `ActionState` IntMaps (never cleared during rendering), eliminating the callback atomicity gap and enabling O(1) skip-if-unchanged diffing
- Pre-registered dismiss `Action` with IORef indirection for error widget dismiss button
- All 16 test demo apps updated; demos needing platform state use IORef indirection pattern
- 172 tests passing, including new test groups for Action equality and Widget Eq behavior

Closes #97

## Test plan
- [x] `cabal build` — typechecker passes (clean, no warnings)
- [x] `cabal test` — all 172 tests pass
- [x] `nix-build nix/ci.nix` — cross-compilation passes (x86_64 + aarch64 android)
- [ ] GitHub CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)