### PR TITLE
Add usage guide to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,3 +32,250 @@ With [vibes](https://jappie.me/haskell-vibes.html) in hand I put my malice
 into crafting something good.
 
 # How to use
+
+## Writing your app
+
+Your app is a Haskell module with a `main :: IO (Ptr AppContext)`.
+You define a `MobileApp` record and pass it to `startMobileApp`:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Data.IORef (newIORef, readIORef, modifyIORef')
+import Data.Text qualified as Text
+import Foreign.Ptr (Ptr)
+import HaskellMobile
+  ( startMobileApp, MobileApp(..), AppContext
+  , loggingMobileContext
+  , newActionState, runActionM, createAction, Action
+  )
+import HaskellMobile.Widget
+
+main :: IO (Ptr AppContext)
+main = do
+  actionState <- newActionState
+  counter <- newIORef (0 :: Int)
+  increment <- runActionM actionState $
+    createAction (modifyIORef' counter (+ 1))
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> do
+        n <- readIORef counter
+        pure $ Column
+          [ Text TextConfig
+              { tcLabel = "Count: " <> Text.pack (show n)
+              , tcFontConfig = Nothing
+              }
+          , Button ButtonConfig
+              { bcLabel      = "+"
+              , bcAction     = increment
+              , bcFontConfig = Nothing
+              }
+          ]
+    , maActionState = actionState
+    }
+```
+
+`maView` is called on every render cycle and returns a `Widget` tree.
+Button taps (and other events) fire `Action` handles created via `runActionM`,
+then the framework re-renders automatically.
+
+### Available widgets
+
+| Widget | Description |
+|--------|-------------|
+| `Text` | Read-only label |
+| `Button` | Tappable button with `Action` callback |
+| `TextInput` | Controlled text field with `OnChange` callback |
+| `Column` | Vertical layout |
+| `Row` | Horizontal layout |
+| `ScrollView` | Vertically scrollable container |
+| `Image` | Image from resource, file path, or raw bytes |
+| `WebView` | Embedded web browser |
+| `Styled` | Wraps a widget with padding, colors, text alignment |
+
+### Platform bridges
+
+The `UserState` passed to `maView` provides access to platform APIs:
+
+| Bridge | Functions |
+|--------|-----------|
+| Permissions | `requestPermission`, `checkPermission` |
+| Secure storage | `secureStorageWrite`, `secureStorageRead`, `secureStorageDelete` |
+| BLE scanning | `startBleScan`, `stopBleScan`, `checkBleAdapter` |
+| Dialogs | `showDialog` |
+| Location | `startLocationUpdates`, `stopLocationUpdates` |
+| Auth sessions | `startAuthSession` (OAuth/ASWebAuthenticationSession) |
+| Camera | `startCameraSession`, `capturePhoto`, `startVideoCapture` |
+| Bottom sheets | `showBottomSheet` |
+| HTTP | `performRequest` |
+
+## Building for Android
+
+Requires Nix. The build cross-compiles your Haskell to a `.so` shared library
+and packages it into an APK with the Java UI layer.
+
+### 1. Build the APK
+
+```bash
+nix-build nix/apk.nix
+```
+
+This produces `result/haskell-mobile.apk` containing both arm64-v8a and armeabi-v7a architectures.
+
+To build with your own `Main.hs`:
+
+```bash
+nix-build nix/apk.nix --arg mainModule ./path/to/your/Main.hs
+```
+
+Or build just the shared library for a single architecture:
+
+```bash
+nix-build nix/android.nix                               # aarch64 (default)
+nix-build nix/android.nix --arg androidArch '"armv7a"'   # armv7a
+```
+
+### 2. Install
+
+```bash
+adb install result/haskell-mobile.apk
+```
+
+### 3. Consumer projects with extra Haskell dependencies
+
+If your app needs Hackage packages beyond what haskell-mobile provides,
+pass them via `consumerCabalFile` or `hpkgs`:
+
+```nix
+# your-app/default.nix
+let
+  haskellMobile = builtins.fetchGit {
+    url = "https://github.com/jappeace/haskell-mobile.git";
+    ref = "master";
+  };
+in import "${haskellMobile}/nix/apk.nix" {
+  mainModule = ./src/Main.hs;
+  # Option A: point to your .cabal file (uses IFD to extract deps)
+  consumerCabalFile = ./your-app.cabal;
+  # Option B: override haskellPackages directly
+  # hpkgs = self: super: { aeson = self.callHackage "aeson" "2.2.1.0" {}; };
+}
+```
+
+### How it works under the hood
+
+The Java activity (`HaskellMobileActivity`) loads the `.so` via `System.loadLibrary`,
+which triggers `JNI_OnLoad` in `cbits/jni_bridge.c`. That initializes the GHC RTS,
+runs your Haskell `main`, and stores the returned `AppContext` pointer.
+When `onCreate` fires, Java calls `renderUI` through JNI, which invokes your `maView`
+and the framework translates the `Widget` tree into Android `View` calls.
+
+You never need to write Java — `HaskellMobileActivity` handles all the native UI,
+permissions, camera, location, etc. Your consumer app's `MainActivity` just extends it:
+
+```java
+package com.example.myapp;
+import me.jappie.haskellmobile.HaskellMobileActivity;
+public class MainActivity extends HaskellMobileActivity {}
+```
+
+## Building for iOS
+
+Requires macOS with Nix. The build produces a static `.a` library that links into
+an Xcode project via a Swift bridge.
+
+### 1. Build the static library
+
+```bash
+nix-build nix/ios.nix
+```
+
+This produces `result/lib/libHaskellMobile.a` and headers in `result/include/`.
+
+To build with your own `Main.hs`:
+
+```bash
+nix-build nix/ios.nix --arg mainModule ./path/to/your/Main.hs
+```
+
+### 2. Set up the Xcode project
+
+Stage the library and headers, then generate the Xcode project with [XcodeGen](https://github.com/yonaskolb/XcodeGen):
+
+```bash
+mkdir -p ios/lib ios/include
+cp result/lib/libHaskellMobile.a ios/lib/
+cp result/include/*.h ios/include/
+
+nix-shell -p xcodegen --run "cd ios && xcodegen generate"
+open ios/HaskellMobile.xcodeproj
+```
+
+The `ios/project.yml` configures the bridging header, library search paths,
+and framework dependencies automatically.
+
+### 3. Build and run
+
+Configure signing in Xcode (team, bundle ID, provisioning profile), then
+build and run on a device or simulator.
+
+### How it works under the hood
+
+The Swift bridge (`ios/HaskellMobile/HaskellBridge.swift`) calls `hs_init` and
+`haskellRunMain` to boot the GHC RTS and run your Haskell `main`.
+It then sets up all the platform bridges (permissions, camera, location, etc.)
+and calls `haskellRenderUI` when SwiftUI requests a view update.
+
+The bridging header (`HaskellMobile-Bridging-Header.h`) exposes the C FFI functions
+to Swift. The `project.yml` links against the required system frameworks
+(CoreLocation, CoreBluetooth, AVFoundation, WebKit, etc.).
+
+### Consumer iOS projects
+
+Copy the `ios/` directory as a starting point for your app.
+The key files are:
+
+| File | Purpose |
+|------|---------|
+| `HaskellBridge.swift` | Boots GHC RTS, dispatches UI events |
+| `HaskellMobileApp.swift` | SwiftUI `@main` entry point |
+| `ContentView.swift` | SwiftUI view that calls `HaskellBridge.renderUI()` |
+| `HaskellMobile-Bridging-Header.h` | C header imports for Swift |
+| `project.yml` | XcodeGen spec with signing, frameworks, search paths |
+
+## Building for watchOS
+
+```bash
+nix-build nix/watchos.nix
+```
+
+Works the same as iOS — produces a static library for watchOS.
+The `watchos/` directory contains the WatchKit app structure.
+
+## Desktop development
+
+For fast iteration, build and test natively:
+
+```bash
+nix-shell
+cabal build all
+cabal test all
+```
+
+The desktop build uses stub C bridges that simulate platform responses
+(e.g. permissions always granted, location returns fixed coordinates).
+This lets you develop and test your app logic without a device.
+
+## CI
+
+Five CI jobs run on every push:
+
+| Job | Platform | What it does |
+|-----|----------|--------------|
+| `nix-build` | Linux | Full nix-build + cabal test |
+| `android` | Linux | Cross-compile aarch64, build APK |
+| `android-armv7a-emulator` | Linux | Cross-compile armv7a, run in emulator |
+| `ios` | macOS | Cross-compile to iOS static lib |
+| `watchos` | macOS | Cross-compile to watchOS static lib |


### PR DESCRIPTION
## Summary
- Documents how to write a Hatter app: `MobileApp` record, `Widget` DSL, `Action` handles, platform bridges
- Build instructions for Android (APK via nix), iOS (static library + XcodeGen), watchOS, and desktop
- Consumer project setup showing how to bring extra Hackage dependencies
- Under-the-hood explanations of the boot sequence for each platform
- CI job overview

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm code examples match current API (Action handles, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)