### PR TITLE
docs: upstream analysis for cross-compilation fixes

### DIFF
--- a/docs/armv7a-android-wear-crosscompilation.md
+++ b/docs/armv7a-android-wear-crosscompilation.md
@@ -1,0 +1,237 @@
+# ARM32 (armv7a) Cross-Compilation for Android Wear
+
+## Problem
+
+Building Haskell for armv7a-android (Android Wear / Wear OS watches) requires
+Template Haskell cross-compilation via `iserv-proxy-interpreter` running under
+QEMU user-mode on an x86_64 build host — the same approach used for aarch64.
+However, armv7a introduces several additional challenges:
+
+1. **LLVM ARM backend crashes** when compiling profiled libraries
+2. **compiler-rt doesn't recognise armv7a** as a valid ARM32 architecture
+3. **Missing ARM EABI division helpers** (`__aeabi_idiv`, `__aeabi_uldivmod`, etc.)
+4. **Bionic TLS crash** under QEMU when binary layout changes
+
+## Diagnosis
+
+### Profiling crash (LLVM ARMAsmPrinter)
+
+The armv7a cross-GHC uses LLVM (no NCG for ARM32). Building profiled boot
+libraries triggers a crash in `ARMAsmPrinter::emitXXStructor`. The aarch64
+cross-GHC works fine because NCG is available.
+
+Fix: Disable profiled libraries for armv7a at three levels:
+- `enableProfiledLibs = false` on the cross-GHC
+- `armv7aProfilingOverride` disabling `enableLibraryProfiling` per-package
+- Patch `generic-builder.nix` to skip the profiled iserv-wrapper variant
+
+### compiler-rt armv7a architecture detection
+
+The nixpkgs `compiler-rt` derivation uses cmake's `builtin-config-ix.cmake` to
+detect supported architectures. The `ARM32` set includes `arm`, `armhf`, `armv7`
+but NOT `armv7a`. Additionally, Android baremetal builds use `-nodefaultlibs`
+which prevents `check_symbol_exists(__arm__)` from linking, so arch detection
+fails even with the set fixed.
+
+Fix: `patch-compiler-rt.py` applies three cmake patches:
+1. Add `armv7a` to the ARM32 set in `builtin-config-ix.cmake`
+2. Add `armv7a_SOURCES` alias in `CMakeLists.txt`
+3. For `COMPILER_RT_DEFAULT_TARGET_ONLY`, use `add_default_target_arch()` directly
+   (bypasses the broken `detect_target_arch()`)
+4. Remove `os_version_check.c` from baremetal builds (requires `pthread.h`)
+
+### LLVM package set: libcxx bootstrap failure
+
+For armv7a, GHC's LLVM backend requires `llvmPackages.clang`. The default
+`clang` for Android targets is `libcxxClang`, which depends on `libcxx`. Building
+`libcxx` requires a working cross-linker, but the bootstrap `clang-wrapper` only
+has GNU binutils (`ld.bfd`), which can't link Android libraries (zstd-compressed
+debug sections, missing builtins path).
+
+Fix: Patch the LLVM package set to select `libstdcxxClang` (which has
+`libcxx=null`) for Android targets. GHC only needs clang for assembly
+(`LLVMAS`), not C++.
+
+### The Bionic TLS crash (the hard one)
+
+With the above fixes, the static `iserv-proxy-interpreter` binary boots under
+QEMU but crashes immediately:
+
+```
+bionic/libc/bionic/bionic_elf_tls.cpp:96:
+  align_checked CHECK 'align != 0 && powerof2(align + 0) && skew < align' failed
+```
+
+This crash appeared when ARM EABI division helpers were added to the binary.
+Systematic testing established:
+
+| Configuration | Result |
+|---|---|
+| No `__aeabi_idiv` at all (compiler inlines division) | WORKS |
+| `__aeabi_idiv` as global in separate `.o` with `-u` flags | CRASH |
+| `__aeabi_idiv` as global in separate `.o` without `-u` flags | CRASH |
+| `__aeabi_idiv` as global in same `.o` as `dlsym` | CRASH |
+| Pure C implementation (no inline asm) | CRASH |
+| Trivial unrelated change to `libdlNative` | WORKS |
+
+The root cause: adding **any** `__aeabi_*` function as a **global symbol** to
+`.dynsym` (via `--export-dynamic`) changes the binary's section layout — hash
+tables grow, sections shift, alignment changes. Under QEMU user-mode emulation,
+this triggers Bionic's TLS initialization check. The check passes mathematically
+(`align != 0 && powerof2(align) && skew < align`) on both binaries, suggesting
+a QEMU bug in how it presents the ELF program headers to Bionic's startup code.
+
+### Missing ARM EABI division helpers
+
+GHC's LLVM backend targets `armv7-a` which lacks hardware integer divide. The
+compiled `.o` files contain calls to:
+
+- `__aeabi_idiv` — signed 32-bit division
+- `__aeabi_uidiv` — unsigned 32-bit division
+- `__aeabi_idivmod` — signed 32-bit division + modulo
+- `__aeabi_uidivmod` — unsigned 32-bit division + modulo
+- `__aeabi_uldivmod` — unsigned 64-bit division + modulo
+- `__aeabi_ldivmod` — signed 64-bit division + modulo
+
+Android NDK's `compiler-rt` omits these because Android API 21+ effectively
+requires Cortex-A7+, which has the IDIV extension. But the cross-compiled `.o`
+files loaded by the RTS linker need them resolved at runtime via `dlsym`.
+
+## Solution
+
+### Static functions with dlsym interception
+
+All ARM EABI division helpers are defined as **`static`** functions in
+`dl_impl.c`. Being static, they do not appear in `.dynsym` — the binary layout
+remains identical to the working (no-aeabi) version.
+
+Our custom `dlsym()` (which already provides dynamic symbol lookup for the
+statically linked binary) intercepts lookups for `__aeabi_*` names and returns
+pointers to the static implementations:
+
+```c
+#if defined(__arm__) || defined(__thumb__)
+
+static unsigned impl_aeabi_uidiv(unsigned numerator, unsigned denominator) {
+    /* shift-and-subtract algorithm, no division operators */
+}
+
+static int impl_aeabi_idiv(int numerator, int denominator) {
+    /* unsigned division + sign handling */
+}
+
+/* ... idivmod, uidivmod ... */
+
+static void *lookup_aeabi(const char *symbol) {
+    if (strcmp(symbol, "__aeabi_idiv") == 0)  return (void *)impl_aeabi_idiv;
+    if (strcmp(symbol, "__aeabi_uidiv") == 0) return (void *)impl_aeabi_uidiv;
+    /* ... */
+    return NULL;
+}
+
+#endif
+
+void *dlsym(void *handle, const char *symbol) {
+    if (!g_inited) init_symtab();
+
+#if defined(__arm__) || defined(__thumb__)
+    { void *aeabi = lookup_aeabi(symbol);
+      if (aeabi) return aeabi; }
+#endif
+
+    /* ... normal .dynsym search ... */
+}
+```
+
+### 64-bit division: naked assembly thunks
+
+The ARM EABI calling convention for `__aeabi_uldivmod` and `__aeabi_ldivmod` is:
+
+```
+Input:  r0:r1 = numerator,  r2:r3 = denominator
+Output: r0:r1 = quotient,   r2:r3 = remainder
+```
+
+This cannot be expressed as a C function (C has no way to return two 64-bit
+values in r0:r1 and r2:r3 simultaneously). The solution uses:
+
+1. A standard C function `impl_udivmoddi4(uint64_t num, uint64_t den, uint64_t *rem)`
+   that implements 64-bit shift-and-subtract division (no division operators,
+   avoiding recursive `__aeabi_uldivmod` calls)
+
+2. A `__attribute__((naked))` assembly thunk that translates calling conventions:
+
+```c
+__attribute__((naked))
+static void impl_aeabi_uldivmod(void) {
+    __asm__ __volatile__ (
+        "push {r6, lr}\n"
+        "sub sp, sp, #16\n"       // 8 bytes remainder + 4 bytes ptr + 4 pad
+        "add r6, sp, #8\n"        // r6 = &remainder
+        "str r6, [sp]\n"          // stack arg for C function
+        "bl impl_udivmoddi4\n"    // r0-r3 pass through (AAPCS matches EABI)
+        "ldr r2, [sp, #8]\n"      // load remainder low
+        "ldr r3, [sp, #12]\n"     // load remainder high
+        "add sp, sp, #16\n"
+        "pop {r6, pc}\n"
+    );
+}
+```
+
+The key insight: the C calling convention (AAPCS) maps `(uint64_t, uint64_t)` to
+`r0:r1, r2:r3` — **identical** to the `__aeabi_uldivmod` input convention. So the
+thunk only needs to handle the remainder output (the C function returns quotient
+in r0:r1, which is already correct).
+
+### Hex diagnostics
+
+A subtle secondary issue: the diagnostic function `diag_num` used decimal
+formatting (`val % 10`, `val / 10`) which on ARM32 generates `__aeabi_idiv`
+calls. Since this code runs before the division helpers are available, it would
+crash. Replaced with `diag_hex` using bitwise operations (`val & 0xf`,
+`val >>= 4`).
+
+### Static PIE
+
+ARM32 omits the `-pie` flag used for aarch64. The ARM32 CRT startup doesn't
+reliably relocate `.dynsym` entries in static PIE binaries, causing `dlsym` to
+return pre-relocation offsets. Plain static linking (`-static` without `-pie`)
+works because `d_ptr` values in `_DYNAMIC` are already absolute addresses.
+
+## Files Changed
+
+- `nix/cross-deps.nix` — armv7a profiling overrides, ELF32 types, static flags
+- `nix/th-support/dl_impl.c` — static aeabi division + dlsym interception,
+  hex diagnostics, 64-bit naked assembly thunks, ELF32 support
+- `nix/patch-compiler-rt.py` — compiler-rt armv7a arch fix, LLVM clang fix,
+  iserv-wrapper profiling fix
+- `nix/patched-nixpkgs.nix` — conditional nixpkgs patching
+
+## Consumer Changes (prrrrrrrrr)
+
+The haskell-mobile `test-aeabi-only` / `fix/armv7a-profiling` branch also
+includes the Action handles API change (PR #126). Consumer apps need to:
+
+1. Create an `ActionState` with `newActionState`
+2. Pre-create `Action` / `OnChange` handles via `runActionM`
+3. Pass handles to view functions instead of inline `IO ()` closures
+4. Add `maActionState` field to `MobileApp`
+
+## Lessons Learned
+
+1. **npins pin management**: Manually editing `npins/sources.json` only changes
+   the `revision` field (metadata). The `url` and `hash` fields determine what's
+   actually fetched. Always use `npins update <name>` CLI.
+
+2. **Binary layout sensitivity under QEMU**: Even tiny changes to a static
+   binary's `.dynsym` can trigger QEMU/Bionic compatibility issues. When
+   providing symbols for the RTS linker, prefer dlsym interception over global
+   symbol export.
+
+3. **ARM32 division in C**: Any use of `%` or `/` on ARM32 generates
+   `__aeabi_idiv` calls. Use bitwise operations for formatting in code that runs
+   before division helpers are available.
+
+4. **ARM EABI 64-bit calling conventions**: `__aeabi_uldivmod` and
+   `__aeabi_ldivmod` use a register-pair convention that can't be expressed in C.
+   Naked assembly thunks are the cleanest way to bridge to C implementations.

--- a/docs/upstream-analysis.md
+++ b/docs/upstream-analysis.md
@@ -1,0 +1,257 @@
+# Upstream Analysis: Cross-Compilation Fixes
+
+Which of our Android cross-compilation workarounds could be upstreamed to the
+projects they work around? Covers both the aarch64 Template Haskell fixes
+(see `template-haskell-android-crosscompilation.md`) and the armv7a fixes
+(see `armv7a-android-wear-crosscompilation.md`).
+
+## nixpkgs — Easy Wins
+
+These are small, self-contained patches that would benefit anyone doing ARM
+Android cross-compilation with Nix.
+
+### 1. compiler-rt: add `armv7a` to ARM32 architecture set
+
+**Our workaround**: `patch-compiler-rt.py` patches `builtin-config-ix.cmake`
+to add `armv7a` to the ARM32 set, and patches `CMakeLists.txt` to add
+`armv7a_SOURCES`.
+
+**What upstream would look like**: PR to nixpkgs adding `armv7a` alongside
+the existing `arm`, `armhf`, `armv7` entries in compiler-rt's cmake config.
+
+**Why it should land**: `armv7a` is the standard Android ARM32 target triple
+(`armv7a-unknown-linux-android`). It's an obvious omission.
+
+**Scope**: ~5 lines in compiler-rt cmake files.
+
+### 2. compiler-rt: baremetal architecture detection with `-nodefaultlibs`
+
+**Our workaround**: `patch-compiler-rt.py` replaces `detect_target_arch()`
+(which uses `check_symbol_exists(__arm__)` — fails to link with
+`-nodefaultlibs`) with direct `add_default_target_arch()` when
+`COMPILER_RT_DEFAULT_TARGET_ONLY` is set.
+
+**What upstream would look like**: Same patch in nixpkgs compiler-rt
+derivation, or upstream to LLVM's compiler-rt.
+
+**Why it should land**: `detect_target_arch()` is fundamentally broken for
+baremetal/Android targets that use `-nodefaultlibs`. The
+`COMPILER_RT_DEFAULT_TARGET_ONLY` codepath already knows the target — it
+shouldn't need to probe for it.
+
+**Scope**: ~10 lines in cmake. Could go to nixpkgs or LLVM upstream.
+
+### 3. compiler-rt: exclude `os_version_check.c` from baremetal builds
+
+**Our workaround**: `patch-compiler-rt.py` removes `os_version_check.c` from
+the baremetal builtins source list.
+
+**What upstream would look like**: Conditional exclusion in cmake when building
+for baremetal targets.
+
+**Why it should land**: `os_version_check.c` requires `pthread.h`, which is
+unavailable in baremetal environments. This file is Apple-specific version
+checking code that has no purpose on Android/Linux baremetal.
+
+**Scope**: ~3 lines in cmake. Probably combine with #1 and #2 into one PR.
+
+### 4. LLVM package set: `libstdcxxClang` for Android cross targets
+
+**Our workaround**: `patch-compiler-rt.py` patches
+`pkgs/development/compilers/llvm/common/default.nix` to select
+`libstdcxxClang` instead of `libcxxClang` for Android targets.
+
+**What upstream would look like**: PR to nixpkgs LLVM package set adding a
+condition: if target is Android, use `libstdcxxClang`.
+
+**Why it should land**: The default `libcxxClang` depends on `libcxx`, which
+requires a working cross-linker to build. The bootstrap `clang-wrapper` only
+has GNU `ld.bfd`, which can't link Android libraries (zstd-compressed debug
+sections, missing builtins path). GHC's LLVM backend only needs clang for
+assembly — no C++ required.
+
+**Risk**: This changes the default clang variant for all Android cross builds
+in nixpkgs. Needs careful review — other consumers might depend on
+`libcxxClang` features. Could be gated on a flag or made specific to the
+GHC use case.
+
+**Scope**: ~5 lines, but needs discussion.
+
+### 5. `generic-builder.nix`: skip profiled iserv-wrapper when profiling disabled
+
+**Our workaround**: `patch-compiler-rt.py` patches
+`pkgs/development/haskell-modules/generic-builder.nix` to skip the profiled
+`iserv-wrapper` variant when `enableProfiling` is false.
+
+**What upstream would look like**: Guard the profiled iserv-wrapper derivation
+behind `enableProfiling` or `enableProfiledLibs`.
+
+**Why it should land**: When a cross-GHC has `enableProfiledLibs = false`
+(needed for armv7a due to LLVM crash), attempting to build a profiled
+iserv-wrapper fails. The non-profiled variant works fine.
+
+**Scope**: ~3 lines in generic-builder.nix.
+
+## GHC — High Value, Needs Discussion
+
+### 6. RTS linker: provide mmap hint even when `linkerAlwaysPic=true`
+
+**Our workaround**: `--wrap=mmap` on iserv-proxy-interpreter intercepts
+`mmap(NULL, ...)` and provides a hint address starting 2 MiB above `_end`.
+
+**What upstream would look like**: In `rts/linker/MMap.c`, when
+`linkerAlwaysPic=true`, instead of calling `mmap(NULL, ...)`, use a hint
+address derived from `LINKER_LOAD_BASE` or the binary's load address. Fall
+back to NULL hint if the hinted allocation fails.
+
+**Why it should land**: This is arguably a bug. The `nearImage()` logic and
+`LINKER_LOAD_BASE` exist precisely to keep linker allocations within ±4 GiB
+for ADRP relocations, but they're completely bypassed when
+`linkerAlwaysPic=true`. Any unusual memory layout (QEMU, aggressive ASLR,
+large address space) can trigger the assertion in
+`rts/linker/elf_reloc_aarch64.c:118`.
+
+**Impact**: Would eliminate the need for our `mmap_wrapper.c` and
+`--wrap=mmap` flag entirely. This is the single most valuable upstream fix.
+
+**Risk**: Low. Providing a hint is advisory — the kernel can ignore it. The
+fallback to NULL hint preserves current behavior if the hint fails.
+
+**Scope**: ~15 lines in `rts/linker/MMap.c`. Probably needs a GHC issue +
+MR, with a reproducer showing the failure under QEMU.
+
+**GHC source refs** (9.10.3):
+- `rts/linker/MMap.c` — `mmapForLinker` / `mmapAnywhere`
+- `rts/linker/MMap.h` — `LINKER_LOAD_BASE`
+- `rts/linker/elf_reloc_aarch64.c:118` — ADRP assertion
+- `rts/include/rts/Flags.h` — `DEFAULT_LINKER_ALWAYS_PIC`
+
+### 7. Cross-compiler: clear `dynamic-library-dirs` for static-only targets
+
+**Our workaround**: `preConfigure` hook in mkDerivation overlay copies global
+package confs, resolves `${pkgroot}`, clears `dynamic-library-dirs`, recaches.
+
+**What upstream would look like**: GHC's cross-compiler installation step
+should not populate `dynamic-library-dirs` when the target platform doesn't
+support shared libraries (e.g., Android static builds).
+
+**Why it should land**: The current behavior causes the RTS to attempt
+`LoadDLL` for boot packages during TH evaluation, which always fails on
+Android (no `.so` files), adding startup latency and confusing error messages
+before falling back to `LoadArchive`.
+
+**Risk**: Very low. Only affects cross-compiler configurations.
+
+**Scope**: Probably a few lines in GHC's install phase or `ghc-pkg` config
+generation. Needs investigation into where `dynamic-library-dirs` gets
+populated during cross-compiler builds.
+
+### 8. RTS flag: allow `-xm` when `linkerAlwaysPic=true`
+
+**Our workaround**: `--wrap=mmap` (same as #6).
+
+**What upstream would look like**: Accept `-xm <addr>` as a hint base even
+when `linkerAlwaysPic=true`, rather than silently ignoring it.
+
+**Why it should land**: Gives users a way to work around mmap placement issues
+without patching the RTS. Complementary to #6.
+
+**Risk**: Very low — it's an opt-in flag.
+
+**Scope**: ~5 lines. But if #6 lands, this becomes less important.
+
+## QEMU — Worth Filing, Hard to Land
+
+### 9. Guest mmap: honor address hints for anonymous mappings
+
+**Our workaround**: `--wrap=mmap` provides hints that QEMU happens to honor
+(QEMU checks if the hinted guest address is free and uses it if so, but its
+default allocator ignores NULL hints entirely, allocating top-down from high
+addresses).
+
+**What upstream would look like**: When `mmap(addr, ...)` is called with a
+non-NULL hint and no `MAP_FIXED`, QEMU should prefer addresses near the hint,
+matching Linux kernel behavior. For NULL hints, QEMU could optionally try
+allocating near the binary before falling back to top-down.
+
+**Why it might land**: It's a correctness argument — Linux kernel's mmap tries
+to honor hints, and programs (like GHC's RTS) depend on this.
+
+**Why it might not**: QEMU's user-mode address allocator is complex and
+changes here affect all guest binaries. The top-down allocator exists for
+good reasons (avoiding fragmentation).
+
+**What to file**: Bug report documenting that `mmap(NULL, ...)` for anonymous
+mappings returns addresses far (>4 GiB) from the binary, breaking
+aarch64 programs that rely on mmap hints for PIC code loading. Include
+reproducer: statically linked aarch64 binary that loads `.o` files with ADRP
+relocations.
+
+**Scope**: Unknown. Would require understanding QEMU's `mmap_find_vma` and
+the guest address allocator deeply.
+
+### 10. Static binary ELF header / TLS presentation (ARM32)
+
+**Our workaround**: Keep `__aeabi_*` symbols out of `.dynsym` (use static
+functions + dlsym interception) to avoid changing binary layout.
+
+**What upstream would look like**: Fix how QEMU presents `AT_PHDR` or TLS
+program headers to statically linked ARM32 binaries.
+
+**Why it probably won't land**: Extremely niche — only triggers with specific
+binary layouts under QEMU + Bionic's static libc. The TLS alignment check
+passes mathematically on the binary itself; the issue is in how QEMU loads or
+presents the ELF segments. Reproducing and root-causing this would require
+deep QEMU ELF loading investigation.
+
+**What to file**: Bug report documenting that adding a global symbol to a
+static ARM32 binary (changing `.dynsym` size) causes Bionic's TLS init to
+crash under QEMU, with both working and crashing binaries attached.
+
+**Scope**: Unknown, probably significant QEMU internals work.
+
+## Android NDK — Not Worth Upstreaming
+
+### 11. Native ELF `libdl.a`
+
+**Our workaround**: Custom `libdl.a` with `dlsym` that walks `.dynsym`.
+
+**Why not upstream**: NDK intentionally ships `libdl.a` as stubs because
+Android apps should use the dynamic linker. Our use case (statically linked
+binary doing its own dynamic symbol lookup for an in-process RTS linker) is
+too niche.
+
+### 12. ARM EABI division helpers in compiler-rt
+
+**Our workaround**: Static implementations in `dl_impl.c` + dlsym
+interception.
+
+**Why not upstream**: NDK targets API 21+ which effectively requires
+hardware IDIV (Cortex-A7+). The helpers are omitted intentionally. Our need
+comes from cross-compiled `.o` files targeting generic `armv7-a` being loaded
+by the RTS linker at runtime — not a normal NDK use case.
+
+## LLVM — Low Priority
+
+### 13. `ARMAsmPrinter::emitXXStructor` crash with profiled code
+
+**Our workaround**: Disable profiled libraries for armv7a.
+
+**Why low priority**: Hard to reproduce outside the GHC build context. Would
+need a minimal `.ll` file that triggers the crash, filed against LLVM's ARM
+backend. The GHC profiling transform generates unusual code patterns that
+LLVM's ARM backend doesn't handle.
+
+**What to file**: LLVM bug with the crashing `.ll` input (extractable from
+a failing GHC build with `-keep-llvm-files`).
+
+## Recommended Order of Action
+
+1. **nixpkgs PR**: compiler-rt fixes (#1, #2, #3) — single PR, easy review
+2. **nixpkgs PR**: generic-builder profiling fix (#5) — standalone, easy
+3. **GHC issue + MR**: RTS linker mmap hints (#6) — highest value
+4. **nixpkgs PR**: LLVM clang for Android (#4) — needs discussion
+5. **GHC issue**: cross-compiler dynamic-library-dirs (#7) — file issue first
+6. **QEMU bug**: mmap hint handling (#9) — file with reproducer
+7. **QEMU bug**: ARM32 TLS crash (#10) — file for documentation, low expectations
+8. **LLVM bug**: ARM32 profiling crash (#13) — file if we can extract the `.ll`


### PR DESCRIPTION
## Summary
- Analyzes which aarch64 + armv7a cross-compilation workarounds could be upstreamed
- Covers GHC, QEMU, nixpkgs, LLVM, and Android NDK
- Recommends starting with nixpkgs compiler-rt fixes (easiest) and GHC RTS linker mmap hints (highest value)

Companion to the two technical reports:
- `docs/template-haskell-android-crosscompilation.md` (aarch64)
- `docs/armv7a-android-wear-crosscompilation.md` (armv7a)

Want a second opinion before opening upstream PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)