### PR TITLE
Add MapView widget with native map embedding (#75)

### DIFF
--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -55,6 +55,7 @@ static jclass   g_class_LinearLayout;
 static jclass   g_class_ScrollView;
 static jclass   g_class_ImageView;
 static jclass   g_class_WebView;
+static jclass   g_class_FrameLayout;
 static jclass   g_class_BitmapFactory;
 static jclass   g_class_ViewGroup;
 static jclass   g_class_ViewGroup_LayoutParams;
@@ -67,6 +68,7 @@ static jmethodID g_ctor_LinearLayout;
 static jmethodID g_ctor_ScrollView;
 static jmethodID g_ctor_ImageView;
 static jmethodID g_ctor_WebView;
+static jmethodID g_ctor_FrameLayout;
 static jmethodID g_ctor_ViewGroup_LayoutParams;
 static jmethodID g_ctor_Integer;
 
@@ -162,6 +164,10 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     if (!cls) return -1;
     g_class_WebView = (*env)->NewGlobalRef(env, cls);
 
+    cls = (*env)->FindClass(env, "android/widget/FrameLayout");
+    if (!cls) return -1;
+    g_class_FrameLayout = (*env)->NewGlobalRef(env, cls);
+
     cls = (*env)->FindClass(env, "android/graphics/BitmapFactory");
     if (!cls) return -1;
     g_class_BitmapFactory = (*env)->NewGlobalRef(env, cls);
@@ -192,6 +198,8 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     g_ctor_ImageView = (*env)->GetMethodID(env, g_class_ImageView,
         "<init>", "(Landroid/content/Context;)V");
     g_ctor_WebView = (*env)->GetMethodID(env, g_class_WebView,
+        "<init>", "(Landroid/content/Context;)V");
+    g_ctor_FrameLayout = (*env)->GetMethodID(env, g_class_FrameLayout,
         "<init>", "(Landroid/content/Context;)V");
     g_ctor_ViewGroup_LayoutParams = (*env)->GetMethodID(env,
         g_class_ViewGroup_LayoutParams, "<init>", "(II)V");
@@ -432,6 +440,20 @@ static int32_t android_create_node(int32_t nodeType)
     case UI_NODE_IMAGE:
         view = (*env)->NewObject(env, g_class_ImageView, g_ctor_ImageView, g_activity);
         break;
+    case UI_NODE_MAP_VIEW: {
+        /* Placeholder: FrameLayout containing a TextView showing coordinates.
+         * A real map (osmdroid or Google Maps) can replace this once the build
+         * pipeline supports AAR dependencies. */
+        jobject frame = (*env)->NewObject(env, g_class_FrameLayout, g_ctor_FrameLayout, g_activity);
+        jobject label = (*env)->NewObject(env, g_class_TextView, g_ctor_TextView, g_activity);
+        jstring text = (*env)->NewStringUTF(env, "Map placeholder (0.0, 0.0) z1.0");
+        (*env)->CallVoidMethod(env, label, g_method_setText, text);
+        (*env)->DeleteLocalRef(env, text);
+        (*env)->CallVoidMethod(env, frame, g_method_addView, label);
+        (*env)->DeleteLocalRef(env, label);
+        view = frame;
+        break;
+    }
     case UI_NODE_WEBVIEW: {
         view = (*env)->NewObject(env, g_class_WebView, g_ctor_WebView, g_activity);
         if (view && g_method_getSettings && g_method_setJavaScriptEnabled) {
@@ -648,6 +670,32 @@ static void android_set_num_prop(int32_t nodeId, int32_t propId, double value)
         LOGI("setNumProp(node=%d, scaleType=%d)", nodeId, (int)value);
         break;
     }
+    case UI_PROP_MAP_LAT:
+    case UI_PROP_MAP_LON:
+    case UI_PROP_MAP_ZOOM: {
+        /* Update placeholder label inside the FrameLayout with new coordinates.
+         * The FrameLayout's first child is the placeholder TextView. */
+        if ((*env)->IsInstanceOf(env, view, g_class_FrameLayout)) {
+            jmethodID getChildAt = (*env)->GetMethodID(env, g_class_ViewGroup,
+                "getChildAt", "(I)Landroid/view/View;");
+            jobject child = (*env)->CallObjectMethod(env, view, getChildAt, (jint)0);
+            if (child && (*env)->IsInstanceOf(env, child, g_class_TextView)) {
+                char buf[128];
+                snprintf(buf, sizeof(buf), "Map placeholder (%.4f, %.4f) z%.1f",
+                         value, value, value);
+                jstring jtext = (*env)->NewStringUTF(env, buf);
+                (*env)->CallVoidMethod(env, child, g_method_setText, jtext);
+                (*env)->DeleteLocalRef(env, jtext);
+            }
+            if (child) (*env)->DeleteLocalRef(env, child);
+        }
+        LOGI("setNumProp(node=%d, mapProp=%d, value=%.4f)", nodeId, propId, value);
+        break;
+    }
+    case UI_PROP_MAP_SHOW_USER_LOC:
+        /* No-op for placeholder — real map would toggle location layer */
+        LOGI("setNumProp(node=%d, showUserLoc=%.0f)", nodeId, value);
+        break;
     default:
         LOGI("setNumProp: unknown propId %d", propId);
         break;
@@ -707,8 +755,11 @@ static void android_set_handler(int32_t nodeId, int32_t eventType, int32_t callb
         LOGI("setHandler(node=%d, click, callback=%d)", nodeId, callbackId);
         break;
     case UI_EVENT_TEXT_CHANGE:
-        /* Register a TextWatcher via our Java helper */
-        if (g_method_registerTextWatcher) {
+        if ((*env)->IsInstanceOf(env, view, g_class_FrameLayout)) {
+            /* MapView placeholder: callbackId stored in tag, no TextWatcher needed */
+            LOGI("setHandler(node=%d, mapRegionChange, callback=%d)", nodeId, callbackId);
+        } else if (g_method_registerTextWatcher) {
+            /* Register a TextWatcher via our Java helper */
             (*env)->CallVoidMethod(env, g_activity, g_method_registerTextWatcher, view);
             LOGI("setHandler(node=%d, textChange, callback=%d)", nodeId, callbackId);
         } else {

--- a/include/UIBridge.h
+++ b/include/UIBridge.h
@@ -11,6 +11,7 @@
 #define UI_NODE_TEXT_INPUT  4
 #define UI_NODE_SCROLL_VIEW 5
 #define UI_NODE_IMAGE       6
+#define UI_NODE_MAP_VIEW    7
 #define UI_NODE_WEBVIEW     8
 
 /* Property IDs for string properties */
@@ -27,7 +28,11 @@
 #define UI_PROP_PADDING     1
 #define UI_PROP_INPUT_TYPE  2
 #define UI_PROP_GRAVITY     3
-#define UI_PROP_SCALE_TYPE  4
+#define UI_PROP_SCALE_TYPE          4
+#define UI_PROP_MAP_LAT             5
+#define UI_PROP_MAP_LON             6
+#define UI_PROP_MAP_ZOOM            7
+#define UI_PROP_MAP_SHOW_USER_LOC   8
 
 /* Event types */
 #define UI_EVENT_CLICK       0

--- a/ios/HaskellMobile/UIBridgeIOS.m
+++ b/ios/HaskellMobile/UIBridgeIOS.m
@@ -10,6 +10,7 @@
 
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
+#import <MapKit/MapKit.h>
 #import <os/log.h>
 #import <objc/runtime.h>
 #include <stdlib.h>
@@ -100,6 +101,29 @@ static UIViewController *g_viewController = nil;
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     LOGI("WebView page loaded: callbackId=%d", self.callbackId);
     haskellOnUIEvent([IOSBridgeHandler shared].haskellCtx, self.callbackId);
+}
+
+@end
+
+/* ---- MKMapView delegate for region-change callbacks ---- */
+@interface HMMapViewDelegate : NSObject <MKMapViewDelegate>
+@property (nonatomic, assign) int32_t callbackId;
+@end
+
+@implementation HMMapViewDelegate
+
+- (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
+    CLLocationCoordinate2D center = mapView.region.center;
+    double longitudeSpan = mapView.region.span.longitudeDelta;
+    double zoom = log2(360.0 / longitudeSpan);
+    if (zoom < 1.0) zoom = 1.0;
+    if (zoom > 20.0) zoom = 20.0;
+    NSString *text = [NSString stringWithFormat:@"%.6f,%.6f,%.1f",
+                      center.latitude, center.longitude, zoom];
+    LOGI("MapView region changed: callbackId=%d text=\"%{public}s\"",
+         self.callbackId, [text UTF8String]);
+    haskellOnUITextChange([IOSBridgeHandler shared].haskellCtx,
+                          self.callbackId, [text UTF8String]);
 }
 
 @end
@@ -287,6 +311,12 @@ static int32_t ios_create_node(int32_t nodeType)
         imageView.contentMode = UIViewContentModeScaleAspectFit;
         imageView.translatesAutoresizingMaskIntoConstraints = NO;
         view = imageView;
+        break;
+    }
+    case UI_NODE_MAP_VIEW: {
+        MKMapView *mapView = [[MKMapView alloc] init];
+        mapView.translatesAutoresizingMaskIntoConstraints = NO;
+        view = mapView;
         break;
     }
     case UI_NODE_WEBVIEW: {
@@ -523,6 +553,44 @@ static void ios_set_num_prop(int32_t nodeId, int32_t propId, double value)
         LOGI("setNumProp(node=%d, gravity=%d)", nodeId, gravity);
         break;
     }
+    case UI_PROP_MAP_LAT: {
+        if ([view isKindOfClass:[MKMapView class]]) {
+            MKMapView *mapView = (MKMapView *)view;
+            MKCoordinateRegion region = mapView.region;
+            region.center.latitude = value;
+            [mapView setRegion:region animated:NO];
+        }
+        LOGI("setNumProp(node=%d, mapLat=%.6f)", nodeId, value);
+        break;
+    }
+    case UI_PROP_MAP_LON: {
+        if ([view isKindOfClass:[MKMapView class]]) {
+            MKMapView *mapView = (MKMapView *)view;
+            MKCoordinateRegion region = mapView.region;
+            region.center.longitude = value;
+            [mapView setRegion:region animated:NO];
+        }
+        LOGI("setNumProp(node=%d, mapLon=%.6f)", nodeId, value);
+        break;
+    }
+    case UI_PROP_MAP_ZOOM: {
+        if ([view isKindOfClass:[MKMapView class]]) {
+            MKMapView *mapView = (MKMapView *)view;
+            MKCoordinateRegion region = mapView.region;
+            double span = 360.0 / pow(2.0, value);
+            region.span = MKCoordinateSpanMake(span, span);
+            [mapView setRegion:region animated:NO];
+        }
+        LOGI("setNumProp(node=%d, mapZoom=%.1f)", nodeId, value);
+        break;
+    }
+    case UI_PROP_MAP_SHOW_USER_LOC: {
+        if ([view isKindOfClass:[MKMapView class]]) {
+            ((MKMapView *)view).showsUserLocation = (value > 0.5);
+        }
+        LOGI("setNumProp(node=%d, showUserLoc=%.0f)", nodeId, value);
+        break;
+    }
     default:
         LOGI("setNumProp: unknown propId %d", propId);
         break;
@@ -568,12 +636,21 @@ static void ios_set_handler(int32_t nodeId, int32_t eventType, int32_t callbackI
         break;
     case UI_EVENT_TEXT_CHANGE:
         view.tag = callbackId;
-        if ([view isKindOfClass:[UITextField class]]) {
+        if ([view isKindOfClass:[MKMapView class]]) {
+            HMMapViewDelegate *mapDelegate = [[HMMapViewDelegate alloc] init];
+            mapDelegate.callbackId = callbackId;
+            ((MKMapView *)view).delegate = mapDelegate;
+            objc_setAssociatedObject(view, "HMMapViewDelegate", mapDelegate,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            LOGI("setHandler(node=%d, mapRegionChange, callback=%d)", nodeId, callbackId);
+        } else if ([view isKindOfClass:[UITextField class]]) {
             [(UITextField *)view addTarget:[IOSBridgeHandler shared]
                                     action:@selector(handleTextChange:)
                           forControlEvents:UIControlEventEditingChanged];
+            LOGI("setHandler(node=%d, textChange, callback=%d)", nodeId, callbackId);
+        } else {
+            LOGI("setHandler(node=%d, textChange, callback=%d)", nodeId, callbackId);
         }
-        LOGI("setHandler(node=%d, textChange, callback=%d)", nodeId, callbackId);
         break;
     default:
         LOGI("setHandler: unknown eventType %d", eventType);

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,4 +30,4 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: HaskellMobile/HaskellMobile-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit"]

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -207,6 +207,17 @@ let
     name = "haskell-mobile-networkstatus-apk";
   };
 
+  mapviewAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/MapViewDemoMain.hs;
+  };
+  mapviewApk = lib.mkApk {
+    sharedLibs = [{ lib = mapviewAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "haskell-mobile-mapview.apk";
+    name = "haskell-mobile-mapview-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -261,6 +272,7 @@ CAMERA_APK="${cameraApk}/haskell-mobile-camera.apk"
 BOTTOM_SHEET_APK="${bottomSheetApk}/haskell-mobile-bottomsheet.apk"
 HTTP_APK="${httpApk}/haskell-mobile-http.apk"
 NETWORK_STATUS_APK="${networkStatusApk}/haskell-mobile-networkstatus.apk"
+MAPVIEW_APK="${mapviewApk}/haskell-mobile-mapview.apk"
 PACKAGE="me.jappie.haskellmobile"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -286,7 +298,8 @@ for so_path in \
     "${cameraAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${bottomSheetAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${httpAndroid}/lib/${abiDir}/libhaskellmobile.so" \
-    "${networkStatusAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
+    "${networkStatusAndroid}/lib/${abiDir}/libhaskellmobile.so" \
+    "${mapviewAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -468,7 +481,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -544,6 +557,8 @@ echo "--- location ---"
 run_with_retry "location" bash "$TEST_SCRIPTS/android/location.sh" || PHASE7_EXIT=1
 echo "--- webview ---"
 run_with_retry "webview" bash "$TEST_SCRIPTS/android/webview.sh" || PHASE9_EXIT=1
+echo "--- mapview ---"
+run_with_retry "mapview" bash "$TEST_SCRIPTS/android/mapview.sh" || PHASE9_EXIT=1
 echo "--- authsession ---"
 run_with_retry "authsession" bash "$TEST_SCRIPTS/android/authsession.sh" || PHASE10_EXIT=1
 echo "--- camera ---"

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -197,6 +197,17 @@ let
     name = "haskell-mobile-networkstatus-simulator-app";
   };
 
+  mapviewIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/MapViewDemoMain.hs;
+    simulator = true;
+  };
+  mapviewSimApp = lib.mkSimulatorApp {
+    iosLib = mapviewIos;
+    iosSrc = ../ios;
+    name = "haskell-mobile-mapview-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -233,6 +244,7 @@ CAMERA_SHARE_DIR="${cameraSimApp}/share/ios"
 BOTTOM_SHEET_SHARE_DIR="${bottomSheetSimApp}/share/ios"
 HTTP_SHARE_DIR="${httpSimApp}/share/ios"
 NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/ios"
+MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -290,7 +302,8 @@ for share_dir in \
     "$AUTH_SESSION_SHARE_DIR" \
     "$CAMERA_SHARE_DIR" \
     "$BOTTOM_SHEET_SHARE_DIR" \
-    "$HTTP_SHARE_DIR"; do
+    "$HTTP_SHARE_DIR" \
+    "$MAPVIEW_SHARE_DIR"; do
     a_path="$share_dir/lib/libHaskellMobile.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1021,6 +1034,50 @@ if [ -z "$NETWORK_STATUS_APP" ]; then
 fi
 echo "Network status app: $NETWORK_STATUS_APP"
 
+# --- Stage and build mapview demo app ---
+echo "=== Staging mapview demo app ==="
+mkdir -p "$WORK_DIR/mapview/lib" "$WORK_DIR/mapview/include"
+cp "$MAPVIEW_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/mapview/lib/"
+cp "$MAPVIEW_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/mapview/include/"
+cp -r "$MAPVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/mapview/"
+cp "$MAPVIEW_SHARE_DIR/project.yml" "$WORK_DIR/mapview/"
+chmod -R u+w "$WORK_DIR/mapview"
+
+echo "=== Generating mapview Xcode project ==="
+cd "$WORK_DIR/mapview"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building mapview demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/mapview-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+MAPVIEW_APP=$(find "$WORK_DIR/mapview-build" -name "*.app" -type d | head -1)
+if [ -z "$MAPVIEW_APP" ]; then
+    echo "ERROR: Could not find mapview .app bundle"
+    exit 1
+fi
+echo "MapView app: $MAPVIEW_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1082,7 +1139,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1158,6 +1215,8 @@ echo "--- location ---"
 run_with_retry "location" bash "$TEST_SCRIPTS/ios/location.sh" || PHASE7_EXIT=1
 echo "--- webview ---"
 run_with_retry "webview" bash "$TEST_SCRIPTS/ios/webview.sh" || PHASE9_EXIT=1
+echo "--- mapview ---"
+run_with_retry "mapview" bash "$TEST_SCRIPTS/ios/mapview.sh" || PHASE9_EXIT=1
 echo "--- authsession ---"
 run_with_retry "authsession" bash "$TEST_SCRIPTS/ios/authsession.sh" || PHASE10_EXIT=1
 echo "--- camera ---"

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -176,6 +176,17 @@ let
     name = "haskell-mobile-watchos-networkstatus-simulator-app";
   };
 
+  mapviewWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/MapViewDemoMain.hs;
+    simulator = true;
+  };
+  mapviewSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = mapviewWatchos;
+    watchosSrc = ../watchos;
+    name = "haskell-mobile-watchos-mapview-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -210,6 +221,7 @@ AUTH_SESSION_SHARE_DIR="${authSessionSimApp}/share/watchos"
 CAMERA_SHARE_DIR="${cameraSimApp}/share/watchos"
 BOTTOM_SHEET_SHARE_DIR="${bottomSheetSimApp}/share/watchos"
 NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/watchos"
+MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -265,7 +277,8 @@ for share_dir in \
     "$AUTH_SESSION_SHARE_DIR" \
     "$CAMERA_SHARE_DIR" \
     "$BOTTOM_SHEET_SHARE_DIR" \
-    "$NETWORK_STATUS_SHARE_DIR"; do
+    "$NETWORK_STATUS_SHARE_DIR" \
+    "$MAPVIEW_SHARE_DIR"; do
     a_path="$share_dir/lib/libHaskellMobile.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -893,6 +906,49 @@ if [ -z "$NETWORK_STATUS_APP" ]; then
 fi
 echo "NetworkStatus app: $NETWORK_STATUS_APP"
 
+# --- Stage and build mapview demo app ---
+echo "=== Staging mapview demo app ==="
+mkdir -p "$WORK_DIR/mapview/lib" "$WORK_DIR/mapview/include"
+cp "$MAPVIEW_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/mapview/lib/"
+cp "$MAPVIEW_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/mapview/include/"
+cp -r "$MAPVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/mapview/"
+cp "$MAPVIEW_SHARE_DIR/project.yml" "$WORK_DIR/mapview/"
+chmod -R u+w "$WORK_DIR/mapview"
+
+echo "=== Generating mapview Xcode project ==="
+cd "$WORK_DIR/mapview"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building mapview demo app for watchOS simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/mapview-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+MAPVIEW_APP=$(find "$WORK_DIR/mapview-build" -name "*.app" -type d | head -1)
+if [ -z "$MAPVIEW_APP" ]; then
+    echo "ERROR: Could not find mapview .app bundle"
+    exit 1
+fi
+echo "MapView app: $MAPVIEW_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -956,7 +1012,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.haskellmobile"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -970,6 +1026,7 @@ PHASE9_EXIT=0
 PHASE10_EXIT=0
 PHASE11_EXIT=0
 PHASE12_EXIT=0
+PHASE13_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1031,6 +1088,8 @@ echo "--- bottomsheet ---"
 run_with_retry "bottomsheet" bash "$TEST_SCRIPTS/watchos/bottomsheet.sh" || PHASE11_EXIT=1
 echo "--- networkstatus ---"
 run_with_retry "networkstatus" bash "$TEST_SCRIPTS/watchos/network_status.sh" || PHASE12_EXIT=1
+echo "--- mapview ---"
+run_with_retry "mapview" bash "$TEST_SCRIPTS/watchos/mapview.sh" || PHASE13_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1151,6 +1210,16 @@ else
     echo "PHASE 12 FAILED"
 fi
 
+if [ $PHASE13_EXIT -eq 0 ]; then
+    PHASE13_OK=1
+    echo ""
+    echo "PHASE 13 PASSED"
+else
+    PHASE13_OK=0
+    echo ""
+    echo "PHASE 13 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1242,6 +1311,13 @@ if [ $PHASE12_OK -eq 1 ]; then
     echo "PASS  Phase 12 — NetworkStatus demo app"
 else
     echo "FAIL  Phase 12 — NetworkStatus demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE13_OK -eq 1 ]; then
+    echo "PASS  Phase 13 — MapView demo app"
+else
+    echo "FAIL  Phase 13 — MapView demo app"
     FINAL_EXIT=1
 fi
 

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -24,7 +24,7 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Int (Int32)
 import Data.Text (Text, pack)
 import HaskellMobile.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
-import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
+import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
@@ -192,6 +192,18 @@ createRenderedNode widget@(WebView config) = do
     Just action -> Bridge.setHandler nodeId Bridge.EventClick (actionId action)
     Nothing     -> pure ()
   pure (RenderedLeaf widget nodeId)
+createRenderedNode widget@(MapView config) = do
+  nodeId <- Bridge.createNode Bridge.NodeMapView
+  Bridge.setNumProp nodeId Bridge.PropMapLat (mvLatitude config)
+  Bridge.setNumProp nodeId Bridge.PropMapLon (mvLongitude config)
+  Bridge.setNumProp nodeId Bridge.PropMapZoom (mvZoom config)
+  Bridge.setNumProp nodeId Bridge.PropMapShowUserLoc
+    (if mvShowUserLocation config then 1.0 else 0.0)
+  case mvOnRegionChange config of
+    Just onChange -> Bridge.setHandler nodeId Bridge.EventTextChange
+                      (onChangeId onChange)
+    Nothing      -> pure ()
+  pure (RenderedLeaf widget nodeId)
 createRenderedNode widget@(Styled style child) = do
   childNode <- createRenderedNode child
   applyStyle (renderedNodeId childNode) style
@@ -226,6 +238,7 @@ sameNodeType (Row _)         (Row _)         = True
 sameNodeType (ScrollView _)  (ScrollView _)  = True
 sameNodeType (Image _)       (Image _)       = True
 sameNodeType (WebView _)     (WebView _)     = True
+sameNodeType (MapView _)     (MapView _)     = True
 sameNodeType (Styled _ _)    (Styled _ _)    = True
 sameNodeType _               _               = False
 

--- a/src/HaskellMobile/UIBridge.hs
+++ b/src/HaskellMobile/UIBridge.hs
@@ -41,6 +41,7 @@ data NodeType
   | NodeTextInput
   | NodeScrollView
   | NodeImage
+  | NodeMapView
   | NodeWebView
   deriving (Show, Eq, Enum, Bounded)
 
@@ -53,6 +54,7 @@ nodeTypeToInt NodeRow        = 3
 nodeTypeToInt NodeTextInput  = 4
 nodeTypeToInt NodeScrollView = 5
 nodeTypeToInt NodeImage      = 6
+nodeTypeToInt NodeMapView    = 7
 nodeTypeToInt NodeWebView    = 8
 
 -- | Property identifiers for 'setStrProp' and 'setNumProp'.
@@ -69,6 +71,10 @@ data PropId
   | PropImageFile
   | PropScaleType
   | PropWebViewUrl
+  | PropMapLat
+  | PropMapLon
+  | PropMapZoom
+  | PropMapShowUserLoc
   deriving (Show, Eq, Enum, Bounded)
 
 -- | Map a 'PropId' to its C integer code.
@@ -84,7 +90,11 @@ propIdToInt PropPadding       = 1
 propIdToInt PropInputType     = 2
 propIdToInt PropGravity       = 3
 propIdToInt PropScaleType     = 4
-propIdToInt PropWebViewUrl   = 6
+propIdToInt PropWebViewUrl    = 6
+propIdToInt PropMapLat        = 5
+propIdToInt PropMapLon        = 6
+propIdToInt PropMapZoom       = 7
+propIdToInt PropMapShowUserLoc = 8
 
 -- | Event types corresponding to @UI_EVENT_*@ in @UIBridge.h@.
 data EventType

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -20,6 +20,7 @@ module HaskellMobile.Widget
   , ImageSource(..)
   , ImageConfig(..)
   , WebViewConfig(..)
+  , MapViewConfig(..)
   , Widget(..)
   , WidgetStyle(..)
   , TextAlignment(..)
@@ -188,6 +189,22 @@ data WebViewConfig = WebViewConfig
     -- ^ Optional handle for a callback fired when a page finishes loading.
   } deriving (Show, Eq)
 
+-- | Configuration for an embedded map view.
+-- Uses native MapKit on iOS, placeholder on Android/watchOS.
+data MapViewConfig = MapViewConfig
+  { mvLatitude         :: Double
+    -- ^ Center latitude.
+  , mvLongitude        :: Double
+    -- ^ Center longitude.
+  , mvZoom             :: Double
+    -- ^ Zoom level (1–20).
+  , mvShowUserLocation :: Bool
+    -- ^ Whether to show the user's current location.
+  , mvOnRegionChange   :: Maybe OnChange
+    -- ^ Optional callback fired when the user pans\/zooms.
+    -- Receives @\"lat,lon,zoom\"@ text encoding the new center and zoom.
+  } deriving (Show, Eq)
+
 -- | A declarative description of a UI element.
 data Widget
   = Text TextConfig
@@ -206,6 +223,8 @@ data Widget
     -- ^ An image widget displaying resource, file, or raw data.
   | WebView WebViewConfig
     -- ^ An embedded web view loading a URL.
+  | MapView MapViewConfig
+    -- ^ An embedded map view (native MapKit on iOS, placeholder elsewhere).
   | Styled WidgetStyle Widget
     -- ^ Apply visual style overrides to a child widget.
   deriving (Show, Eq)

--- a/test/MapViewDemoMain.hs
+++ b/test/MapViewDemoMain.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Mobile entry point for the mapview-demo test app.
+--
+-- Used by the emulator and simulator MapView integration tests.
+-- Renders a MapView centered on Amsterdam with a region-change callback.
+module Main where
+
+import Data.Text (pack)
+import Foreign.Ptr (Ptr)
+import HaskellMobile
+  ( MobileApp(..)
+  , UserState
+  , OnChange
+  , startMobileApp
+  , platformLog
+  , loggingMobileContext
+  , AppContext
+  , newActionState
+  , runActionM
+  , createOnChange
+  )
+import HaskellMobile.Widget
+  ( MapViewConfig(..)
+  , TextConfig(..)
+  , Widget(..)
+  )
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "MapView demo app registered"
+  actionState <- newActionState
+  onRegionChange <- runActionM actionState $
+    createOnChange (\newRegion ->
+      platformLog ("MapView region changed: " <> newRegion))
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = mapViewDemoView onRegionChange
+    , maActionState = actionState
+    }
+
+-- | Builds a Column with a label and a MapView centered on Amsterdam.
+mapViewDemoView :: OnChange -> UserState -> IO Widget
+mapViewDemoView onRegionChange _userState =
+  pure $ Column
+    [ Text TextConfig { tcLabel = "MapView Demo", tcFontConfig = Nothing }
+    , MapView MapViewConfig
+        { mvLatitude         = 52.3676
+        , mvLongitude        = 4.9041
+        , mvZoom             = 12.0
+        , mvShowUserLocation = False
+        , mvOnRegionChange   = Just onRegionChange
+        }
+    ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -11,7 +11,7 @@ import HaskellMobile.BottomSheet (BottomSheetState)
 import HaskellMobile.Http (HttpState)
 import Test.Helpers (testApp)
 import Test.CoreTests (qcProps, unitTests, lifecycleTests, localeTests, i18nTests)
-import Test.WidgetTests (uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, styledTests, textAlignTests, colorTests)
+import Test.WidgetTests (uiTests, scrollViewTests, textInputTests, imageTests, webViewTests, mapViewTests, styledTests, textAlignTests, colorTests)
 import Test.PlatformTests (permissionTests, secureStorageTests, bleTests, dialogTests, authSessionTests, locationTests, bottomSheetTests, cameraTests, httpTests, networkStatusTests)
 import Test.AppContextTests (registrationTests, appContextTests, exceptionHandlerTests)
 import Test.ActionTests (actionTests, widgetEqTests, incrementalRenderTests)
@@ -42,6 +42,7 @@ tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiB
     , textInputTests
     , imageTests
     , webViewTests
+    , mapViewTests
     , styledTests
     , textAlignTests
     , colorTests

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -118,6 +118,7 @@ viewIsErrorWidget ctxPtr = do
     TextInput _              -> pure False
     Image _                  -> pure False
     WebView _                -> pure False
+    MapView _                -> pure False
     Row _                    -> pure False
     ScrollView _             -> pure False
     Styled _ _               -> pure False

--- a/test/Test/WidgetTests.hs
+++ b/test/Test/WidgetTests.hs
@@ -6,6 +6,7 @@ module Test.WidgetTests
   , textInputTests
   , imageTests
   , webViewTests
+  , mapViewTests
   , styledTests
   , textAlignTests
   , colorTests
@@ -31,6 +32,7 @@ import HaskellMobile.Widget
   , ImageConfig(..)
   , ImageSource(..)
   , InputType(..)
+  , MapViewConfig(..)
   , ResourceName(..)
   , ScaleType(..)
   , TextAlignment(..)
@@ -169,6 +171,7 @@ uiTests = testGroup "UI"
         TextInput _     -> assertFailure "expected Text, got TextInput"
         Image _         -> assertFailure "expected Text, got Image"
         WebView _       -> assertFailure "expected Text, got WebView"
+        MapView _       -> assertFailure "expected Text, got MapView"
         Row _           -> assertFailure "expected Text, got Row"
         ScrollView _    -> assertFailure "expected Text, got ScrollView"
         Styled _ _      -> assertFailure "expected Text, got Styled"
@@ -576,4 +579,65 @@ colorTests = testGroup "Colors"
   , testCase "colorToHex roundtrips through colorFromText" $ do
       let color = Color 255 128 0 255
       colorFromText (colorToHex color) @?= Just color
+  ]
+
+-- | Tests for the MapView widget.
+mapViewTests :: TestTree
+mapViewTests = testGroup "MapView"
+  [ testCase "MapView renders without error" $ do
+      ((), rs) <- withActions (pure ())
+      renderWidget rs $ MapView MapViewConfig
+        { mvLatitude = 52.3676, mvLongitude = 4.9041
+        , mvZoom = 12.0, mvShowUserLocation = False
+        , mvOnRegionChange = Nothing
+        }
+
+  , testCase "region change callback registered and fires via dispatchTextEvent" $ do
+      ref <- newIORef ("" :: String)
+      (changeHandle, rs) <- withActions $
+        createOnChange (\t -> modifyIORef' ref (const (show t)))
+      renderWidget rs $ MapView MapViewConfig
+        { mvLatitude = 52.3676, mvLongitude = 4.9041
+        , mvZoom = 12.0, mvShowUserLocation = False
+        , mvOnRegionChange = Just changeHandle
+        }
+      dispatchTextEvent rs (onChangeId changeHandle) "51.5074,-0.1278,10.0"
+      val <- readIORef ref
+      val @?= show ("51.5074,-0.1278,10.0" :: String)
+
+  , testCase "MapView without callback renders cleanly" $ do
+      ((), rs) <- withActions (pure ())
+      renderWidget rs $ MapView MapViewConfig
+        { mvLatitude = 0.0, mvLongitude = 0.0
+        , mvZoom = 1.0, mvShowUserLocation = True
+        , mvOnRegionChange = Nothing
+        }
+      -- Dispatching unknown ID should not crash
+      dispatchTextEvent rs 999 "ignored"
+
+  , testCase "MapView inside Column renders" $ do
+      ((), rs) <- withActions (pure ())
+      renderWidget rs $ Column
+        [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
+        , MapView MapViewConfig
+            { mvLatitude = 52.3676, mvLongitude = 4.9041
+            , mvZoom = 12.0, mvShowUserLocation = False
+            , mvOnRegionChange = Nothing
+            }
+        ]
+
+  , testCase "re-render preserves region change callback" $ do
+      ref <- newIORef ("" :: String)
+      (changeHandle, rs) <- withActions $
+        createOnChange (\t -> modifyIORef' ref (const (show t)))
+      let config = MapViewConfig
+            { mvLatitude = 52.3676, mvLongitude = 4.9041
+            , mvZoom = 12.0, mvShowUserLocation = False
+            , mvOnRegionChange = Just changeHandle
+            }
+      renderWidget rs $ MapView config
+      renderWidget rs $ MapView config { mvZoom = 14.0 }
+      dispatchTextEvent rs (onChangeId changeHandle) "52.3676,4.9041,14.0"
+      val <- readIORef ref
+      val @?= show ("52.3676,4.9041,14.0" :: String)
   ]

--- a/test/android/mapview.sh
+++ b/test/android/mapview.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Android mapview test: install mapview APK, assert MapView placeholder renders.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, MAPVIEW_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$MAPVIEW_APK" "mapview"
+wait_for_render "mapview"
+sleep 5
+collect_logcat "mapview"
+
+# MapView node created (type=7)
+assert_logcat "$LOGCAT_FILE" "createNode.*type=7" "createNode(type=7) MapView node"
+
+# Latitude property set
+assert_logcat "$LOGCAT_FILE" "setNumProp.*mapProp=5" "MapView latitude set"
+
+# Longitude property set
+assert_logcat "$LOGCAT_FILE" "setNumProp.*mapProp=6" "MapView longitude set"
+
+# Zoom property set
+assert_logcat "$LOGCAT_FILE" "setNumProp.*mapProp=7" "MapView zoom set"
+
+# Region change handler registered
+assert_logcat "$LOGCAT_FILE" "setHandler.*mapRegionChange" "setHandler registered for region change"
+
+# setRoot called
+assert_logcat "$LOGCAT_FILE" "setRoot" "setRoot called"
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/mapview.sh
+++ b/test/ios/mapview.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# iOS mapview test: install mapview app, launch, assert MKMapView renders.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, MAPVIEW_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$MAPVIEW_APP" "mapview"
+wait_for_render "mapview"
+sleep 5
+collect_logs "mapview"
+
+# MapView node created (type=7)
+assert_log "$FULL_LOG" "createNode\(type=7\)" "createNode(type=7) — MKMapView created"
+assert_log "$FULL_LOG" "setNumProp.*mapLat=" "MapView latitude set"
+assert_log "$FULL_LOG" "setNumProp.*mapLon=" "MapView longitude set"
+assert_log "$FULL_LOG" "setNumProp.*mapZoom=" "MapView zoom set"
+assert_log "$FULL_LOG" "setHandler.*mapRegionChange" "setHandler registered for region change"
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/mapview.sh
+++ b/test/watchos/mapview.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# watchOS mapview test: install mapview app, launch, assert placeholder renders.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, MAPVIEW_APP, WORK_DIR, LOG_SUBSYSTEM
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$MAPVIEW_APP" "mapview"
+wait_for_render "mapview"
+sleep 5
+collect_logs "mapview"
+
+# MapView node created (type=7)
+assert_log "$FULL_LOG" "createNode\(type=7\)" "createNode(type=7) — MapView node created"
+
+# Map properties set
+assert_log "$FULL_LOG" "setNumProp.*mapLat=" "MapView latitude set"
+assert_log "$FULL_LOG" "setNumProp.*mapZoom=" "MapView zoom set"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/watchos/HaskellMobile/ContentView.swift
+++ b/watchos/HaskellMobile/ContentView.swift
@@ -54,6 +54,17 @@ struct NodeView: View {
             }
         case 6: // UI_NODE_IMAGE
             ImageNodeView(node: node)
+        case 7: // UI_NODE_MAP_VIEW
+            VStack {
+                Text("Map")
+                    .font(.caption2)
+                Text(String(format: "%.4f, %.4f z%.1f",
+                            node.mapLatitude ?? 0.0,
+                            node.mapLongitude ?? 0.0,
+                            node.mapZoom ?? 1.0))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
         case 8: // UI_NODE_WEBVIEW
             Text("WebView not available")
                 .foregroundColor(.secondary)

--- a/watchos/HaskellMobile/WatchUIBridgeState.swift
+++ b/watchos/HaskellMobile/WatchUIBridgeState.swift
@@ -68,6 +68,17 @@ class WatchUIBridgeState: ObservableObject {
         case 4: // UI_PROP_SCALE_TYPE
             os_log("setNumProp(node=%d, scaleType=%.0f)", log: bridgeLog, type: .info, nodeId, value)
             node.scaleType = Int32(value)
+        case 5: // UI_PROP_MAP_LAT
+            os_log("setNumProp(node=%d, mapLat=%.6f)", log: bridgeLog, type: .info, nodeId, value)
+            node.mapLatitude = value
+        case 6: // UI_PROP_MAP_LON
+            os_log("setNumProp(node=%d, mapLon=%.6f)", log: bridgeLog, type: .info, nodeId, value)
+            node.mapLongitude = value
+        case 7: // UI_PROP_MAP_ZOOM
+            os_log("setNumProp(node=%d, mapZoom=%.1f)", log: bridgeLog, type: .info, nodeId, value)
+            node.mapZoom = value
+        case 8: // UI_PROP_MAP_SHOW_USER_LOC (no-op on watchOS)
+            os_log("setNumProp(node=%d, showUserLoc=%.0f)", log: bridgeLog, type: .info, nodeId, value)
         default:
             os_log("setNumProp: unknown propId %d", log: bridgeLog, type: .info, propId)
         }

--- a/watchos/HaskellMobile/WatchUINode.swift
+++ b/watchos/HaskellMobile/WatchUINode.swift
@@ -19,6 +19,9 @@ class WatchUINode: ObservableObject, Identifiable {
     @Published var imageFile: String?
     @Published var imageData: Data?
     @Published var scaleType: Int32 = 0
+    @Published var mapLatitude: Double?
+    @Published var mapLongitude: Double?
+    @Published var mapZoom: Double?
     @Published var children: [WatchUINode] = []
 
     init(id: Int32, nodeType: Int32) {


### PR DESCRIPTION
## Summary
- Adds `MapView` widget (UI_NODE_MAP_VIEW=7) with lat/lon/zoom/showUserLocation properties and optional region change callback
- **iOS**: Real `MKMapView` with `MKMapViewDelegate` for region change callbacks (MapKit framework, no API key)
- **Android**: `FrameLayout`+`TextView` placeholder (Google Maps requires Play Services AAR, incompatible with javac+d8 pipeline)
- **watchOS**: Placeholder text showing coordinates (MapKit `Map` requires watchOS 10+, deployment target is 9.0)
- 5 unit tests + integration test scripts wired into all 3 nix harnesses (emulator, simulator, watchOS simulator)

Closes #75

## Test plan
- [x] `cabal build` — zero warnings
- [x] `cabal test` — all 203 tests pass (including 5 new MapView tests)
- [ ] CI: nix-build job passes
- [ ] CI: android emulator integration tests pass
- [ ] CI: iOS simulator integration tests pass
- [ ] CI: watchOS simulator integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)