### PR TITLE
Add animation support with Animated widget wrapper

### DIFF
--- a/android/java/me/jappie/haskellmobile/HaskellMobileActivity.java
+++ b/android/java/me/jappie/haskellmobile/HaskellMobileActivity.java
@@ -39,6 +39,7 @@ import android.text.TextWatcher;
 import android.view.View;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.view.Choreographer;
 import android.widget.EditText;
 
 /**
@@ -83,6 +84,7 @@ public class HaskellMobileActivity extends Activity implements View.OnClickListe
     private native void onHttpResult(int requestId, int resultCode, int httpStatus,
                                       String headers, byte[] body);
     private native void onNetworkStatusChange(int connected, int transport);
+    private native void onAnimationFrame(double timestampMs);
 
     private static final String SECURE_PREFS_NAME = "haskell_mobile_secure_storage";
 
@@ -106,6 +108,9 @@ public class HaskellMobileActivity extends Activity implements View.OnClickListe
     private Thread audioRecordThread;
     private volatile boolean audioRecording;
     private int videoRequestId;
+
+    private Choreographer.FrameCallback animationFrameCallback;
+    private boolean animationLoopRunning;
 
     /**
      * Map a permission code (from PermissionBridge.h) to an Android permission string.
@@ -1043,5 +1048,40 @@ public class HaskellMobileActivity extends Activity implements View.OnClickListe
     public void onLowMemory() {
         super.onLowMemory();
         onLifecycleLowMemory();
+    }
+
+    /**
+     * Start the Choreographer-based animation frame loop. Called from native code via JNI.
+     * Posts a FrameCallback that calls onAnimationFrame with the timestamp in milliseconds,
+     * then re-posts itself for the next vsync.
+     */
+    public void startAnimationLoop() {
+        if (animationLoopRunning) return;
+        animationLoopRunning = true;
+
+        animationFrameCallback = new Choreographer.FrameCallback() {
+            @Override
+            public void doFrame(long frameTimeNanos) {
+                if (!animationLoopRunning) return;
+                double timestampMs = frameTimeNanos / 1_000_000.0;
+                onAnimationFrame(timestampMs);
+                if (animationLoopRunning) {
+                    Choreographer.getInstance().postFrameCallback(this);
+                }
+            }
+        };
+
+        Choreographer.getInstance().postFrameCallback(animationFrameCallback);
+    }
+
+    /**
+     * Stop the Choreographer-based animation frame loop. Called from native code via JNI.
+     */
+    public void stopAnimationLoop() {
+        animationLoopRunning = false;
+        if (animationFrameCallback != null) {
+            Choreographer.getInstance().removeFrameCallback(animationFrameCallback);
+            animationFrameCallback = null;
+        }
     }
 }

--- a/cbits/animation_bridge.c
+++ b/cbits/animation_bridge.c
@@ -1,0 +1,49 @@
+/*
+ * Platform-agnostic animation frame loop bridge dispatcher.
+ *
+ * Stores function pointers filled by the platform (Android/iOS).
+ * Each animation_* function delegates to the corresponding pointer.
+ * When no callbacks are registered (desktop), start_loop fires
+ * three synchronous test frames (0ms, 16.67ms, 1000ms) so that
+ * cabal test can verify the Haskell animation callback chain.
+ */
+
+#include "AnimationBridge.h"
+#include <stdio.h>
+
+/* Haskell FFI export (dispatches animation frame back to Haskell) */
+extern void haskellOnAnimationFrame(void *ctx, double timestampMs);
+
+static void (*g_start_loop_impl)(void *) = NULL;
+static void (*g_stop_loop_impl)(void) = NULL;
+
+void animation_register_impl(
+    void (*start_loop)(void *),
+    void (*stop_loop)(void))
+{
+    g_start_loop_impl = start_loop;
+    g_stop_loop_impl = stop_loop;
+}
+
+void animation_start_loop(void *ctx)
+{
+    if (g_start_loop_impl) {
+        g_start_loop_impl(ctx);
+        return;
+    }
+    /* Desktop stub: fire three synchronous test frames */
+    fprintf(stderr, "[AnimationBridge stub] animation_start_loop() -> firing test frames\n");
+    haskellOnAnimationFrame(ctx, 0.0);
+    haskellOnAnimationFrame(ctx, 16.67);
+    haskellOnAnimationFrame(ctx, 1000.0);
+}
+
+void animation_stop_loop(void)
+{
+    if (g_stop_loop_impl) {
+        g_stop_loop_impl();
+        return;
+    }
+    /* Desktop stub: no-op */
+    fprintf(stderr, "[AnimationBridge stub] animation_stop_loop() -> no-op\n");
+}

--- a/cbits/animation_bridge_android.c
+++ b/cbits/animation_bridge_android.c
@@ -1,0 +1,120 @@
+/*
+ * Android implementation of the animation frame loop bridge.
+ *
+ * Uses JNI to call Activity.startAnimationLoop() and
+ * Activity.stopAnimationLoop(). Compiled by NDK clang, not cabal.
+ *
+ * All functions run on the main/UI thread, the same thread that
+ * calls haskellRenderUI from Java.
+ */
+
+#include <jni.h>
+#include <android/log.h>
+#include "AnimationBridge.h"
+#include "JniBridge.h"
+
+#define LOG_TAG "AnimationBridge"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+/* Haskell FFI export (dispatches animation frame back to Haskell) */
+extern void haskellOnAnimationFrame(void *ctx, double timestampMs);
+
+/* ---- Global state (valid only on the UI thread) ---- */
+static JNIEnv  *g_env          = NULL;
+static jobject  g_activity      = NULL;   /* global ref to Activity */
+static void    *g_haskell_ctx   = NULL;   /* stored for async JNI callback */
+
+/* Cached JNI method IDs */
+static jmethodID g_method_startAnimationLoop;
+static jmethodID g_method_stopAnimationLoop;
+
+/* ---- Animation bridge implementations ---- */
+
+static void android_animation_start_loop(void *ctx)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("animation_start_loop: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("animation_start_loop()");
+    (*env)->CallVoidMethod(env, g_activity, g_method_startAnimationLoop);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("animation_start_loop: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+}
+
+static void android_animation_stop_loop(void)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("animation_stop_loop: bridge not initialized");
+        return;
+    }
+
+    LOGI("animation_stop_loop()");
+    (*env)->CallVoidMethod(env, g_activity, g_method_stopAnimationLoop);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("animation_stop_loop: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+}
+
+/* ---- Public API ---- */
+
+/*
+ * Set up the Android animation bridge. Called from jni_bridge.c
+ * during renderUI (after the Activity is available).
+ * Resolves JNI method IDs and registers callbacks with the
+ * platform-agnostic dispatcher.
+ */
+void setup_android_animation_bridge(JNIEnv *env, jobject activity, void *haskellCtx)
+{
+    g_env = env;
+    g_haskell_ctx = haskellCtx;
+
+    if (!g_activity) {
+        g_activity = (*env)->NewGlobalRef(env, activity);
+    }
+
+    jclass actClass = (*env)->GetObjectClass(env, activity);
+
+    g_method_startAnimationLoop = (*env)->GetMethodID(env, actClass,
+        "startAnimationLoop", "()V");
+    g_method_stopAnimationLoop = (*env)->GetMethodID(env, actClass,
+        "stopAnimationLoop", "()V");
+
+    /* Clean up local reference */
+    (*env)->DeleteLocalRef(env, actClass);
+
+    if (!g_method_startAnimationLoop || !g_method_stopAnimationLoop) {
+        LOGE("Failed to resolve animation JNI method IDs — animation bridge disabled");
+        (*env)->ExceptionClear(env);
+        return;
+    }
+
+    /* Clear any unexpected pending exception before continuing */
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("Unexpected JNI exception after animation method resolution");
+        (*env)->ExceptionClear(env);
+    }
+
+    animation_register_impl(android_animation_start_loop,
+                             android_animation_stop_loop);
+
+    LOGI("Android animation bridge initialized");
+}
+
+/* ---- JNI callback from Java animation frame ---- */
+
+JNIEXPORT void JNICALL
+JNI_METHOD(onAnimationFrame)(JNIEnv *env, jobject thiz,
+                              jdouble timestampMs)
+{
+    g_env = env;
+    haskellOnAnimationFrame(g_haskell_ctx, (double)timestampMs);
+}

--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -23,6 +23,7 @@
 #include "BottomSheetBridge.h"
 #include "HttpBridge.h"
 #include "NetworkStatusBridge.h"
+#include "AnimationBridge.h"
 
 /* Runs the user's Haskell main via RTS API (cbits/run_main.c).
  * Returns the opaque AppContext pointer. */
@@ -60,6 +61,7 @@ extern void haskellOnHttpResult(void *ctx, int32_t requestId,
                                  const char *headers,
                                  const char *body, int32_t bodyLen);
 extern void haskellOnNetworkStatusChange(void *ctx, int connected, int transport);
+extern void haskellOnAnimationFrame(void *ctx, double timestampMs);
 
 /* Android UI bridge (from ui_bridge_android.c) */
 extern void setup_android_ui_bridge(JNIEnv *env, jobject activity, void *haskellCtx);
@@ -94,6 +96,9 @@ extern void setup_android_http_bridge(JNIEnv *env, jobject activity, void *haske
 
 /* Android network status bridge (from network_status_android.c) */
 extern void setup_android_network_status_bridge(JNIEnv *env, jobject activity, void *haskellCtx);
+
+/* Android animation bridge (from animation_bridge_android.c) */
+extern void setup_android_animation_bridge(JNIEnv *env, jobject activity, void *haskellCtx);
 
 /* Lifecycle event codes (must match HaskellMobile.h) */
 #define LIFECYCLE_CREATE     0
@@ -175,6 +180,7 @@ JNI_METHOD(renderUI)(JNIEnv *env, jobject thiz)
     setup_android_bottom_sheet_bridge(env, thiz, g_haskell_ctx);
     setup_android_http_bridge(env, thiz, g_haskell_ctx);
     setup_android_network_status_bridge(env, thiz, g_haskell_ctx);
+    setup_android_animation_bridge(env, thiz, g_haskell_ctx);
     haskellRenderUI(g_haskell_ctx);
 }
 

--- a/haskell-mobile.cabal
+++ b/haskell-mobile.cabal
@@ -62,6 +62,7 @@ library
   exposed-modules:
       HaskellMobile
       HaskellMobile.Action
+      HaskellMobile.Animation
       HaskellMobile.AppContext
       HaskellMobile.Types
       HaskellMobile.Lifecycle
@@ -102,6 +103,7 @@ library
       cbits/bottom_sheet_bridge.c
       cbits/http_bridge.c
       cbits/network_status_bridge.c
+      cbits/animation_bridge.c
   include-dirs:
       include
 
@@ -116,6 +118,7 @@ test-suite unit
       Test.PlatformTests
       Test.AppContextTests
       Test.ActionTests
+      Test.AnimationTests
   ghc-options: -Wno-unused-packages -threaded -rtsopts "-with-rtsopts=-N -M7G -T -Iw10"
   hs-source-dirs:
       test

--- a/include/AnimationBridge.h
+++ b/include/AnimationBridge.h
@@ -1,0 +1,30 @@
+#ifndef ANIMATION_BRIDGE_H
+#define ANIMATION_BRIDGE_H
+
+/*
+ * Platform-agnostic animation frame loop bridge.
+ *
+ * Haskell calls animation_start_loop / animation_stop_loop through
+ * these wrappers.  When no platform callbacks are registered (desktop),
+ * start_loop fires three synchronous test frames (0ms, 16.67ms, 1000ms)
+ * so that cabal test can verify the callback chain.
+ *
+ * On Android/iOS the platform-specific setup function fills in real
+ * implementations via animation_register_impl().
+ */
+
+/* Start the platform animation frame loop.
+ * Each vsync frame calls haskellOnAnimationFrame(ctx, timestampMs).
+ * ctx is the opaque Haskell context pointer. */
+void animation_start_loop(void *ctx);
+
+/* Stop the platform animation frame loop. */
+void animation_stop_loop(void);
+
+/* Register platform-specific implementations.
+ * Called by platform setup functions (setup_android_animation_bridge, etc). */
+void animation_register_impl(
+    void (*start_loop)(void *),
+    void (*stop_loop)(void));
+
+#endif /* ANIMATION_BRIDGE_H */

--- a/include/HaskellMobile.h
+++ b/include/HaskellMobile.h
@@ -191,4 +191,11 @@ void haskellOnHttpResult(void *ctx, int32_t requestId,
  * ctx must be a pointer returned by haskellRunMain(). */
 void haskellOnBottomSheetResult(void *ctx, int32_t requestId, int32_t actionCode);
 
+/* Dispatch an animation frame from native code back to Haskell.
+ * Ticks all active tweens, applies interpolated properties, then
+ * re-renders the UI.
+ * timestampMs: frame timestamp in milliseconds.
+ * ctx must be a pointer returned by haskellRunMain(). */
+void haskellOnAnimationFrame(void *ctx, double timestampMs);
+
 #endif /* HASKELL_MOBILE_H */

--- a/ios/HaskellMobile/AnimationBridgeIOS.m
+++ b/ios/HaskellMobile/AnimationBridgeIOS.m
@@ -1,0 +1,89 @@
+/*
+ * iOS implementation of the animation frame loop bridge.
+ *
+ * Uses CADisplayLink from QuartzCore to receive vsync frames.
+ * Compiled by Xcode, not GHC.
+ *
+ * All Haskell callbacks are dispatched on the main thread.
+ */
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/CADisplayLink.h>
+#import <os/log.h>
+#include "AnimationBridge.h"
+
+#define LOG_TAG "AnimationBridge"
+static os_log_t g_log;
+
+#define LOGI(fmt, ...) os_log_info(g_log, fmt, ##__VA_ARGS__)
+#define LOGE(fmt, ...) os_log_error(g_log, fmt, ##__VA_ARGS__)
+
+/* Haskell FFI export (dispatches animation frame back to Haskell) */
+extern void haskellOnAnimationFrame(void *ctx, double timestampMs);
+
+/* ---- AnimationFrameHandler (CADisplayLink target) ---- */
+
+@interface AnimationFrameHandler : NSObject
+@property (nonatomic, assign) void *haskellCtx;
+@property (nonatomic, strong) CADisplayLink *displayLink;
+- (void)onFrame:(CADisplayLink *)link;
+@end
+
+@implementation AnimationFrameHandler
+
+- (void)onFrame:(CADisplayLink *)link {
+    double timestampMs = link.timestamp * 1000.0;
+    haskellOnAnimationFrame(self.haskellCtx, timestampMs);
+}
+
+@end
+
+/* ---- Global state ---- */
+static AnimationFrameHandler *g_handler = nil;
+
+/* ---- Animation bridge implementations ---- */
+
+static void ios_animation_start_loop(void *ctx)
+{
+    LOGI("ios_animation_start_loop()");
+
+    /* Stop any existing loop */
+    if (g_handler) {
+        [g_handler.displayLink invalidate];
+        g_handler = nil;
+    }
+
+    g_handler = [[AnimationFrameHandler alloc] init];
+    g_handler.haskellCtx = ctx;
+    g_handler.displayLink = [CADisplayLink displayLinkWithTarget:g_handler
+                                                        selector:@selector(onFrame:)];
+    [g_handler.displayLink addToRunLoop:[NSRunLoop mainRunLoop]
+                                forMode:NSRunLoopCommonModes];
+    LOGI("Animation loop started");
+}
+
+static void ios_animation_stop_loop(void)
+{
+    LOGI("ios_animation_stop_loop()");
+
+    if (g_handler) {
+        [g_handler.displayLink invalidate];
+        g_handler = nil;
+    }
+}
+
+/* ---- Public API ---- */
+
+/*
+ * Set up the iOS animation bridge. Called from Swift during initialisation.
+ * Registers callbacks with the platform-agnostic dispatcher.
+ */
+void setup_ios_animation_bridge(void *haskellCtx)
+{
+    g_log = os_log_create("me.jappie.haskellmobile", LOG_TAG);
+
+    animation_register_impl(ios_animation_start_loop,
+                             ios_animation_stop_loop);
+
+    LOGI("iOS animation bridge initialized");
+}

--- a/ios/HaskellMobile/HaskellBridge.swift
+++ b/ios/HaskellMobile/HaskellBridge.swift
@@ -30,6 +30,7 @@ class HaskellBridge {
         setup_ios_bottom_sheet_bridge(context)
         setup_ios_http_bridge(context)
         setup_ios_network_status_bridge(context)
+        setup_ios_animation_bridge(context)
     }
 
     /// Call Haskell's haskellGreet and return the result as a Swift String.

--- a/ios/HaskellMobile/HaskellMobile-Bridging-Header.h
+++ b/ios/HaskellMobile/HaskellMobile-Bridging-Header.h
@@ -42,3 +42,7 @@ void setup_ios_http_bridge(void *haskellCtx);
 #include "NetworkStatusBridge.h"
 /* iOS network status bridge setup — called from Swift during initialisation */
 void setup_ios_network_status_bridge(void *haskellCtx);
+
+#include "AnimationBridge.h"
+/* iOS animation bridge setup — called from Swift during initialisation */
+void setup_ios_animation_bridge(void *haskellCtx);

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,4 +30,4 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: HaskellMobile/HaskellMobile-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHaskellMobile", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit", "-framework", "QuartzCore"]

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -218,6 +218,17 @@ let
     name = "haskell-mobile-mapview-apk";
   };
 
+  animationAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/AnimationDemoMain.hs;
+  };
+  animationApk = lib.mkApk {
+    sharedLibs = [{ lib = animationAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "haskell-mobile-animation.apk";
+    name = "haskell-mobile-animation-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -273,6 +284,7 @@ BOTTOM_SHEET_APK="${bottomSheetApk}/haskell-mobile-bottomsheet.apk"
 HTTP_APK="${httpApk}/haskell-mobile-http.apk"
 NETWORK_STATUS_APK="${networkStatusApk}/haskell-mobile-networkstatus.apk"
 MAPVIEW_APK="${mapviewApk}/haskell-mobile-mapview.apk"
+ANIMATION_APK="${animationApk}/haskell-mobile-animation.apk"
 PACKAGE="me.jappie.haskellmobile"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -299,7 +311,8 @@ for so_path in \
     "${bottomSheetAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${httpAndroid}/lib/${abiDir}/libhaskellmobile.so" \
     "${networkStatusAndroid}/lib/${abiDir}/libhaskellmobile.so" \
-    "${mapviewAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
+    "${mapviewAndroid}/lib/${abiDir}/libhaskellmobile.so" \
+    "${animationAndroid}/lib/${abiDir}/libhaskellmobile.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -365,6 +378,7 @@ PHASE9_OK=0
 PHASE10_OK=0
 PHASE11_OK=0
 PHASE12_OK=0
+PHASE13_OK=0
 
 cleanup() {
     echo ""
@@ -481,7 +495,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -495,6 +509,7 @@ PHASE9_EXIT=0
 PHASE10_EXIT=0
 PHASE11_EXIT=0
 PHASE12_EXIT=0
+PHASE13_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -569,6 +584,8 @@ echo "--- http ---"
 run_with_retry "http" bash "$TEST_SCRIPTS/android/http.sh" || PHASE12_EXIT=1
 echo "--- networkstatus ---"
 run_with_retry "networkstatus" bash "$TEST_SCRIPTS/android/network_status.sh" || PHASE7_EXIT=1
+echo "--- animation ---"
+run_with_retry "animation" bash "$TEST_SCRIPTS/android/animation.sh" || PHASE13_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -689,6 +706,16 @@ else
     echo "PHASE 12 FAILED"
 fi
 
+if [ $PHASE13_EXIT -eq 0 ]; then
+    PHASE13_OK=1
+    echo ""
+    echo "PHASE 13 PASSED"
+else
+    PHASE13_OK=0
+    echo ""
+    echo "PHASE 13 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -780,6 +807,13 @@ if [ $PHASE12_OK -eq 1 ]; then
     echo "PASS  Phase 12 — HTTP demo app"
 else
     echo "FAIL  Phase 12 — HTTP demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE13_OK -eq 1 ]; then
+    echo "PASS  Phase 13 — Animation demo app"
+else
+    echo "FAIL  Phase 13 — Animation demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -288,6 +288,7 @@ in {
         cp ${haskellMobileSrc}/cbits/bottom_sheet_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/http_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/network_status_bridge.c cbits/
+        cp ${haskellMobileSrc}/cbits/animation_bridge.c cbits/
 
         # Step 4: Compile Haskell to shared library with cross-GHC.
         # Discover library paths dynamically — hash suffixes vary across nixpkgs.
@@ -349,6 +350,7 @@ in {
           cbits/bottom_sheet_bridge.c \
           cbits/http_bridge.c \
           cbits/network_status_bridge.c \
+          cbits/animation_bridge.c \
           -optl-L${androidPkgs.gmp}/lib \
           -optl-L${androidPkgs.libffi}/lib \
           -optl-lffi \
@@ -613,6 +615,7 @@ in {
         cp ${haskellMobileSrc}/cbits/bottom_sheet_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/http_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/network_status_bridge.c cbits/
+        cp ${haskellMobileSrc}/cbits/animation_bridge.c cbits/
 
         ghc -staticlib \
           -O2 \
@@ -652,6 +655,7 @@ in {
           cbits/bottom_sheet_bridge.c \
           cbits/http_bridge.c \
           cbits/network_status_bridge.c \
+          cbits/animation_bridge.c \
           Main.hs \
           HaskellMobile.hs
       '';
@@ -679,6 +683,7 @@ in {
         cp ${haskellMobileSrc}/include/BottomSheetBridge.h $out/include/BottomSheetBridge.h
         cp ${haskellMobileSrc}/include/HttpBridge.h $out/include/HttpBridge.h
         cp ${haskellMobileSrc}/include/NetworkStatusBridge.h $out/include/NetworkStatusBridge.h
+        cp ${haskellMobileSrc}/include/AnimationBridge.h $out/include/AnimationBridge.h
       '';
     };
 
@@ -739,6 +744,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${iosLib}/include/BottomSheetBridge.h $out/share/ios/include/
         cp ${iosLib}/include/HttpBridge.h $out/share/ios/include/
         cp ${iosLib}/include/NetworkStatusBridge.h $out/share/ios/include/
+        cp ${iosLib}/include/AnimationBridge.h $out/share/ios/include/
         ${patchProjectYml}
       '';
 
@@ -818,6 +824,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${haskellMobileSrc}/cbits/bottom_sheet_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/http_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/network_status_bridge.c cbits/
+        cp ${haskellMobileSrc}/cbits/animation_bridge.c cbits/
 
         ghc -staticlib \
           -O2 \
@@ -857,6 +864,7 @@ open(sys.argv[1], "w").write(yml)
           cbits/bottom_sheet_bridge.c \
           cbits/http_bridge.c \
           cbits/network_status_bridge.c \
+          cbits/animation_bridge.c \
           Main.hs \
           HaskellMobile.hs
       '';
@@ -884,6 +892,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${haskellMobileSrc}/include/BottomSheetBridge.h $out/include/BottomSheetBridge.h
         cp ${haskellMobileSrc}/include/HttpBridge.h $out/include/HttpBridge.h
         cp ${haskellMobileSrc}/include/NetworkStatusBridge.h $out/include/NetworkStatusBridge.h
+        cp ${haskellMobileSrc}/include/AnimationBridge.h $out/include/AnimationBridge.h
       '';
     };
 
@@ -919,6 +928,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${watchosLib}/include/BottomSheetBridge.h $out/share/watchos/include/
         cp ${watchosLib}/include/HttpBridge.h $out/share/watchos/include/
         cp ${watchosLib}/include/NetworkStatusBridge.h $out/share/watchos/include/
+        cp ${watchosLib}/include/AnimationBridge.h $out/share/watchos/include/
       '';
 
       installPhase = "true";

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -213,6 +213,14 @@ in {
           -o network_status_android.o \
           ${haskellMobileSrc}/cbits/network_status_android.c
 
+        ${ndkCc} -c -fPIC \
+          -DJNI_PACKAGE=me_jappie_haskellmobile \
+          -I${sysroot}/usr/include \
+          -I$RTS_INCLUDE \
+          -I${haskellMobileSrc}/include \
+          -o animation_bridge_android.o \
+          ${haskellMobileSrc}/cbits/animation_bridge_android.c
+
         # Compile extra JNI bridge sources (consumer-specific JNI methods)
         ${builtins.concatStringsSep "\n" (builtins.genList (i:
           let src = builtins.elemAt extraJniBridge i;
@@ -358,6 +366,7 @@ in {
           -optl$(pwd)/bottom_sheet_android.o \
           -optl$(pwd)/http_bridge_android.o \
           -optl$(pwd)/network_status_android.o \
+          -optl$(pwd)/animation_bridge_android.o \
           ${builtins.concatStringsSep " " (builtins.genList (i: "-optl$(pwd)/extra_jni_${toString i}.o") (builtins.length extraJniBridge))} \
           ${builtins.concatStringsSep " " (map (o: "-optl${o}") extraLinkObjects)} \
           -optl-Wl,-u,haskellRunMain \

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -208,6 +208,17 @@ let
     name = "haskell-mobile-mapview-simulator-app";
   };
 
+  animationIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/AnimationDemoMain.hs;
+    simulator = true;
+  };
+  animationSimApp = lib.mkSimulatorApp {
+    iosLib = animationIos;
+    iosSrc = ../ios;
+    name = "haskell-mobile-animation-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -245,6 +256,7 @@ BOTTOM_SHEET_SHARE_DIR="${bottomSheetSimApp}/share/ios"
 HTTP_SHARE_DIR="${httpSimApp}/share/ios"
 NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/ios"
 MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/ios"
+ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -264,6 +276,7 @@ PHASE9_OK=0
 PHASE10_OK=0
 PHASE11_OK=0
 PHASE12_OK=0
+PHASE13_OK=0
 
 cleanup() {
     echo ""
@@ -346,6 +359,7 @@ cp "$COUNTER_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/counter/include/"
+cp "$COUNTER_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/counter/include/"
 cp -r "$COUNTER_SHARE_DIR/HaskellMobile" "$WORK_DIR/counter/"
 cp "$COUNTER_SHARE_DIR/project.yml" "$WORK_DIR/counter/"
 chmod -R u+w "$WORK_DIR/counter"
@@ -390,6 +404,7 @@ cp "$SCROLL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/scroll/include/"
+cp "$SCROLL_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/scroll/include/"
 cp -r "$SCROLL_SHARE_DIR/HaskellMobile" "$WORK_DIR/scroll/"
 cp "$SCROLL_SHARE_DIR/project.yml" "$WORK_DIR/scroll/"
 chmod -R u+w "$WORK_DIR/scroll"
@@ -434,6 +449,7 @@ cp "$TEXTINPUT_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/textinput/include/"
+cp "$TEXTINPUT_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/textinput/include/"
 cp -r "$TEXTINPUT_SHARE_DIR/HaskellMobile" "$WORK_DIR/textinput/"
 cp "$TEXTINPUT_SHARE_DIR/project.yml" "$WORK_DIR/textinput/"
 chmod -R u+w "$WORK_DIR/textinput"
@@ -478,6 +494,7 @@ cp "$PERMISSION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/permission/include/
 cp "$PERMISSION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/permission/include/"
 cp "$PERMISSION_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/permission/include/"
 cp "$PERMISSION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/permission/include/"
+cp "$PERMISSION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/permission/include/"
 cp -r "$PERMISSION_SHARE_DIR/HaskellMobile" "$WORK_DIR/permission/"
 cp "$PERMISSION_SHARE_DIR/project.yml" "$WORK_DIR/permission/"
 chmod -R u+w "$WORK_DIR/permission"
@@ -522,6 +539,7 @@ cp "$SECURE_STORAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/securestorage/i
 cp "$SECURE_STORAGE_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/securestorage/include/"
+cp "$SECURE_STORAGE_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/securestorage/include/"
 cp -r "$SECURE_STORAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/securestorage/"
 cp "$SECURE_STORAGE_SHARE_DIR/project.yml" "$WORK_DIR/securestorage/"
 chmod -R u+w "$WORK_DIR/securestorage"
@@ -566,6 +584,7 @@ cp "$IMAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/image/include/"
+cp "$IMAGE_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/image/include/"
 cp -r "$IMAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/image/"
 cp "$IMAGE_SHARE_DIR/project.yml" "$WORK_DIR/image/"
 chmod -R u+w "$WORK_DIR/image"
@@ -610,6 +629,7 @@ cp "$NODEPOOL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/nodepool/include/"
+cp "$NODEPOOL_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/nodepool/include/"
 cp -r "$NODEPOOL_SHARE_DIR/HaskellMobile" "$WORK_DIR/nodepool/"
 cp "$NODEPOOL_SHARE_DIR/project.yml" "$WORK_DIR/nodepool/"
 chmod -R u+w "$WORK_DIR/nodepool"
@@ -654,6 +674,7 @@ cp "$BLE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/ble/include/"
+cp "$BLE_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/ble/include/"
 cp -r "$BLE_SHARE_DIR/HaskellMobile" "$WORK_DIR/ble/"
 cp "$BLE_SHARE_DIR/project.yml" "$WORK_DIR/ble/"
 chmod -R u+w "$WORK_DIR/ble"
@@ -698,6 +719,7 @@ cp "$DIALOG_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/dialog/include/"
+cp "$DIALOG_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/dialog/include/"
 cp -r "$DIALOG_SHARE_DIR/HaskellMobile" "$WORK_DIR/dialog/"
 cp "$DIALOG_SHARE_DIR/project.yml" "$WORK_DIR/dialog/"
 chmod -R u+w "$WORK_DIR/dialog"
@@ -742,6 +764,7 @@ cp "$LOCATION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/location/include/"
+cp "$LOCATION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/location/include/"
 cp -r "$LOCATION_SHARE_DIR/HaskellMobile" "$WORK_DIR/location/"
 cp "$LOCATION_SHARE_DIR/project.yml" "$WORK_DIR/location/"
 chmod -R u+w "$WORK_DIR/location"
@@ -786,6 +809,7 @@ cp "$WEBVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/webview/include/"
 cp -r "$WEBVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/webview/"
 cp "$WEBVIEW_SHARE_DIR/project.yml" "$WORK_DIR/webview/"
 chmod -R u+w "$WORK_DIR/webview"
@@ -830,6 +854,7 @@ cp "$AUTH_SESSION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/authsession/inclu
 cp "$AUTH_SESSION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/authsession/include/"
+cp "$AUTH_SESSION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/authsession/include/"
 cp -r "$AUTH_SESSION_SHARE_DIR/HaskellMobile" "$WORK_DIR/authsession/"
 cp "$AUTH_SESSION_SHARE_DIR/project.yml" "$WORK_DIR/authsession/"
 chmod -R u+w "$WORK_DIR/authsession"
@@ -874,6 +899,7 @@ cp "$CAMERA_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/camera/include/"
 cp "$CAMERA_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/camera/include/"
 cp "$CAMERA_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/camera/include/"
 cp "$CAMERA_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/camera/include/"
 cp -r "$CAMERA_SHARE_DIR/HaskellMobile" "$WORK_DIR/camera/"
 cp "$CAMERA_SHARE_DIR/project.yml" "$WORK_DIR/camera/"
 chmod -R u+w "$WORK_DIR/camera"
@@ -918,6 +944,7 @@ cp "$BOTTOM_SHEET_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/bottomsheet/inclu
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/bottomsheet/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/bottomsheet/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/bottomsheet/include/"
 cp -r "$BOTTOM_SHEET_SHARE_DIR/HaskellMobile" "$WORK_DIR/bottomsheet/"
 cp "$BOTTOM_SHEET_SHARE_DIR/project.yml" "$WORK_DIR/bottomsheet/"
 chmod -R u+w "$WORK_DIR/bottomsheet"
@@ -962,6 +989,7 @@ cp "$HTTP_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/http/include/"
 cp "$HTTP_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/http/include/"
 cp "$HTTP_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/http/include/"
 cp "$HTTP_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/http/include/"
+cp "$HTTP_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/http/include/"
 cp -r "$HTTP_SHARE_DIR/HaskellMobile" "$WORK_DIR/http/"
 cp "$HTTP_SHARE_DIR/project.yml" "$WORK_DIR/http/"
 chmod -R u+w "$WORK_DIR/http"
@@ -1006,6 +1034,7 @@ cp "$NETWORK_STATUS_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/networkstatus/i
 cp "$NETWORK_STATUS_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/networkstatus/include/"
 cp "$NETWORK_STATUS_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/networkstatus/include/"
 cp "$NETWORK_STATUS_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/networkstatus/include/"
+cp "$NETWORK_STATUS_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/networkstatus/include/"
 cp -r "$NETWORK_STATUS_SHARE_DIR/HaskellMobile" "$WORK_DIR/networkstatus/"
 cp "$NETWORK_STATUS_SHARE_DIR/project.yml" "$WORK_DIR/networkstatus/"
 chmod -R u+w "$WORK_DIR/networkstatus"
@@ -1050,6 +1079,7 @@ cp "$MAPVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/mapview/include/"
 cp "$MAPVIEW_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/mapview/include/"
 cp "$MAPVIEW_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/mapview/include/"
 cp "$MAPVIEW_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/mapview/include/"
 cp -r "$MAPVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/mapview/"
 cp "$MAPVIEW_SHARE_DIR/project.yml" "$WORK_DIR/mapview/"
 chmod -R u+w "$WORK_DIR/mapview"
@@ -1077,6 +1107,51 @@ if [ -z "$MAPVIEW_APP" ]; then
     exit 1
 fi
 echo "MapView app: $MAPVIEW_APP"
+
+# --- Stage and build animation demo app ---
+echo "=== Staging animation demo app ==="
+mkdir -p "$WORK_DIR/animation/lib" "$WORK_DIR/animation/include"
+cp "$ANIMATION_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/animation/lib/"
+cp "$ANIMATION_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/animation/include/"
+cp -r "$ANIMATION_SHARE_DIR/HaskellMobile" "$WORK_DIR/animation/"
+cp "$ANIMATION_SHARE_DIR/project.yml" "$WORK_DIR/animation/"
+chmod -R u+w "$WORK_DIR/animation"
+
+echo "=== Generating animation Xcode project ==="
+cd "$WORK_DIR/animation"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building animation demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/animation-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+ANIMATION_APP=$(find "$WORK_DIR/animation-build" -name "*.app" -type d | head -1)
+if [ -z "$ANIMATION_APP" ]; then
+    echo "ERROR: Could not find animation .app bundle"
+    exit 1
+fi
+echo "Animation app: $ANIMATION_APP"
 
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
@@ -1139,7 +1214,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1153,6 +1228,7 @@ PHASE9_EXIT=0
 PHASE10_EXIT=0
 PHASE11_EXIT=0
 PHASE12_EXIT=0
+PHASE13_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1227,6 +1303,8 @@ echo "--- http ---"
 run_with_retry "http" bash "$TEST_SCRIPTS/ios/http.sh" || PHASE12_EXIT=1
 echo "--- networkstatus ---"
 run_with_retry "networkstatus" bash "$TEST_SCRIPTS/ios/network_status.sh" || PHASE7_EXIT=1
+echo "--- animation ---"
+run_with_retry "animation" bash "$TEST_SCRIPTS/ios/animation.sh" || PHASE13_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1347,6 +1425,16 @@ else
     echo "PHASE 12 FAILED"
 fi
 
+if [ $PHASE13_EXIT -eq 0 ]; then
+    PHASE13_OK=1
+    echo ""
+    echo "PHASE 13 PASSED"
+else
+    PHASE13_OK=0
+    echo ""
+    echo "PHASE 13 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1438,6 +1526,13 @@ if [ $PHASE12_OK -eq 1 ]; then
     echo "PASS  Phase 12 — HTTP demo app"
 else
     echo "FAIL  Phase 12 — HTTP demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE13_OK -eq 1 ]; then
+    echo "PASS  Phase 13 — Animation demo app"
+else
+    echo "FAIL  Phase 13 — Animation demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -187,6 +187,17 @@ let
     name = "haskell-mobile-watchos-mapview-simulator-app";
   };
 
+  animationWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/AnimationDemoMain.hs;
+    simulator = true;
+  };
+  animationSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = animationWatchos;
+    watchosSrc = ../watchos;
+    name = "haskell-mobile-watchos-animation-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -222,6 +233,7 @@ CAMERA_SHARE_DIR="${cameraSimApp}/share/watchos"
 BOTTOM_SHEET_SHARE_DIR="${bottomSheetSimApp}/share/watchos"
 NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/watchos"
 MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/watchos"
+ANIMATION_SHARE_DIR="${animationSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -241,6 +253,7 @@ PHASE9_OK=0
 PHASE10_OK=0
 PHASE11_OK=0
 PHASE12_OK=0
+PHASE14_OK=0
 
 cleanup() {
     echo ""
@@ -320,6 +333,7 @@ cp "$COUNTER_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/counter/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/counter/include/"
+cp "$COUNTER_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/counter/include/"
 cp -r "$COUNTER_SHARE_DIR/HaskellMobile" "$WORK_DIR/counter/"
 cp "$COUNTER_SHARE_DIR/project.yml" "$WORK_DIR/counter/"
 chmod -R u+w "$WORK_DIR/counter"
@@ -363,6 +377,7 @@ cp "$SCROLL_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/scroll/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/scroll/include/"
 cp "$SCROLL_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/scroll/include/"
+cp "$SCROLL_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/scroll/include/"
 cp -r "$SCROLL_SHARE_DIR/HaskellMobile" "$WORK_DIR/scroll/"
 cp "$SCROLL_SHARE_DIR/project.yml" "$WORK_DIR/scroll/"
 chmod -R u+w "$WORK_DIR/scroll"
@@ -406,6 +421,7 @@ cp "$TEXTINPUT_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/textinput/inclu
 cp "$TEXTINPUT_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/textinput/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/textinput/include/"
 cp "$TEXTINPUT_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/textinput/include/"
+cp "$TEXTINPUT_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/textinput/include/"
 cp -r "$TEXTINPUT_SHARE_DIR/HaskellMobile" "$WORK_DIR/textinput/"
 cp "$TEXTINPUT_SHARE_DIR/project.yml" "$WORK_DIR/textinput/"
 chmod -R u+w "$WORK_DIR/textinput"
@@ -449,6 +465,7 @@ cp "$IMAGE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/image/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/image/include/"
 cp "$IMAGE_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/image/include/"
+cp "$IMAGE_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/image/include/"
 cp -r "$IMAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/image/"
 cp "$IMAGE_SHARE_DIR/project.yml" "$WORK_DIR/image/"
 chmod -R u+w "$WORK_DIR/image"
@@ -492,6 +509,7 @@ cp "$SECURE_STORAGE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/securestor
 cp "$SECURE_STORAGE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/securestorage/include/"
 cp "$SECURE_STORAGE_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/securestorage/include/"
+cp "$SECURE_STORAGE_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/securestorage/include/"
 cp -r "$SECURE_STORAGE_SHARE_DIR/HaskellMobile" "$WORK_DIR/securestorage/"
 cp "$SECURE_STORAGE_SHARE_DIR/project.yml" "$WORK_DIR/securestorage/"
 chmod -R u+w "$WORK_DIR/securestorage"
@@ -534,6 +552,7 @@ cp "$NODEPOOL_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/nodepool/include
 cp "$NODEPOOL_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/nodepool/include/"
 cp "$NODEPOOL_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/nodepool/include/"
+cp "$NODEPOOL_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/nodepool/include/"
 cp -r "$NODEPOOL_SHARE_DIR/HaskellMobile" "$WORK_DIR/nodepool/"
 cp "$NODEPOOL_SHARE_DIR/project.yml" "$WORK_DIR/nodepool/"
 chmod -R u+w "$WORK_DIR/nodepool"
@@ -577,6 +596,7 @@ cp "$BLE_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/ble/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/ble/include/"
 cp "$BLE_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/ble/include/"
+cp "$BLE_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/ble/include/"
 cp -r "$BLE_SHARE_DIR/HaskellMobile" "$WORK_DIR/ble/"
 cp "$BLE_SHARE_DIR/project.yml" "$WORK_DIR/ble/"
 chmod -R u+w "$WORK_DIR/ble"
@@ -620,6 +640,7 @@ cp "$DIALOG_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/dialog/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/dialog/include/"
 cp "$DIALOG_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/dialog/include/"
+cp "$DIALOG_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/dialog/include/"
 cp -r "$DIALOG_SHARE_DIR/HaskellMobile" "$WORK_DIR/dialog/"
 cp "$DIALOG_SHARE_DIR/project.yml" "$WORK_DIR/dialog/"
 chmod -R u+w "$WORK_DIR/dialog"
@@ -663,6 +684,7 @@ cp "$LOCATION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/location/include
 cp "$LOCATION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/location/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/location/include/"
 cp "$LOCATION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/location/include/"
+cp "$LOCATION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/location/include/"
 cp -r "$LOCATION_SHARE_DIR/HaskellMobile" "$WORK_DIR/location/"
 cp "$LOCATION_SHARE_DIR/project.yml" "$WORK_DIR/location/"
 chmod -R u+w "$WORK_DIR/location"
@@ -706,6 +728,7 @@ cp "$WEBVIEW_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/webview/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/webview/include/"
 cp "$WEBVIEW_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/webview/include/"
+cp "$WEBVIEW_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/webview/include/"
 cp -r "$WEBVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/webview/"
 cp "$WEBVIEW_SHARE_DIR/project.yml" "$WORK_DIR/webview/"
 chmod -R u+w "$WORK_DIR/webview"
@@ -749,6 +772,7 @@ cp "$AUTH_SESSION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/authsession/
 cp "$AUTH_SESSION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/authsession/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/authsession/include/"
 cp "$AUTH_SESSION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/authsession/include/"
+cp "$AUTH_SESSION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/authsession/include/"
 cp -r "$AUTH_SESSION_SHARE_DIR/HaskellMobile" "$WORK_DIR/authsession/"
 cp "$AUTH_SESSION_SHARE_DIR/project.yml" "$WORK_DIR/authsession/"
 chmod -R u+w "$WORK_DIR/authsession"
@@ -792,6 +816,7 @@ cp "$CAMERA_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/camera/include/"
 cp "$CAMERA_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/camera/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/camera/include/"
 cp "$CAMERA_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/camera/include/"
+cp "$CAMERA_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/camera/include/"
 cp -r "$CAMERA_SHARE_DIR/HaskellMobile" "$WORK_DIR/camera/"
 cp "$CAMERA_SHARE_DIR/project.yml" "$WORK_DIR/camera/"
 chmod -R u+w "$WORK_DIR/camera"
@@ -835,6 +860,7 @@ cp "$BOTTOM_SHEET_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/bottomsheet/
 cp "$BOTTOM_SHEET_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/bottomsheet/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/bottomsheet/include/"
 cp "$BOTTOM_SHEET_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/bottomsheet/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/bottomsheet/include/"
 cp -r "$BOTTOM_SHEET_SHARE_DIR/HaskellMobile" "$WORK_DIR/bottomsheet/"
 cp "$BOTTOM_SHEET_SHARE_DIR/project.yml" "$WORK_DIR/bottomsheet/"
 chmod -R u+w "$WORK_DIR/bottomsheet"
@@ -878,6 +904,7 @@ cp "$NETWORK_STATUS_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/networksta
 cp "$NETWORK_STATUS_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/networkstatus/include/"
 cp "$NETWORK_STATUS_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/networkstatus/include/"
 cp "$NETWORK_STATUS_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/networkstatus/include/"
+cp "$NETWORK_STATUS_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/networkstatus/include/"
 cp -r "$NETWORK_STATUS_SHARE_DIR/HaskellMobile" "$WORK_DIR/networkstatus/"
 cp "$NETWORK_STATUS_SHARE_DIR/project.yml" "$WORK_DIR/networkstatus/"
 chmod -R u+w "$WORK_DIR/networkstatus"
@@ -921,6 +948,7 @@ cp "$MAPVIEW_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/mapview/include/"
 cp "$MAPVIEW_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/mapview/include/"
 cp "$MAPVIEW_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/mapview/include/"
 cp "$MAPVIEW_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/mapview/include/"
+cp "$MAPVIEW_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/mapview/include/"
 cp -r "$MAPVIEW_SHARE_DIR/HaskellMobile" "$WORK_DIR/mapview/"
 cp "$MAPVIEW_SHARE_DIR/project.yml" "$WORK_DIR/mapview/"
 chmod -R u+w "$WORK_DIR/mapview"
@@ -948,6 +976,50 @@ if [ -z "$MAPVIEW_APP" ]; then
     exit 1
 fi
 echo "MapView app: $MAPVIEW_APP"
+
+# --- Stage and build animation demo app ---
+echo "=== Staging animation demo app ==="
+mkdir -p "$WORK_DIR/animation/lib" "$WORK_DIR/animation/include"
+cp "$ANIMATION_SHARE_DIR/lib/libHaskellMobile.a" "$WORK_DIR/animation/lib/"
+cp "$ANIMATION_SHARE_DIR/include/HaskellMobile.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/animation/include/"
+cp "$BOTTOM_SHEET_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/animation/include/"
+cp "$ANIMATION_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/animation/include/"
+cp -r "$ANIMATION_SHARE_DIR/HaskellMobile" "$WORK_DIR/animation/"
+cp "$ANIMATION_SHARE_DIR/project.yml" "$WORK_DIR/animation/"
+chmod -R u+w "$WORK_DIR/animation"
+
+echo "=== Generating animation Xcode project ==="
+cd "$WORK_DIR/animation"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building animation demo app for simulator ==="
+xcodebuild build \
+    -project HaskellMobile.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/animation-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+ANIMATION_APP=$(find "$WORK_DIR/animation-build" -name "*.app" -type d | head -1)
+if [ -z "$ANIMATION_APP" ]; then
+    echo "ERROR: Could not find animation .app bundle"
+    exit 1
+fi
+echo "Animation app: $ANIMATION_APP"
 
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
@@ -1012,7 +1084,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.haskellmobile"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1027,6 +1099,7 @@ PHASE10_EXIT=0
 PHASE11_EXIT=0
 PHASE12_EXIT=0
 PHASE13_EXIT=0
+PHASE14_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1090,6 +1163,8 @@ echo "--- networkstatus ---"
 run_with_retry "networkstatus" bash "$TEST_SCRIPTS/watchos/network_status.sh" || PHASE12_EXIT=1
 echo "--- mapview ---"
 run_with_retry "mapview" bash "$TEST_SCRIPTS/watchos/mapview.sh" || PHASE13_EXIT=1
+echo "--- animation ---"
+run_with_retry "animation" bash "$TEST_SCRIPTS/watchos/animation.sh" || PHASE14_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1220,6 +1295,16 @@ else
     echo "PHASE 13 FAILED"
 fi
 
+if [ $PHASE14_EXIT -eq 0 ]; then
+    PHASE14_OK=1
+    echo ""
+    echo "PHASE 14 PASSED"
+else
+    PHASE14_OK=0
+    echo ""
+    echo "PHASE 14 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1318,6 +1403,13 @@ if [ $PHASE13_OK -eq 1 ]; then
     echo "PASS  Phase 13 — MapView demo app"
 else
     echo "FAIL  Phase 13 — MapView demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE14_OK -eq 1 ]; then
+    echo "PASS  Phase 14 — Animation demo app"
+else
+    echo "FAIL  Phase 14 — Animation demo app"
     FINAL_EXIT=1
 fi
 

--- a/src/HaskellMobile.hs
+++ b/src/HaskellMobile.hs
@@ -28,6 +28,7 @@ module HaskellMobile
   , haskellOnBottomSheetResult
   , haskellOnHttpResult
   , haskellOnNetworkStatusChange
+  , haskellOnAnimationFrame
   -- Error handling
   , errorWidget
   -- Re-exports from Lifecycle
@@ -114,6 +115,10 @@ module HaskellMobile
   , HttpError(..)
   , HttpState(..)
   , performRequest
+  -- Re-exports from Animation
+  , AnimationState(..)
+  , Easing(..)
+  , AnimatedConfig(..)
   -- Re-exports from NetworkStatus
   , NetworkTransport(..)
   , NetworkStatus(..)
@@ -138,6 +143,10 @@ import HaskellMobile.Action
   , createOnChange
   , newActionState
   , runActionM
+  )
+import HaskellMobile.Animation
+  ( AnimationState(..)
+  , dispatchAnimationFrame
   )
 import HaskellMobile.AppContext (AppContext(..), newAppContext, freeAppContext, derefAppContext)
 import HaskellMobile.AuthSession
@@ -240,7 +249,7 @@ import HaskellMobile.SecureStorage
   , dispatchSecureStorageResult
   )
 import HaskellMobile.Types (MobileApp(..), UserState(..))
-import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), TextConfig(..), Widget(..))
+import HaskellMobile.Widget (AnimatedConfig(..), ButtonConfig(..), Easing(..), FontConfig(..), TextConfig(..), Widget(..))
 
 -- | Create an 'AppContext' from a 'MobileApp' and return it as a typed
 -- pointer suitable for the C FFI. This is the user-facing API: the user's
@@ -302,6 +311,7 @@ renderView ctxPtr = do
         , userBottomSheetState   = acBottomSheetState appCtx
         , userHttpState              = acHttpState appCtx
         , userNetworkStatusState    = acNetworkStatusState appCtx
+        , userAnimationState     = acAnimationState appCtx
         }
   widget <- viewFunction userState
   renderWidget (acRenderState appCtx) widget
@@ -537,6 +547,18 @@ haskellOnNetworkStatusChange ctxPtr cConnected cTransport =
     dispatchNetworkStatusChange (acNetworkStatusState appCtx) cConnected cTransport
 
 foreign export ccall haskellOnNetworkStatusChange :: Ptr AppContext -> CInt -> CInt -> IO ()
+
+-- | Handle an animation frame from native code.  Ticks all active tweens,
+-- applies interpolated properties, then re-renders the UI so that the
+-- user's view function can confirm the target (Eq match → no new tween).
+haskellOnAnimationFrame :: Ptr AppContext -> CDouble -> IO ()
+haskellOnAnimationFrame ctxPtr (CDouble timestampMs) =
+  withExceptionHandler ctxPtr $ do
+    appCtx <- derefAppContext ctxPtr
+    dispatchAnimationFrame (acAnimationState appCtx) timestampMs
+    renderView ctxPtr
+
+foreign export ccall haskellOnAnimationFrame :: Ptr AppContext -> CDouble -> IO ()
 
 -- | Peek an optional CString: returns 'Nothing' for null pointers,
 -- 'Just' with the decoded 'Text' otherwise.

--- a/src/HaskellMobile/Animation.hs
+++ b/src/HaskellMobile/Animation.hs
@@ -1,0 +1,236 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+-- | Core animation engine for the @Animated@ widget wrapper.
+--
+-- Manages a registry of active tweens keyed by native node ID.
+-- When a property change is detected on an 'Animated' child,
+-- the render engine registers a tween here.  The platform frame
+-- loop calls 'dispatchAnimationFrame' each vsync, which iterates
+-- tweens, computes eased progress, applies interpolated property
+-- values to native nodes, and removes completed tweens.
+module HaskellMobile.Animation
+  ( AnimationState(..)
+  , ActiveTween(..)
+  , newAnimationState
+  , registerTween
+  , dispatchAnimationFrame
+  , applyEasing
+  , interpolateDouble
+  , interpolateAndApply
+  -- Re-exported for tests
+  , stopLoop
+  )
+where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
+import Data.Int (Int32)
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Foreign.Ptr (Ptr)
+import HaskellMobile.Widget
+  ( Easing(..)
+  , FontConfig(..)
+  , MapViewConfig(..)
+  , TextConfig(..)
+  , ButtonConfig(..)
+  , TextInputConfig(..)
+  , Widget(..)
+  , WidgetStyle(..)
+  , colorToHex
+  , interpolateColor
+  )
+import HaskellMobile.UIBridge qualified as Bridge
+import System.IO (hPutStrLn, stderr)
+
+-- | A single active tween, animating one native node from old to new properties.
+data ActiveTween = ActiveTween
+  { atStartTime  :: Maybe Double
+    -- ^ Timestamp (ms) of the first frame; set lazily on first dispatch.
+  , atFromWidget :: Widget
+    -- ^ The widget we are animating FROM (old property values).
+  , atToWidget   :: Widget
+    -- ^ The widget we are animating TO (new property values).
+  , atNodeId     :: Int32
+    -- ^ Native node ID to apply interpolated properties to.
+  , atDuration   :: Double
+    -- ^ Total duration in milliseconds.
+  , atEasing     :: Easing
+    -- ^ Easing function.
+  }
+
+-- | Mutable state for the animation engine.
+data AnimationState = AnimationState
+  { ansTweens     :: IORef (IntMap ActiveTween)
+    -- ^ Active tweens, keyed by native node ID.
+  , ansLoopActive :: IORef Bool
+    -- ^ Whether the platform frame loop is currently running.
+  , ansContextPtr :: IORef (Ptr ())
+    -- ^ Haskell context pointer, written by AppContext initialisation.
+  }
+
+-- | Create a fresh 'AnimationState' with no active tweens.
+newAnimationState :: IO AnimationState
+newAnimationState = do
+  tweens     <- newIORef IntMap.empty
+  loopActive <- newIORef False
+  ctxPtr     <- newIORef (error "AnimationState: context pointer not set")
+  pure AnimationState
+    { ansTweens     = tweens
+    , ansLoopActive = loopActive
+    , ansContextPtr = ctxPtr
+    }
+
+-- | Register a tween from old widget properties to new widget properties.
+-- If a tween already exists for this node ID, it is replaced (the old
+-- tween's current target becomes irrelevant).  Starts the platform
+-- frame loop if not already running.
+registerTween :: AnimationState -> Int32 -> Widget -> Widget -> Double -> Easing -> IO ()
+registerTween animState nodeId fromWidget toWidget duration easing = do
+  let tween = ActiveTween
+        { atStartTime  = Nothing
+        , atFromWidget = fromWidget
+        , atToWidget   = toWidget
+        , atNodeId     = nodeId
+        , atDuration   = duration
+        , atEasing     = easing
+        }
+  modifyIORef' (ansTweens animState) (IntMap.insert (fromIntegral nodeId) tween)
+  ensureLoopStarted animState
+
+-- | Start the platform animation loop if not already active.
+ensureLoopStarted :: AnimationState -> IO ()
+ensureLoopStarted animState = do
+  active <- readIORef (ansLoopActive animState)
+  if active
+    then pure ()
+    else do
+      writeIORef (ansLoopActive animState) True
+      ctxPtr <- readIORef (ansContextPtr animState)
+      c_animationStartLoop ctxPtr
+
+-- | Stop the platform animation loop.
+stopLoop :: AnimationState -> IO ()
+stopLoop animState = do
+  writeIORef (ansLoopActive animState) False
+  c_animationStopLoop
+
+-- | Process one animation frame.  Called by the FFI entry point
+-- @haskellOnAnimationFrame@ each vsync.  Iterates all active tweens,
+-- computes eased progress, applies interpolated properties, and
+-- removes completed tweens.  Stops the loop when no tweens remain.
+dispatchAnimationFrame :: AnimationState -> Double -> IO ()
+dispatchAnimationFrame animState timestampMs = do
+  tweens <- readIORef (ansTweens animState)
+  if IntMap.null tweens
+    then stopLoop animState
+    else do
+      -- Process each tween, collecting those that are still active
+      remaining <- IntMap.traverseWithKey (processTween timestampMs) tweens
+      let activeTweens = IntMap.mapMaybe id remaining
+      writeIORef (ansTweens animState) activeTweens
+      if IntMap.null activeTweens
+        then stopLoop animState
+        else pure ()
+
+-- | Process a single tween for the current frame.
+-- Returns 'Nothing' if the tween is complete, 'Just tween' if still active.
+processTween :: Double -> IntMap.Key -> ActiveTween -> IO (Maybe ActiveTween)
+processTween timestampMs _key tween = do
+  let startTime = case atStartTime tween of
+        Just t  -> t
+        Nothing -> timestampMs
+      updatedTween = tween { atStartTime = Just startTime }
+      elapsed = timestampMs - startTime
+      rawProgress = if atDuration updatedTween <= 0
+                    then 1.0
+                    else min 1.0 (elapsed / atDuration updatedTween)
+      easedProgress = applyEasing (atEasing updatedTween) rawProgress
+  interpolateAndApply (atNodeId updatedTween) (atFromWidget updatedTween)
+                      (atToWidget updatedTween) easedProgress
+  if rawProgress >= 1.0
+    then pure Nothing
+    else pure (Just updatedTween)
+
+-- | Apply easing to a linear progress value (0–1).
+applyEasing :: Easing -> Double -> Double
+applyEasing Linear    progress = progress
+applyEasing EaseIn    progress = progress * progress * progress
+applyEasing EaseOut   progress =
+  let inverted = 1.0 - progress
+  in 1.0 - inverted * inverted * inverted
+applyEasing EaseInOut progress =
+  if progress < 0.5
+    then 4.0 * progress * progress * progress
+    else 1.0 - ((-2.0 * progress + 2.0) ** 3) / 2.0
+
+-- | Linearly interpolate between two 'Double' values.
+interpolateDouble :: Double -> Double -> Double -> Double
+interpolateDouble from to progress = from + (to - from) * progress
+
+-- | Interpolate properties between two widgets and apply them to the
+-- native node via bridge calls.  Only animatable properties (numeric
+-- and color) are interpolated; others snap to the target instantly.
+interpolateAndApply :: Int32 -> Widget -> Widget -> Double -> IO ()
+interpolateAndApply nodeId (Styled fromStyle _) (Styled toStyle _) progress =
+  interpolateStyle nodeId fromStyle toStyle progress
+interpolateAndApply nodeId (MapView fromConfig) (MapView toConfig) progress = do
+  Bridge.setNumProp nodeId Bridge.PropMapLat
+    (interpolateDouble (mvLatitude fromConfig) (mvLatitude toConfig) progress)
+  Bridge.setNumProp nodeId Bridge.PropMapLon
+    (interpolateDouble (mvLongitude fromConfig) (mvLongitude toConfig) progress)
+  Bridge.setNumProp nodeId Bridge.PropMapZoom
+    (interpolateDouble (mvZoom fromConfig) (mvZoom toConfig) progress)
+interpolateAndApply nodeId (Text fromConfig) (Text toConfig) progress =
+  interpolateFontSize nodeId (tcFontConfig fromConfig) (tcFontConfig toConfig) progress
+interpolateAndApply nodeId (Button fromConfig) (Button toConfig) progress =
+  interpolateFontSize nodeId (bcFontConfig fromConfig) (bcFontConfig toConfig) progress
+interpolateAndApply nodeId (TextInput fromConfig) (TextInput toConfig) progress =
+  interpolateFontSize nodeId (tiFontConfig fromConfig) (tiFontConfig toConfig) progress
+-- Non-animatable widget types: log warning (should not normally happen)
+interpolateAndApply _nodeId _from _to _progress =
+  hPutStrLn stderr "interpolateAndApply: non-animatable widget pair"
+
+-- | Interpolate 'WidgetStyle' properties and apply them to a native node.
+interpolateStyle :: Int32 -> WidgetStyle -> WidgetStyle -> Double -> IO ()
+interpolateStyle nodeId fromStyle toStyle progress = do
+  -- Padding
+  case (wsPadding fromStyle, wsPadding toStyle) of
+    (Just fromPad, Just toPad) ->
+      Bridge.setNumProp nodeId Bridge.PropPadding
+        (interpolateDouble fromPad toPad progress)
+    (Nothing, Just toPad) ->
+      Bridge.setNumProp nodeId Bridge.PropPadding toPad
+    (Just _fromPad, Nothing) -> pure ()
+    (Nothing, Nothing) -> pure ()
+  -- Text color
+  case (wsTextColor fromStyle, wsTextColor toStyle) of
+    (Just fromColor, Just toColor) ->
+      Bridge.setStrProp nodeId Bridge.PropColor
+        (colorToHex (interpolateColor fromColor toColor progress))
+    (Nothing, Just toColor) ->
+      Bridge.setStrProp nodeId Bridge.PropColor (colorToHex toColor)
+    (Just _fromColor, Nothing) -> pure ()
+    (Nothing, Nothing) -> pure ()
+  -- Background color
+  case (wsBackgroundColor fromStyle, wsBackgroundColor toStyle) of
+    (Just fromColor, Just toColor) ->
+      Bridge.setStrProp nodeId Bridge.PropBgColor
+        (colorToHex (interpolateColor fromColor toColor progress))
+    (Nothing, Just toColor) ->
+      Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex toColor)
+    (Just _fromColor, Nothing) -> pure ()
+    (Nothing, Nothing) -> pure ()
+
+-- | Interpolate font size between two optional 'FontConfig' values.
+interpolateFontSize :: Int32 -> Maybe FontConfig -> Maybe FontConfig -> Double -> IO ()
+interpolateFontSize nodeId (Just (FontConfig fromSize)) (Just (FontConfig toSize)) progress =
+  Bridge.setNumProp nodeId Bridge.PropFontSize
+    (interpolateDouble fromSize toSize progress)
+interpolateFontSize nodeId Nothing (Just (FontConfig toSize)) _progress =
+  Bridge.setNumProp nodeId Bridge.PropFontSize toSize
+interpolateFontSize _nodeId (Just _) Nothing _progress = pure ()
+interpolateFontSize _nodeId Nothing Nothing _progress = pure ()
+
+-- | FFI imports for the C animation bridge.
+foreign import ccall "animation_start_loop" c_animationStartLoop :: Ptr () -> IO ()
+foreign import ccall "animation_stop_loop"  c_animationStopLoop  :: IO ()

--- a/src/HaskellMobile/AppContext.hs
+++ b/src/HaskellMobile/AppContext.hs
@@ -15,6 +15,7 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Foreign.Ptr (Ptr, castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, newStablePtr, deRefStablePtr, freeStablePtr)
 import HaskellMobile.Action (Action, ActionState, runActionM, createAction)
+import HaskellMobile.Animation (AnimationState(..), newAnimationState)
 import HaskellMobile.AuthSession (AuthSessionState(..), newAuthSessionState)
 import HaskellMobile.Ble (BleState(..), newBleState)
 import HaskellMobile.Camera (CameraState(..), newCameraState)
@@ -47,6 +48,7 @@ data AppContext = AppContext
   , acBottomSheetState    :: BottomSheetState
   , acHttpState           :: HttpState
   , acNetworkStatusState  :: NetworkStatusState
+  , acAnimationState      :: AnimationState
   , acViewFunction        :: IORef (UserState -> IO Widget)
   , acDismissAction       :: Action
     -- ^ Pre-registered dismiss action for the error widget.
@@ -63,7 +65,8 @@ data AppContext = AppContext
 newAppContext :: MobileApp -> IO (Ptr AppContext)
 newAppContext mobileApp = do
   let actionState = maActionState mobileApp
-  renderState        <- newRenderState actionState
+  animationState     <- newAnimationState
+  renderState        <- newRenderState actionState animationState
   permissionState    <- newPermissionState
   secureStorageState <- newSecureStorageState
   bleState           <- newBleState
@@ -93,6 +96,7 @@ newAppContext mobileApp = do
         , acBottomSheetState   = bottomSheetState
         , acHttpState          = httpState
         , acNetworkStatusState = networkStatusState
+        , acAnimationState     = animationState
         , acViewFunction       = viewRef
         , acDismissAction      = dismissAction
         , acDismissRef         = dismissRef
@@ -110,6 +114,7 @@ newAppContext mobileApp = do
   writeIORef (bssContextPtr bottomSheetState) (castPtr ptr)
   writeIORef (hsContextPtr httpState) (castPtr ptr)
   writeIORef (nssContextPtr networkStatusState) (castPtr ptr)
+  writeIORef (ansContextPtr animationState) (castPtr ptr)
   pure ptr
 
 -- | Release a pointer previously created by 'newAppContext'.

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -24,7 +24,8 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Int (Int32)
 import Data.Text (Text, pack)
 import HaskellMobile.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
-import HaskellMobile.Widget (ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
+import HaskellMobile.Animation (AnimationState, registerTween)
+import HaskellMobile.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
@@ -46,6 +47,9 @@ data RenderedNode
       Widget         -- ^ Widget value (Styled wrapper).
       WidgetStyle    -- ^ Applied style (for change detection).
       RenderedNode   -- ^ Child (Styled doesn't own a native node).
+  | RenderedAnimated
+      Widget         -- ^ Full Animated widget (Animated config child) for Eq comparison.
+      RenderedNode   -- ^ Child's rendered node (owns native node IDs).
 
 -- | Get the native node ID for a rendered node.
 -- 'RenderedStyled' follows through to its child's node ID.
@@ -53,12 +57,14 @@ renderedNodeId :: RenderedNode -> Int32
 renderedNodeId (RenderedLeaf _ nodeId)         = nodeId
 renderedNodeId (RenderedContainer _ nodeId _)  = nodeId
 renderedNodeId (RenderedStyled _ _ child)      = renderedNodeId child
+renderedNodeId (RenderedAnimated _ child)      = renderedNodeId child
 
 -- | Get the widget value for a rendered node.
 renderedWidget :: RenderedNode -> Widget
 renderedWidget (RenderedLeaf widget _)        = widget
 renderedWidget (RenderedContainer widget _ _) = widget
 renderedWidget (RenderedStyled widget _ _)    = widget
+renderedWidget (RenderedAnimated widget _)    = widget
 
 -- ---------------------------------------------------------------------------
 -- Render state
@@ -68,19 +74,23 @@ renderedWidget (RenderedStyled widget _ _)    = widget
 -- Holds a reference to the shared 'ActionState' callback registry
 -- and the previously rendered tree for incremental diffing.
 data RenderState = RenderState
-  { rsActionState  :: ActionState
+  { rsActionState    :: ActionState
     -- ^ Shared callback registry (never cleared during rendering).
-  , rsRenderedTree :: IORef (Maybe RenderedNode)
+  , rsRenderedTree   :: IORef (Maybe RenderedNode)
     -- ^ The previously rendered tree, or 'Nothing' for the first render.
+  , rsAnimationState :: AnimationState
+    -- ^ Mutable animation tween registry.
   }
 
--- | Create a fresh 'RenderState' wrapping the given 'ActionState'.
-newRenderState :: ActionState -> IO RenderState
-newRenderState actionState = do
+-- | Create a fresh 'RenderState' wrapping the given 'ActionState'
+-- and 'AnimationState'.
+newRenderState :: ActionState -> AnimationState -> IO RenderState
+newRenderState actionState animState = do
   renderedTree <- newIORef Nothing
   pure RenderState
-    { rsActionState  = actionState
-    , rsRenderedTree = renderedTree
+    { rsActionState    = actionState
+    , rsRenderedTree   = renderedTree
+    , rsAnimationState = animState
     }
 
 -- ---------------------------------------------------------------------------
@@ -133,19 +143,19 @@ applyStyle nodeId style = do
 
 -- | Create a native node from a 'Widget', returning a 'RenderedNode'
 -- snapshot. Used for fresh creation (no old node to diff against).
-createRenderedNode :: Widget -> IO RenderedNode
-createRenderedNode widget@(Text config) = do
+createRenderedNode :: AnimationState -> Widget -> IO RenderedNode
+createRenderedNode _animState widget@(Text config) = do
   nodeId <- Bridge.createNode Bridge.NodeText
   Bridge.setStrProp nodeId Bridge.PropText (tcLabel config)
   applyFontConfig nodeId (tcFontConfig config)
   pure (RenderedLeaf widget nodeId)
-createRenderedNode widget@(Button config) = do
+createRenderedNode _animState widget@(Button config) = do
   nodeId <- Bridge.createNode Bridge.NodeButton
   Bridge.setStrProp nodeId Bridge.PropText (bcLabel config)
   Bridge.setHandler nodeId Bridge.EventClick (actionId (bcAction config))
   applyFontConfig nodeId (bcFontConfig config)
   pure (RenderedLeaf widget nodeId)
-createRenderedNode widget@(TextInput config) = do
+createRenderedNode _animState widget@(TextInput config) = do
   nodeId <- Bridge.createNode Bridge.NodeTextInput
   Bridge.setStrProp nodeId Bridge.PropText (tiValue config)
   Bridge.setStrProp nodeId Bridge.PropHint (tiHint config)
@@ -153,31 +163,31 @@ createRenderedNode widget@(TextInput config) = do
   Bridge.setHandler nodeId Bridge.EventTextChange (onChangeId (tiOnChange config))
   applyFontConfig nodeId (tiFontConfig config)
   pure (RenderedLeaf widget nodeId)
-createRenderedNode widget@(Column children) = do
+createRenderedNode animState widget@(Column children) = do
   nodeId <- Bridge.createNode Bridge.NodeColumn
   childNodes <- mapM (\child -> do
-    childNode <- createRenderedNode child
+    childNode <- createRenderedNode animState child
     Bridge.addChild nodeId (renderedNodeId childNode)
     pure childNode
     ) children
   pure (RenderedContainer widget nodeId childNodes)
-createRenderedNode widget@(Row children) = do
+createRenderedNode animState widget@(Row children) = do
   nodeId <- Bridge.createNode Bridge.NodeRow
   childNodes <- mapM (\child -> do
-    childNode <- createRenderedNode child
+    childNode <- createRenderedNode animState child
     Bridge.addChild nodeId (renderedNodeId childNode)
     pure childNode
     ) children
   pure (RenderedContainer widget nodeId childNodes)
-createRenderedNode widget@(ScrollView children) = do
+createRenderedNode animState widget@(ScrollView children) = do
   nodeId <- Bridge.createNode Bridge.NodeScrollView
   childNodes <- mapM (\child -> do
-    childNode <- createRenderedNode child
+    childNode <- createRenderedNode animState child
     Bridge.addChild nodeId (renderedNodeId childNode)
     pure childNode
     ) children
   pure (RenderedContainer widget nodeId childNodes)
-createRenderedNode widget@(Image config) = do
+createRenderedNode _animState widget@(Image config) = do
   nodeId <- Bridge.createNode Bridge.NodeImage
   case icSource config of
     ImageResource (ResourceName name) -> Bridge.setStrProp nodeId Bridge.PropImageResource name
@@ -185,14 +195,14 @@ createRenderedNode widget@(Image config) = do
     ImageFile path                    -> Bridge.setStrProp nodeId Bridge.PropImageFile (pack path)
   Bridge.setNumProp nodeId Bridge.PropScaleType (scaleTypeToDouble (icScaleType config))
   pure (RenderedLeaf widget nodeId)
-createRenderedNode widget@(WebView config) = do
+createRenderedNode _animState widget@(WebView config) = do
   nodeId <- Bridge.createNode Bridge.NodeWebView
   Bridge.setStrProp nodeId Bridge.PropWebViewUrl (wvUrl config)
   case wvOnPageLoad config of
     Just action -> Bridge.setHandler nodeId Bridge.EventClick (actionId action)
     Nothing     -> pure ()
   pure (RenderedLeaf widget nodeId)
-createRenderedNode widget@(MapView config) = do
+createRenderedNode _animState widget@(MapView config) = do
   nodeId <- Bridge.createNode Bridge.NodeMapView
   Bridge.setNumProp nodeId Bridge.PropMapLat (mvLatitude config)
   Bridge.setNumProp nodeId Bridge.PropMapLon (mvLongitude config)
@@ -204,10 +214,13 @@ createRenderedNode widget@(MapView config) = do
                       (onChangeId onChange)
     Nothing      -> pure ()
   pure (RenderedLeaf widget nodeId)
-createRenderedNode widget@(Styled style child) = do
-  childNode <- createRenderedNode child
+createRenderedNode animState widget@(Styled style child) = do
+  childNode <- createRenderedNode animState child
   applyStyle (renderedNodeId childNode) style
   pure (RenderedStyled widget style childNode)
+createRenderedNode animState widget@(Animated _config child) = do
+  childNode <- createRenderedNode animState child
+  pure (RenderedAnimated widget childNode)
 
 -- ---------------------------------------------------------------------------
 -- Destroying rendered subtrees
@@ -221,6 +234,8 @@ destroyRenderedSubtree (RenderedContainer _ nodeId children) = do
   mapM_ destroyRenderedSubtree children
   Bridge.destroyNode nodeId
 destroyRenderedSubtree (RenderedStyled _ _ child) =
+  destroyRenderedSubtree child
+destroyRenderedSubtree (RenderedAnimated _ child) =
   destroyRenderedSubtree child
 
 -- ---------------------------------------------------------------------------
@@ -240,6 +255,7 @@ sameNodeType (Image _)       (Image _)       = True
 sameNodeType (WebView _)     (WebView _)     = True
 sameNodeType (MapView _)     (MapView _)     = True
 sameNodeType (Styled _ _)    (Styled _ _)    = True
+sameNodeType (Animated _ _)  (Animated _ _)  = True
 sameNodeType _               _               = False
 
 -- | Diff the old rendered tree against a new 'Widget' and produce
@@ -252,51 +268,69 @@ sameNodeType _               _               = False
 -- 4. Same Styled, diff child recursively, re-apply style if changed.
 -- 5. Same leaf type but properties differ -> destroy old, create new.
 -- 6. Different node type -> destroy old subtree, create new.
-diffRenderNode :: Maybe RenderedNode -> Widget -> IO RenderedNode
+diffRenderNode :: AnimationState -> Maybe RenderedNode -> Widget -> IO RenderedNode
 -- Case 1: No previous node — create from scratch.
-diffRenderNode Nothing newWidget =
-  createRenderedNode newWidget
+diffRenderNode animState Nothing newWidget =
+  createRenderedNode animState newWidget
 
 -- Case 2: Exact match — reuse native node entirely.
-diffRenderNode (Just oldNode) newWidget
+diffRenderNode _animState (Just oldNode) newWidget
   | newWidget == renderedWidget oldNode =
     pure oldNode
 
+-- Case: Both are Animated — diff the child, possibly registering a tween.
+diffRenderNode animState (Just (RenderedAnimated _ oldChildNode)) (Animated newConfig newChild) = do
+  let oldChildWidget = renderedWidget oldChildNode
+  if sameNodeType oldChildWidget newChild
+    then do
+      -- Same child node type: keep native node, register tween if properties differ
+      if oldChildWidget /= newChild
+        then registerTween animState (renderedNodeId oldChildNode)
+               oldChildWidget newChild (anDuration newConfig) (anEasing newConfig)
+        else pure ()
+      -- Update the RenderedAnimated to reflect the new target
+      pure (RenderedAnimated (Animated newConfig newChild) oldChildNode)
+    else do
+      -- Different child type: can't animate, destroy+create
+      destroyRenderedSubtree oldChildNode
+      newChildNode <- createRenderedNode animState newChild
+      pure (RenderedAnimated (Animated newConfig newChild) newChildNode)
+
 -- Case 4: Both are Styled — diff child recursively.
-diffRenderNode (Just (RenderedStyled _ oldStyle oldChild)) (Styled newStyle newChild) = do
-  diffedChild <- diffRenderNode (Just oldChild) newChild
+diffRenderNode animState (Just (RenderedStyled _ oldStyle oldChild)) (Styled newStyle newChild) = do
+  diffedChild <- diffRenderNode animState (Just oldChild) newChild
   if newStyle /= oldStyle
     then applyStyle (renderedNodeId diffedChild) newStyle
     else pure ()
   pure (RenderedStyled (Styled newStyle newChild) newStyle diffedChild)
 
 -- Case 3: Same container type, children may differ — keep container, diff children.
-diffRenderNode (Just oldNode@(RenderedContainer _ containerNodeId oldChildren)) newWidget
+diffRenderNode animState (Just oldNode@(RenderedContainer _ containerNodeId oldChildren)) newWidget
   | sameNodeType (renderedWidget oldNode) newWidget =
     case newWidget of
-      Column newChildren     -> diffContainer containerNodeId oldChildren newChildren newWidget
-      Row newChildren        -> diffContainer containerNodeId oldChildren newChildren newWidget
-      ScrollView newChildren -> diffContainer containerNodeId oldChildren newChildren newWidget
+      Column newChildren     -> diffContainer animState containerNodeId oldChildren newChildren newWidget
+      Row newChildren        -> diffContainer animState containerNodeId oldChildren newChildren newWidget
+      ScrollView newChildren -> diffContainer animState containerNodeId oldChildren newChildren newWidget
       -- Non-container but same type at container level shouldn't happen,
       -- but fall through to destroy+create for safety.
-      _ -> replaceNode oldNode newWidget
+      _ -> replaceNode animState oldNode newWidget
 
 -- Case 5/6: Same leaf type with different properties, or completely different
 -- node types — destroy old and create new.
-diffRenderNode (Just oldNode) newWidget =
-  replaceNode oldNode newWidget
+diffRenderNode animState (Just oldNode) newWidget =
+  replaceNode animState oldNode newWidget
 
 -- | Diff container children: remove all children from parent, diff each
 -- individually, then re-add all in correct order.
-diffContainer :: Int32 -> [RenderedNode] -> [Widget]
+diffContainer :: AnimationState -> Int32 -> [RenderedNode] -> [Widget]
               -> Widget -> IO RenderedNode
-diffContainer containerNodeId oldChildren newChildren newWidget = do
+diffContainer animState containerNodeId oldChildren newChildren newWidget = do
   -- Remove all children from the container (order may change).
   mapM_ (\oldChild -> Bridge.removeChild containerNodeId (renderedNodeId oldChild)) oldChildren
   -- Diff each child position, pairing old children with new where available.
   let paired = zipPadded oldChildren newChildren
   diffedChildren <- mapM (\(maybeOld, newChild) ->
-    diffRenderNode maybeOld newChild
+    diffRenderNode animState maybeOld newChild
     ) paired
   -- Destroy any excess old children that weren't paired.
   let excessOld = drop (length newChildren) oldChildren
@@ -313,10 +347,10 @@ zipPadded _ []                  = []
 zipPadded (old:olds) (new:news) = (Just old, new) : zipPadded olds news
 
 -- | Destroy an old node and create a fresh replacement.
-replaceNode :: RenderedNode -> Widget -> IO RenderedNode
-replaceNode oldNode newWidget = do
+replaceNode :: AnimationState -> RenderedNode -> Widget -> IO RenderedNode
+replaceNode animState oldNode newWidget = do
   destroyRenderedSubtree oldNode
-  createRenderedNode newWidget
+  createRenderedNode animState newWidget
 
 -- ---------------------------------------------------------------------------
 -- Top-level render entry point
@@ -330,7 +364,7 @@ replaceNode oldNode newWidget = do
 renderWidget :: RenderState -> Widget -> IO ()
 renderWidget rs widget = do
   oldTree <- readIORef (rsRenderedTree rs)
-  newTree <- diffRenderNode oldTree widget
+  newTree <- diffRenderNode (rsAnimationState rs) oldTree widget
   -- Set root if this is the first render or the root node changed.
   case oldTree of
     Nothing -> Bridge.setRoot (renderedNodeId newTree)

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -25,7 +25,7 @@ import Data.Int (Int32)
 import Data.Text (Text, pack)
 import HaskellMobile.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
 import HaskellMobile.Animation (AnimationState, registerTween)
-import HaskellMobile.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex)
+import HaskellMobile.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex, normalizeAnimated)
 import HaskellMobile.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
@@ -218,9 +218,19 @@ createRenderedNode animState widget@(Styled style child) = do
   childNode <- createRenderedNode animState child
   applyStyle (renderedNodeId childNode) style
   pure (RenderedStyled widget style childNode)
-createRenderedNode animState widget@(Animated _config child) = do
-  childNode <- createRenderedNode animState child
-  pure (RenderedAnimated widget childNode)
+createRenderedNode animState (Animated config child) = do
+  let normalized = normalizeAnimated config child
+  case normalized of
+    -- normalizeAnimated distributed into a container — render the container directly
+    -- (each child is now individually wrapped in Animated).
+    Column _     -> createRenderedNode animState normalized
+    Row _        -> createRenderedNode animState normalized
+    ScrollView _ -> createRenderedNode animState normalized
+    -- Everything else (Styled, leaves): wrap in RenderedAnimated for tween interpolation.
+    _            -> do
+      let finalWidget = Animated config normalized
+      childNode <- createRenderedNode animState normalized
+      pure (RenderedAnimated finalWidget childNode)
 
 -- ---------------------------------------------------------------------------
 -- Destroying rendered subtrees
@@ -278,7 +288,18 @@ diffRenderNode _animState (Just oldNode) newWidget
   | newWidget == renderedWidget oldNode =
     pure oldNode
 
--- Case: Both are Animated — diff the child, possibly registering a tween.
+-- Case: Animated wrapping a container — normalize (distribute to children) and recurse.
+diffRenderNode animState maybeOld (Animated config child@(Column _)) =
+  diffRenderNode animState maybeOld (normalizeAnimated config child)
+diffRenderNode animState maybeOld (Animated config child@(Row _)) =
+  diffRenderNode animState maybeOld (normalizeAnimated config child)
+diffRenderNode animState maybeOld (Animated config child@(ScrollView _)) =
+  diffRenderNode animState maybeOld (normalizeAnimated config child)
+-- Case: Nested Animated — inner config wins.
+diffRenderNode animState maybeOld (Animated _outerConfig child@(Animated _ _)) =
+  diffRenderNode animState maybeOld child
+
+-- Case: Both are Animated (leaf) — diff the child, possibly registering a tween.
 diffRenderNode animState (Just (RenderedAnimated _ oldChildNode)) (Animated newConfig newChild) = do
   let oldChildWidget = renderedWidget oldChildNode
   if sameNodeType oldChildWidget newChild

--- a/src/HaskellMobile/Types.hs
+++ b/src/HaskellMobile/Types.hs
@@ -9,6 +9,7 @@ module HaskellMobile.Types
 where
 
 import HaskellMobile.Action (ActionState)
+import HaskellMobile.Animation (AnimationState)
 import HaskellMobile.AuthSession (AuthSessionState)
 import HaskellMobile.Ble (BleState)
 import HaskellMobile.Camera (CameraState)
@@ -37,6 +38,7 @@ data UserState = UserState
   , userBottomSheetState   :: BottomSheetState
   , userHttpState              :: HttpState
   , userNetworkStatusState    :: NetworkStatusState
+  , userAnimationState     :: AnimationState
   }
 
 -- | Application definition record. Downstream apps create one of these

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -28,6 +28,10 @@ module HaskellMobile.Widget
   , colorFromText
   , colorToHex
   , defaultStyle
+  , Easing(..)
+  , AnimatedConfig(..)
+  , interpolateColor
+  , lerpWord8
   )
 where
 
@@ -151,6 +155,36 @@ defaultStyle = WidgetStyle
   , wsBackgroundColor = Nothing
   }
 
+-- | Easing function for animations.
+data Easing
+  = Linear     -- ^ Constant speed.
+  | EaseIn     -- ^ Slow start, fast end.
+  | EaseOut    -- ^ Fast start, slow end.
+  | EaseInOut  -- ^ Slow start and end, fast middle.
+  deriving (Show, Eq)
+
+-- | Configuration for an 'Animated' widget wrapper.
+data AnimatedConfig = AnimatedConfig
+  { anDuration :: Double
+    -- ^ Animation duration in milliseconds.
+  , anEasing   :: Easing
+    -- ^ Easing function to apply.
+  } deriving (Show, Eq)
+
+-- | Linearly interpolate a single 'Word8' channel.
+lerpWord8 :: Word8 -> Word8 -> Double -> Word8
+lerpWord8 from to progress =
+  round (fromIntegral from + (fromIntegral to - fromIntegral from) * progress :: Double)
+
+-- | Interpolate between two colors by lerping each RGBA channel.
+interpolateColor :: Color -> Color -> Double -> Color
+interpolateColor (Color r1 g1 b1 a1) (Color r2 g2 b2 a2) progress = Color
+  { colorRed   = lerpWord8 r1 r2 progress
+  , colorGreen = lerpWord8 g1 g2 progress
+  , colorBlue  = lerpWord8 b1 b2 progress
+  , colorAlpha = lerpWord8 a1 a2 progress
+  }
+
 -- | How an image should be scaled within its bounds.
 data ScaleType
   = ScaleFit   -- ^ Scale to fit within bounds, preserving aspect ratio.
@@ -227,4 +261,6 @@ data Widget
     -- ^ An embedded map view (native MapKit on iOS, placeholder elsewhere).
   | Styled WidgetStyle Widget
     -- ^ Apply visual style overrides to a child widget.
+  | Animated AnimatedConfig Widget
+    -- ^ Animate property changes on the child widget over a duration.
   deriving (Show, Eq)

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -30,6 +30,7 @@ module HaskellMobile.Widget
   , defaultStyle
   , Easing(..)
   , AnimatedConfig(..)
+  , normalizeAnimated
   , interpolateColor
   , lerpWord8
   )
@@ -164,6 +165,29 @@ data Easing
   deriving (Show, Eq)
 
 -- | Configuration for an 'Animated' widget wrapper.
+--
+-- When 'Animated' wraps a container ('Column', 'Row', 'ScrollView'), the
+-- config is distributed to each child:
+--
+-- @
+-- Animated cfg (Column [a, b, c])  =  Column [Animated cfg a, Animated cfg b, Animated cfg c]
+-- @
+--
+-- When two 'Animated' wrappers are nested, the __inner config wins__ — the
+-- outer wrapper is stripped.  This lets you animate a whole container while
+-- overriding individual children:
+--
+-- @
+-- Animated (AnimatedConfig 500 EaseOut) $
+--   Column
+--     [ styledText   -- inherits 500ms EaseOut
+--     , Animated (AnimatedConfig 100 EaseIn) fastWidget  -- keeps 100ms EaseIn
+--     ]
+-- @
+--
+-- Non-animatable children (containers with no visual properties of their
+-- own) are recursively distributed until a leaf or 'Styled' node is
+-- reached.
 data AnimatedConfig = AnimatedConfig
   { anDuration :: Double
     -- ^ Animation duration in milliseconds.
@@ -184,6 +208,29 @@ interpolateColor (Color r1 g1 b1 a1) (Color r2 g2 b2 a2) progress = Color
   , colorBlue  = lerpWord8 b1 b2 progress
   , colorAlpha = lerpWord8 a1 a2 progress
   }
+
+-- | Normalize an 'Animated' wrapper before rendering.
+--
+-- * Distributes 'Animated' over container children ('Column', 'Row',
+--   'ScrollView').
+-- * Collapses nested 'Animated' — inner config wins.
+-- * All other widgets ('Styled', leaves) are returned unchanged;
+--   the render engine wraps them in @RenderedAnimated@ for tween
+--   interpolation.
+normalizeAnimated :: AnimatedConfig -> Widget -> Widget
+-- Inner Animated wins: strip the outer config.
+normalizeAnimated _outerConfig (Animated innerConfig child) =
+  Animated innerConfig (normalizeAnimated innerConfig child)
+-- Distribute over containers.
+normalizeAnimated config (Column children) =
+  Column (map (Animated config) children)
+normalizeAnimated config (Row children) =
+  Row (map (Animated config) children)
+normalizeAnimated config (ScrollView children) =
+  ScrollView (map (Animated config) children)
+-- Everything else (Styled, leaves): return unchanged.
+-- The caller wraps the result in Animated for the render engine.
+normalizeAnimated _config other = other
 
 -- | How an image should be scaled within its bounds.
 data ScaleType
@@ -263,4 +310,8 @@ data Widget
     -- ^ Apply visual style overrides to a child widget.
   | Animated AnimatedConfig Widget
     -- ^ Animate property changes on the child widget over a duration.
+    -- When wrapping a container ('Column', 'Row', 'ScrollView'), the
+    -- animation is distributed to each child.  Nested 'Animated'
+    -- wrappers collapse: the innermost config wins.
+    -- See 'AnimatedConfig' for details.
   deriving (Show, Eq)

--- a/test/AnimationDemoMain.hs
+++ b/test/AnimationDemoMain.hs
@@ -9,6 +9,7 @@ module Main where
 
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (pack)
+import Foreign.Ptr (Ptr)
 import HaskellMobile
   ( MobileApp(..)
   , UserState(..)
@@ -21,6 +22,7 @@ import HaskellMobile
   , loggingMobileContext
   , platformLog
   )
+import HaskellMobile.AppContext (AppContext(..))
 import HaskellMobile.Widget
   ( Widget(..)
   , TextConfig(..)
@@ -29,7 +31,7 @@ import HaskellMobile.Widget
   , defaultStyle
   )
 
-main :: IO ()
+main :: IO (Ptr AppContext)
 main = do
   actionState <- newActionState
   paddingRef <- newIORef (10.0 :: Double)
@@ -59,5 +61,6 @@ main = do
         , maView        = viewFn
         , maActionState = actionState
         }
-  _ctxPtr <- startMobileApp app
+  ctxPtr <- startMobileApp app
   platformLog "AnimationDemoMain started"
+  pure ctxPtr

--- a/test/AnimationDemoMain.hs
+++ b/test/AnimationDemoMain.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | Self-contained animation demo app.
 --
 -- A button toggles padding between 10 and 50, wrapped in
@@ -6,7 +7,8 @@
 -- tween interpolation path and logs progress to stderr.
 module Main where
 
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (pack)
 import HaskellMobile
   ( MobileApp(..)
   , UserState(..)
@@ -35,7 +37,7 @@ main = do
     currentPadding <- readIORef paddingRef
     let newPadding = if currentPadding < 30.0 then 50.0 else 10.0
     writeIORef paddingRef newPadding
-    platformLog ("Toggled padding to " <> show newPadding)
+    platformLog ("Toggled padding to " <> pack (show newPadding))
   let viewFn :: UserState -> IO Widget
       viewFn _userState = do
         currentPadding <- readIORef paddingRef

--- a/test/AnimationDemoMain.hs
+++ b/test/AnimationDemoMain.hs
@@ -1,0 +1,61 @@
+-- | Self-contained animation demo app.
+--
+-- A button toggles padding between 10 and 50, wrapped in
+-- @Animated 500 EaseInOut@.  The desktop stub fires test frames
+-- synchronously (0ms, 16.67ms, 1000ms), which exercises the
+-- tween interpolation path and logs progress to stderr.
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import HaskellMobile
+  ( MobileApp(..)
+  , UserState(..)
+  , AnimatedConfig(..)
+  , Easing(..)
+  , startMobileApp
+  , newActionState
+  , runActionM
+  , createAction
+  , loggingMobileContext
+  , platformLog
+  )
+import HaskellMobile.Widget
+  ( Widget(..)
+  , TextConfig(..)
+  , ButtonConfig(..)
+  , WidgetStyle(..)
+  , defaultStyle
+  )
+
+main :: IO ()
+main = do
+  actionState <- newActionState
+  paddingRef <- newIORef (10.0 :: Double)
+  toggleAction <- runActionM actionState $ createAction $ do
+    currentPadding <- readIORef paddingRef
+    let newPadding = if currentPadding < 30.0 then 50.0 else 10.0
+    writeIORef paddingRef newPadding
+    platformLog ("Toggled padding to " <> show newPadding)
+  let viewFn :: UserState -> IO Widget
+      viewFn _userState = do
+        currentPadding <- readIORef paddingRef
+        pure $ Column
+          [ Animated (AnimatedConfig 500 EaseInOut) $
+              Styled (defaultStyle { wsPadding = Just currentPadding }) $
+                Text TextConfig
+                  { tcLabel = "Animated padding"
+                  , tcFontConfig = Nothing
+                  }
+          , Button ButtonConfig
+              { bcLabel = "Toggle Padding"
+              , bcAction = toggleAction
+              , bcFontConfig = Nothing
+              }
+          ]
+      app = MobileApp
+        { maContext     = loggingMobileContext
+        , maView        = viewFn
+        , maActionState = actionState
+        }
+  _ctxPtr <- startMobileApp app
+  platformLog "AnimationDemoMain started"

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -15,6 +15,7 @@ import Test.WidgetTests (uiTests, scrollViewTests, textInputTests, imageTests, w
 import Test.PlatformTests (permissionTests, secureStorageTests, bleTests, dialogTests, authSessionTests, locationTests, bottomSheetTests, cameraTests, httpTests, networkStatusTests)
 import Test.AppContextTests (registrationTests, appContextTests, exceptionHandlerTests)
 import Test.ActionTests (actionTests, widgetEqTests, incrementalRenderTests)
+import Test.AnimationTests (animationTests)
 
 main :: IO ()
 main = do
@@ -64,4 +65,5 @@ tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiB
     , actionTests
     , widgetEqTests
     , incrementalRenderTests
+    , animationTests
     ]

--- a/test/Test/ActionTests.hs
+++ b/test/Test/ActionTests.hs
@@ -113,12 +113,14 @@ nodeIdOf :: RenderedNode -> Int32
 nodeIdOf (RenderedLeaf _ nodeId)         = nodeId
 nodeIdOf (RenderedContainer _ nodeId _)  = nodeId
 nodeIdOf (RenderedStyled _ _ child)      = nodeIdOf child
+nodeIdOf (RenderedAnimated _ child)      = nodeIdOf child
 
 -- | Helper to extract children from a RenderedContainer.
 childrenOf :: RenderedNode -> [RenderedNode]
 childrenOf (RenderedContainer _ _ children) = children
 childrenOf (RenderedLeaf _ _)              = []
 childrenOf (RenderedStyled _ _ _)          = []
+childrenOf (RenderedAnimated _ _)          = []
 
 incrementalRenderTests :: TestTree
 incrementalRenderTests = testGroup "Incremental rendering"

--- a/test/Test/AnimationTests.hs
+++ b/test/Test/AnimationTests.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+-- | Tests for the animation engine: easing, interpolation,
+-- tween registration, and the Animated widget diff behaviour.
+module Test.AnimationTests (animationTests) where
+
+import Data.IORef (readIORef, writeIORef)
+import Data.Int (Int32)
+import Data.IntMap.Strict qualified as IntMap
+import Foreign.Ptr (nullPtr)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import HaskellMobile
+  ( AnimatedConfig(..)
+  , Easing(..)
+  , newActionState
+  )
+import HaskellMobile.Animation
+  ( ActiveTween(..)
+  , AnimationState(..)
+  , applyEasing
+  , dispatchAnimationFrame
+  , interpolateDouble
+  , newAnimationState
+  , registerTween
+  )
+import HaskellMobile.Render (RenderState(..), RenderedNode(..), newRenderState, renderWidget)
+import HaskellMobile.Widget
+  ( Color(..)
+  , Widget(..)
+  , WidgetStyle(..)
+  , TextConfig(..)
+  , defaultStyle
+  , interpolateColor
+  , lerpWord8
+  )
+
+animationTests :: TestTree
+animationTests = testGroup "Animation"
+  [ easingTests
+  , interpolationTests
+  , colorInterpolationTests
+  , tweenRegistryTests
+  , animatedWidgetRenderTests
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Easing
+-- ---------------------------------------------------------------------------
+
+easingTests :: TestTree
+easingTests = testGroup "Easing"
+  [ testCase "Linear at 0 and 1" $ do
+      applyEasing Linear 0.0 @?= 0.0
+      applyEasing Linear 1.0 @?= 1.0
+  , testCase "Linear midpoint" $
+      applyEasing Linear 0.5 @?= 0.5
+  , testCase "EaseIn at boundaries" $ do
+      applyEasing EaseIn 0.0 @?= 0.0
+      applyEasing EaseIn 1.0 @?= 1.0
+  , testCase "EaseIn slower at 0.25" $ do
+      let easeInVal = applyEasing EaseIn 0.25
+          linearVal = applyEasing Linear 0.25
+      assertBool "EaseIn at 0.25 should be slower than Linear"
+        (easeInVal < linearVal)
+  , testCase "EaseOut at boundaries" $ do
+      applyEasing EaseOut 0.0 @?= 0.0
+      applyEasing EaseOut 1.0 @?= 1.0
+  , testCase "EaseOut faster at 0.25" $ do
+      let easeOutVal = applyEasing EaseOut 0.25
+          linearVal  = applyEasing Linear 0.25
+      assertBool "EaseOut at 0.25 should be faster than Linear"
+        (easeOutVal > linearVal)
+  , testCase "EaseInOut at boundaries" $ do
+      applyEasing EaseInOut 0.0 @?= 0.0
+      applyEasing EaseInOut 1.0 @?= 1.0
+  , testCase "EaseInOut symmetry around midpoint" $ do
+      let valAt025 = applyEasing EaseInOut 0.25
+          valAt075 = applyEasing EaseInOut 0.75
+      -- EaseInOut is symmetric: f(0.25) + f(0.75) ≈ 1.0
+      assertBool "EaseInOut symmetric"
+        (abs (valAt025 + valAt075 - 1.0) < 0.01)
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Interpolation
+-- ---------------------------------------------------------------------------
+
+interpolationTests :: TestTree
+interpolationTests = testGroup "Interpolation"
+  [ testCase "interpolateDouble boundaries" $ do
+      interpolateDouble 10.0 20.0 0.0 @?= 10.0
+      interpolateDouble 10.0 20.0 1.0 @?= 20.0
+  , testCase "interpolateDouble midpoint" $
+      interpolateDouble 10.0 20.0 0.5 @?= 15.0
+  , testCase "interpolateDouble negative range" $
+      interpolateDouble (-10.0) 10.0 0.5 @?= 0.0
+  , testCase "lerpWord8 boundaries" $ do
+      lerpWord8 0 255 0.0 @?= 0
+      lerpWord8 0 255 1.0 @?= 255
+  , testCase "lerpWord8 midpoint" $
+      lerpWord8 0 200 0.5 @?= 100
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Color interpolation
+-- ---------------------------------------------------------------------------
+
+colorInterpolationTests :: TestTree
+colorInterpolationTests = testGroup "Color interpolation"
+  [ testCase "Red to blue midpoint" $ do
+      let red  = Color 255 0 0 255
+          blue = Color 0 0 255 255
+          mid  = interpolateColor red blue 0.5
+      colorRed mid   @?= 128
+      colorGreen mid @?= 0
+      colorBlue mid  @?= 128
+      colorAlpha mid @?= 255
+  , testCase "Boundaries" $ do
+      let from = Color 100 50 200 128
+          to   = Color 200 100 50 255
+      interpolateColor from to 0.0 @?= from
+      interpolateColor from to 1.0 @?= to
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Tween registry
+-- ---------------------------------------------------------------------------
+
+tweenRegistryTests :: TestTree
+tweenRegistryTests = testGroup "Tween registry"
+  [ testCase "Register and dispatch tween" $ do
+      animState <- newAnimationState
+      -- Prevent the C stub from calling haskellOnAnimationFrame
+      -- by pre-setting ansLoopActive so ensureLoopStarted is a no-op.
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      let fromWidget = Text TextConfig { tcLabel = "old", tcFontConfig = Nothing }
+          toWidget   = Text TextConfig { tcLabel = "new", tcFontConfig = Nothing }
+      registerTween animState 42 fromWidget toWidget 500.0 Linear
+      tweens <- readIORef (ansTweens animState)
+      assertBool "Tween should be registered" (not (IntMap.null tweens))
+  , testCase "Completed tween is removed" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      let fromWidget = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          toWidget   = Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+          tween = ActiveTween
+            { atStartTime  = Just 0.0
+            , atFromWidget = fromWidget
+            , atToWidget   = toWidget
+            , atNodeId     = 1
+            , atDuration   = 100.0
+            , atEasing     = Linear
+            }
+      writeIORef (ansTweens animState) (IntMap.singleton 1 tween)
+      -- Dispatch at t=200 (past duration) — tween should complete
+      dispatchAnimationFrame animState 200.0
+      tweens <- readIORef (ansTweens animState)
+      assertBool "Tween should be removed after completion" (IntMap.null tweens)
+      loopActive <- readIORef (ansLoopActive animState)
+      assertBool "Loop should be stopped" (not loopActive)
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Animated widget rendering
+-- ---------------------------------------------------------------------------
+
+animatedWidgetRenderTests :: TestTree
+animatedWidgetRenderTests = testGroup "Animated widget rendering"
+  [ testCase "First render creates RenderedAnimated" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let child = Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing }
+          widget = Animated (AnimatedConfig 300 EaseOut) child
+      renderWidget rs widget
+      renderedTree <- readIORef (rsRenderedTree rs)
+      case renderedTree of
+        Just (RenderedAnimated _ _) -> pure ()
+        other -> assertFailure ("Expected RenderedAnimated, got: " ++ show (fmap renderedNodeSummary other))
+  , testCase "Same widget reuses node (Eq match)" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let child = Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing }
+          widget = Animated (AnimatedConfig 300 EaseOut) child
+      renderWidget rs widget
+      Just firstTree <- readIORef (rsRenderedTree rs)
+      let firstNodeId = renderedNodeIdSafe firstTree
+      -- Render same widget again — should reuse
+      renderWidget rs widget
+      Just secondTree <- readIORef (rsRenderedTree rs)
+      let secondNodeId = renderedNodeIdSafe secondTree
+      firstNodeId @?= secondNodeId
+  , testCase "Property change keeps same native node" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let child1 = Styled (defaultStyle { wsPadding = Just 10 }) (Text TextConfig { tcLabel = "x", tcFontConfig = Nothing })
+          child2 = Styled (defaultStyle { wsPadding = Just 50 }) (Text TextConfig { tcLabel = "x", tcFontConfig = Nothing })
+          widget1 = Animated (AnimatedConfig 300 EaseOut) child1
+          widget2 = Animated (AnimatedConfig 300 EaseOut) child2
+      renderWidget rs widget1
+      Just firstTree <- readIORef (rsRenderedTree rs)
+      let firstNodeId = renderedNodeIdSafe firstTree
+      renderWidget rs widget2
+      Just secondTree <- readIORef (rsRenderedTree rs)
+      let secondNodeId = renderedNodeIdSafe secondTree
+      firstNodeId @?= secondNodeId
+  , testCase "Different node type destroys and recreates" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let child1 = Text TextConfig { tcLabel = "text", tcFontConfig = Nothing }
+          child2 = Column []
+          widget1 = Animated (AnimatedConfig 300 EaseOut) child1
+          widget2 = Animated (AnimatedConfig 300 EaseOut) child2
+      renderWidget rs widget1
+      Just firstTree <- readIORef (rsRenderedTree rs)
+      let firstNodeId = renderedNodeIdSafe firstTree
+      renderWidget rs widget2
+      Just secondTree <- readIORef (rsRenderedTree rs)
+      let secondNodeId = renderedNodeIdSafe secondTree
+      -- Different node type means different node ID
+      assertBool "Node ID should change for different node types"
+        (firstNodeId /= secondNodeId)
+  ]
+
+-- | Helper: get the native node ID from a RenderedNode, following through
+-- Animated and Styled wrappers.
+renderedNodeIdSafe :: RenderedNode -> Int32
+renderedNodeIdSafe (RenderedLeaf _ nodeId)        = nodeId
+renderedNodeIdSafe (RenderedContainer _ nodeId _) = nodeId
+renderedNodeIdSafe (RenderedStyled _ _ child)     = renderedNodeIdSafe child
+renderedNodeIdSafe (RenderedAnimated _ child)     = renderedNodeIdSafe child
+
+-- | Helper: produce a short string summary of a RenderedNode for error messages.
+renderedNodeSummary :: RenderedNode -> String
+renderedNodeSummary (RenderedLeaf _ nodeId)        = "RenderedLeaf " ++ show nodeId
+renderedNodeSummary (RenderedContainer _ nodeId _) = "RenderedContainer " ++ show nodeId
+renderedNodeSummary (RenderedStyled _ _ child)     = "RenderedStyled -> " ++ renderedNodeSummary child
+renderedNodeSummary (RenderedAnimated _ child)     = "RenderedAnimated -> " ++ renderedNodeSummary child

--- a/test/Test/AnimationTests.hs
+++ b/test/Test/AnimationTests.hs
@@ -33,6 +33,7 @@ import HaskellMobile.Widget
   , defaultStyle
   , interpolateColor
   , lerpWord8
+  , normalizeAnimated
   )
 
 animationTests :: TestTree
@@ -42,6 +43,7 @@ animationTests = testGroup "Animation"
   , colorInterpolationTests
   , tweenRegistryTests
   , animatedWidgetRenderTests
+  , normalizeAnimatedTests
   ]
 
 -- ---------------------------------------------------------------------------
@@ -247,3 +249,101 @@ renderedNodeSummary (RenderedLeaf _ nodeId)        = "RenderedLeaf " ++ show nod
 renderedNodeSummary (RenderedContainer _ nodeId _) = "RenderedContainer " ++ show nodeId
 renderedNodeSummary (RenderedStyled _ _ child)     = "RenderedStyled -> " ++ renderedNodeSummary child
 renderedNodeSummary (RenderedAnimated _ child)     = "RenderedAnimated -> " ++ renderedNodeSummary child
+
+-- ---------------------------------------------------------------------------
+-- normalizeAnimated
+-- ---------------------------------------------------------------------------
+
+normalizeAnimatedTests :: TestTree
+normalizeAnimatedTests = testGroup "normalizeAnimated"
+  [ testCase "Distributes over Column children" $ do
+      let cfg = AnimatedConfig 300 EaseOut
+          childA = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          childB = Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+          result = normalizeAnimated cfg (Column [childA, childB])
+      result @?= Column [Animated cfg childA, Animated cfg childB]
+  , testCase "Distributes over Row children" $ do
+      let cfg = AnimatedConfig 300 EaseOut
+          childA = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          result = normalizeAnimated cfg (Row [childA])
+      result @?= Row [Animated cfg childA]
+  , testCase "Distributes over ScrollView children" $ do
+      let cfg = AnimatedConfig 300 EaseOut
+          childA = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          result = normalizeAnimated cfg (ScrollView [childA])
+      result @?= ScrollView [Animated cfg childA]
+  , testCase "Inner Animated wins over outer" $ do
+      let outerCfg = AnimatedConfig 500 EaseOut
+          innerCfg = AnimatedConfig 100 EaseIn
+          leaf = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          result = normalizeAnimated outerCfg (Animated innerCfg leaf)
+      -- Inner config is preserved, leaf is normalized under inner config
+      result @?= Animated innerCfg leaf
+  , testCase "Inner wins when distributed over Column" $ do
+      let outerCfg = AnimatedConfig 500 EaseOut
+          innerCfg = AnimatedConfig 100 EaseIn
+          leaf = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          explicitChild = Animated innerCfg leaf
+          plainChild = Text TextConfig { tcLabel = "y", tcFontConfig = Nothing }
+          result = normalizeAnimated outerCfg (Column [explicitChild, plainChild])
+      -- Distribution wraps each child in outer Animated; the render engine
+      -- then collapses the nested Animated (inner wins) during traversal.
+      result @?= Column [ Animated outerCfg (Animated innerCfg leaf)
+                         , Animated outerCfg plainChild ]
+  , testCase "Styled returned unchanged" $ do
+      let cfg = AnimatedConfig 300 EaseOut
+          style = defaultStyle { wsPadding = Just 10 }
+          child = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          result = normalizeAnimated cfg (Styled style child)
+      -- Styled is animatable as a unit, so normalizeAnimated doesn't modify it
+      result @?= Styled style child
+  , testCase "Leaf widget unchanged" $ do
+      let cfg = AnimatedConfig 300 EaseOut
+          leaf = Text TextConfig { tcLabel = "hi", tcFontConfig = Nothing }
+          result = normalizeAnimated cfg leaf
+      result @?= leaf
+  , testCase "Animated Column renders as RenderedContainer with RenderedAnimated children" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let cfg = AnimatedConfig 300 EaseOut
+          childA = Styled (defaultStyle { wsPadding = Just 10 }) $
+                     Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          childB = Styled (defaultStyle { wsPadding = Just 20 }) $
+                     Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+          widget = Animated cfg (Column [childA, childB])
+      renderWidget rs widget
+      renderedTree <- readIORef (rsRenderedTree rs)
+      case renderedTree of
+        Just (RenderedContainer (Column _) _ children) -> do
+          assertEqual "Should have 2 children" 2 (length children)
+          -- Each child should be RenderedAnimated wrapping RenderedStyled
+          mapM_ (\child -> case child of
+            RenderedAnimated _ (RenderedStyled _ _ _) -> pure ()
+            other -> assertFailure ("Expected RenderedAnimated(RenderedStyled), got: "
+                                     ++ renderedNodeSummary other)
+            ) children
+        other -> assertFailure ("Expected RenderedContainer, got: "
+                                 ++ show (fmap renderedNodeSummary other))
+  , testCase "Animated Column re-render with changed child diffs correctly" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let cfg = AnimatedConfig 300 EaseOut
+          style1 = defaultStyle { wsPadding = Just 10 }
+          style2 = defaultStyle { wsPadding = Just 50 }
+          child = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+          widget1 = Animated cfg (Column [Styled style1 child])
+          widget2 = Animated cfg (Column [Styled style2 child])
+      renderWidget rs widget1
+      Just tree1 <- readIORef (rsRenderedTree rs)
+      let nodeId1 = renderedNodeIdSafe tree1
+      renderWidget rs widget2
+      Just tree2 <- readIORef (rsRenderedTree rs)
+      let nodeId2 = renderedNodeIdSafe tree2
+      -- Container node ID should be the same (diff, not destroy+create)
+      nodeId1 @?= nodeId2
+  ]

--- a/test/Test/AppContextTests.hs
+++ b/test/Test/AppContextTests.hs
@@ -42,6 +42,7 @@ import HaskellMobile.AuthSession (newAuthSessionState)
 import HaskellMobile.Camera (newCameraState)
 import HaskellMobile.BottomSheet (newBottomSheetState)
 import HaskellMobile.Http (newHttpState)
+import HaskellMobile.Animation (newAnimationState)
 import HaskellMobile.NetworkStatus (newNetworkStatusState)
 import Test.Helpers (testApp, viewIsErrorWidget)
 
@@ -76,6 +77,7 @@ registrationTests = testGroup "Registration"
       dummyBottomSheetState <- newBottomSheetState
       dummyHttpState <- newHttpState
       dummyNetworkStatusState <- newNetworkStatusState
+      dummyAnimationState <- newAnimationState
       let dummyUserState = UserState
             { userPermissionState    = dummyPermState
             , userSecureStorageState = dummySecureStorageState
@@ -87,6 +89,7 @@ registrationTests = testGroup "Registration"
             , userBottomSheetState   = dummyBottomSheetState
             , userHttpState          = dummyHttpState
             , userNetworkStatusState = dummyNetworkStatusState
+            , userAnimationState     = dummyAnimationState
             }
       viewFn <- readIORef (acViewFunction appCtx)
       widget <- viewFn dummyUserState
@@ -122,6 +125,7 @@ registrationTests = testGroup "Registration"
       dummyBottomSheetState <- newBottomSheetState
       dummyHttpState <- newHttpState
       dummyNetworkStatusState <- newNetworkStatusState
+      dummyAnimationState <- newAnimationState
       let dummyUserState = UserState
             { userPermissionState    = dummyPermState
             , userSecureStorageState = dummySecureStorageState
@@ -133,6 +137,7 @@ registrationTests = testGroup "Registration"
             , userBottomSheetState   = dummyBottomSheetState
             , userHttpState          = dummyHttpState
             , userNetworkStatusState = dummyNetworkStatusState
+            , userAnimationState     = dummyAnimationState
             }
       viewFnA <- readIORef (acViewFunction appCtxA)
       viewFnB <- readIORef (acViewFunction appCtxB)

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -29,6 +29,7 @@ import HaskellMobile.Lifecycle
   , defaultMobileContext
   , loggingMobileContext
   )
+import HaskellMobile.Animation (newAnimationState)
 import HaskellMobile.Widget (TextConfig(..), Widget(..))
 import HaskellMobile.Render (RenderState, newRenderState)
 
@@ -39,7 +40,8 @@ withActions :: ActionM a -> IO (a, RenderState)
 withActions actionM = do
   actionState <- newActionState
   result <- runActionM actionState actionM
-  rs <- newRenderState actionState
+  animState <- newAnimationState
+  rs <- newRenderState actionState animState
   pure (result, rs)
 
 -- | Helper: create an 'AppContext' from a 'MobileApp',
@@ -108,6 +110,7 @@ viewIsErrorWidget ctxPtr = do
         , userBottomSheetState   = acBottomSheetState appCtx
         , userHttpState          = acHttpState appCtx
         , userNetworkStatusState = acNetworkStatusState appCtx
+        , userAnimationState     = acAnimationState appCtx
         }
   widget <- viewFn userState
   case widget of
@@ -122,3 +125,4 @@ viewIsErrorWidget ctxPtr = do
     Row _                    -> pure False
     ScrollView _             -> pure False
     Styled _ _               -> pure False
+    Animated _ _             -> pure False

--- a/test/Test/WidgetTests.hs
+++ b/test/Test/WidgetTests.hs
@@ -55,6 +55,7 @@ import HaskellMobile.AuthSession (newAuthSessionState)
 import HaskellMobile.Camera (newCameraState)
 import HaskellMobile.BottomSheet (newBottomSheetState)
 import HaskellMobile.Http (newHttpState)
+import HaskellMobile.Animation (newAnimationState)
 import HaskellMobile.NetworkStatus (newNetworkStatusState)
 import Test.Helpers (withActions, testApp)
 
@@ -149,6 +150,7 @@ uiTests = testGroup "UI"
       dummyBottomSheetState <- newBottomSheetState
       dummyHttpState <- newHttpState
       dummyNetworkStatusState <- newNetworkStatusState
+      dummyAnimationState <- newAnimationState
       let dummyUserState = UserState
             { userPermissionState    = dummyPermState
             , userSecureStorageState = dummySecureStorageState
@@ -160,6 +162,7 @@ uiTests = testGroup "UI"
             , userBottomSheetState   = dummyBottomSheetState
             , userHttpState          = dummyHttpState
             , userNetworkStatusState = dummyNetworkStatusState
+            , userAnimationState     = dummyAnimationState
             }
       app <- testApp
       widget <- maView app dummyUserState
@@ -175,6 +178,7 @@ uiTests = testGroup "UI"
         Row _           -> assertFailure "expected Text, got Row"
         ScrollView _    -> assertFailure "expected Text, got ScrollView"
         Styled _ _      -> assertFailure "expected Text, got Styled"
+        Animated _ _    -> assertFailure "expected Text, got Animated"
   ]
 
 -- | Tests for the ScrollView widget binding.

--- a/test/android/animation.sh
+++ b/test/android/animation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Android animation test: install animation APK, launch app,
+# verify the animation bridge fires callbacks and padding changes.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, ANIMATION_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+install_apk "$ANIMATION_APK" || { echo "FAIL: install_apk"; exit 1; }
+
+"$ADB" -s "$EMULATOR_SERIAL" logcat -c
+"$ADB" -s "$EMULATOR_SERIAL" shell am start -n "$PACKAGE/$ACTIVITY"
+
+wait_for_logcat "setRoot" 120 || true
+sleep 3
+
+# Tap Toggle Padding button to trigger animation
+tap_button "Toggle Padding" || { echo "WARNING: could not tap Toggle Padding"; }
+sleep 3
+
+# Dump logcat to check for animation callbacks
+LOGCAT_FILE="$WORK_DIR/animation_logcat.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_FILE" 2>&1 || true
+assert_logcat "$LOGCAT_FILE" "Toggled padding" "Padding toggled"
+assert_logcat "$LOGCAT_FILE" "setNumProp.*padding\|setRoot" "Animation rendered"
+
+# Verify no crash
+LOGCAT_ERR="$WORK_DIR/animation_logcat_err.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:E' > "$LOGCAT_ERR" 2>&1 || true
+if grep -qE "$FATAL_PATTERNS" "$LOGCAT_ERR" 2>/dev/null; then
+    echo "FAIL: Fatal crash detected during animation test"
+    grep -E "$FATAL_PATTERNS" "$LOGCAT_ERR" | tail -10
+    EXIT_CODE=1
+else
+    echo "PASS: No crash during animation test"
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/animation.sh
+++ b/test/ios/animation.sh
@@ -3,26 +3,58 @@
 # verify the animation bridge fires callbacks.
 #
 # Required env vars (set by simulator-all.nix harness):
-#   SIMCTL, DEVICE_ID, ANIMATION_APP, WORK_DIR
+#   SIM_UDID, BUNDLE_ID, ANIMATION_APP, WORK_DIR
 set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
 
 EXIT_CODE=0
 
 echo "--- Installing animation app ---"
-xcrun simctl install "$DEVICE_ID" "$ANIMATION_APP" || { echo "FAIL: install"; exit 1; }
-xcrun simctl launch --console "$DEVICE_ID" me.jappie.haskellmobile > "$WORK_DIR/animation_log.txt" 2>&1 &
-APP_PID=$!
+xcrun simctl install "$SIM_UDID" "$ANIMATION_APP" || { echo "FAIL: install"; exit 1; }
+
+ANIM_START=$(date "+%Y-%m-%d %H:%M:%S")
+
+STREAM_LOG="$WORK_DIR/animation_stream.txt"
+> "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$BUNDLE_ID\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
 sleep 5
 
-# Check log output for animation activity
-if grep -q "setRoot\|AnimationDemoMain" "$WORK_DIR/animation_log.txt" 2>/dev/null; then
-    echo "PASS: Animation app rendered"
-else
-    echo "FAIL: Animation app did not render"
-    EXIT_CODE=1
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest
+
+render_done=0
+wait_for_log "$STREAM_LOG" "setRoot" 60 && render_done=1 || true
+
+if [ $render_done -eq 0 ]; then
+    echo "WARNING: setRoot not found — retrying with relaunch"
+    xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+    sleep 3
+    > "$STREAM_LOG"
+    xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest
+    wait_for_log "$STREAM_LOG" "setRoot" 60 || true
 fi
 
-kill "$APP_PID" 2>/dev/null || true
-xcrun simctl uninstall "$DEVICE_ID" me.jappie.haskellmobile 2>/dev/null || true
+sleep 10
+
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+FULL_LOG="$WORK_DIR/animation_full.txt"
+get_full_log "$ANIM_START" "$FULL_LOG"
+
+if ! grep -q "setRoot" "$FULL_LOG" 2>/dev/null; then
+    echo "  'log show' empty/incomplete, using stream log"
+    FULL_LOG="$STREAM_LOG"
+fi
+
+assert_log "$FULL_LOG" "AnimationDemoMain started" "Animation demo app started"
+assert_log "$FULL_LOG" "createNode" "createNode called (app renders)"
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
 
 exit $EXIT_CODE

--- a/test/ios/animation.sh
+++ b/test/ios/animation.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# iOS animation test: install animation app, launch,
+# verify the animation bridge fires callbacks.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIMCTL, DEVICE_ID, ANIMATION_APP, WORK_DIR
+set -euo pipefail
+
+EXIT_CODE=0
+
+echo "--- Installing animation app ---"
+xcrun simctl install "$DEVICE_ID" "$ANIMATION_APP" || { echo "FAIL: install"; exit 1; }
+xcrun simctl launch --console "$DEVICE_ID" me.jappie.haskellmobile > "$WORK_DIR/animation_log.txt" 2>&1 &
+APP_PID=$!
+sleep 5
+
+# Check log output for animation activity
+if grep -q "setRoot\|AnimationDemoMain" "$WORK_DIR/animation_log.txt" 2>/dev/null; then
+    echo "PASS: Animation app rendered"
+else
+    echo "FAIL: Animation app did not render"
+    EXIT_CODE=1
+fi
+
+kill "$APP_PID" 2>/dev/null || true
+xcrun simctl uninstall "$DEVICE_ID" me.jappie.haskellmobile 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/watchos/animation.sh
+++ b/test/watchos/animation.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# watchOS animation test: install animation app, launch,
+# verify the animation bridge fires callbacks (uses desktop stub).
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIMCTL, DEVICE_ID, ANIMATION_APP, WORK_DIR
+set -euo pipefail
+
+EXIT_CODE=0
+
+echo "--- Installing animation app ---"
+xcrun simctl install "$DEVICE_ID" "$ANIMATION_APP" || { echo "FAIL: install"; exit 1; }
+xcrun simctl launch --console "$DEVICE_ID" me.jappie.haskellmobile > "$WORK_DIR/animation_log.txt" 2>&1 &
+APP_PID=$!
+sleep 5
+
+# Check log output for animation activity
+if grep -q "setRoot\|AnimationDemoMain" "$WORK_DIR/animation_log.txt" 2>/dev/null; then
+    echo "PASS: Animation app rendered"
+else
+    echo "FAIL: Animation app did not render"
+    EXIT_CODE=1
+fi
+
+kill "$APP_PID" 2>/dev/null || true
+xcrun simctl uninstall "$DEVICE_ID" me.jappie.haskellmobile 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/watchos/animation.sh
+++ b/test/watchos/animation.sh
@@ -3,26 +3,58 @@
 # verify the animation bridge fires callbacks (uses desktop stub).
 #
 # Required env vars (set by watchos-simulator-all.nix harness):
-#   SIMCTL, DEVICE_ID, ANIMATION_APP, WORK_DIR
+#   SIM_UDID, BUNDLE_ID, ANIMATION_APP, WORK_DIR
 set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
 
 EXIT_CODE=0
 
 echo "--- Installing animation app ---"
-xcrun simctl install "$DEVICE_ID" "$ANIMATION_APP" || { echo "FAIL: install"; exit 1; }
-xcrun simctl launch --console "$DEVICE_ID" me.jappie.haskellmobile > "$WORK_DIR/animation_log.txt" 2>&1 &
-APP_PID=$!
+xcrun simctl install "$SIM_UDID" "$ANIMATION_APP" || { echo "FAIL: install"; exit 1; }
+
+ANIM_START=$(date "+%Y-%m-%d %H:%M:%S")
+
+STREAM_LOG="$WORK_DIR/animation_stream.txt"
+> "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$BUNDLE_ID\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
 sleep 5
 
-# Check log output for animation activity
-if grep -q "setRoot\|AnimationDemoMain" "$WORK_DIR/animation_log.txt" 2>/dev/null; then
-    echo "PASS: Animation app rendered"
-else
-    echo "FAIL: Animation app did not render"
-    EXIT_CODE=1
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest
+
+render_done=0
+wait_for_log "$STREAM_LOG" "setRoot" 60 && render_done=1 || true
+
+if [ $render_done -eq 0 ]; then
+    echo "WARNING: setRoot not found — retrying with relaunch"
+    xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+    sleep 3
+    > "$STREAM_LOG"
+    xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest
+    wait_for_log "$STREAM_LOG" "setRoot" 60 || true
 fi
 
-kill "$APP_PID" 2>/dev/null || true
-xcrun simctl uninstall "$DEVICE_ID" me.jappie.haskellmobile 2>/dev/null || true
+sleep 10
+
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+FULL_LOG="$WORK_DIR/animation_full.txt"
+get_full_log "$ANIM_START" "$FULL_LOG"
+
+if ! grep -q "setRoot" "$FULL_LOG" 2>/dev/null; then
+    echo "  'log show' empty/incomplete, using stream log"
+    FULL_LOG="$STREAM_LOG"
+fi
+
+assert_log "$FULL_LOG" "AnimationDemoMain started" "Animation demo app started"
+assert_log "$FULL_LOG" "createNode" "createNode called (app renders)"
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
 
 exit $EXIT_CODE

--- a/watchos/HaskellMobile/HaskellMobile-Bridging-Header.h
+++ b/watchos/HaskellMobile/HaskellMobile-Bridging-Header.h
@@ -9,6 +9,7 @@
 #include "CameraBridge.h"
 #include "BottomSheetBridge.h"
 #include "NetworkStatusBridge.h"
+#include "AnimationBridge.h"
 
 /* Dispatch a text change event to Haskell.
  * Not declared in HaskellMobile.h but exported via foreign export ccall. */


### PR DESCRIPTION
## Summary

- Implements **Issue #66**: widget-tree based animation system using an `Animated` wrapper widget
- When child properties change between renders, the render engine automatically tweens from old to new values over a configurable duration/easing curve (Linear, EaseIn, EaseOut, EaseInOut)
- Animatable properties: padding, text color, background color (via `Styled`), font size, map coordinates
- Platform frame loops: Choreographer on Android, CADisplayLink on iOS, desktop stub for testing

## Architecture

```
Animated config child  -- user wraps any widget
  → render engine detects property change via Eq diff
  → registers ActiveTween in AnimationState (keyed by native node ID)
  → starts platform animation loop via C bridge

Platform vsync → haskellOnAnimationFrame(ctx, timestampMs)
  → dispatchAnimationFrame: iterate tweens, interpolateAndApply
  → renderView: user's view returns same target → Eq match → no new tween
  → loop auto-stops when no tweens remain
```

## Files changed

**New (10):** `Animation.hs`, `AnimationBridge.h`, `animation_bridge.c`, `animation_bridge_android.c`, `AnimationBridgeIOS.m`, `AnimationTests.hs`, `AnimationDemoMain.hs`, integration test scripts

**Modified (21):** Widget.hs, Render.hs, Types.hs, AppContext.hs, HaskellMobile.hs, cabal, platform headers/bridges, nix integration, test helpers

## Test plan

- [x] 21 new animation unit tests (easing, interpolation, color blending, tween registry, Animated widget rendering)
- [x] All 224 tests pass (`cabal test`)
- [x] Zero warnings (`cabal clean && cabal build`)
- [ ] CI passes (nix-build, android emulator, iOS simulator, watchOS simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)