### PR TITLE
Add translateX/translateY offset to WidgetStyle

### DIFF
--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -696,6 +696,20 @@ static void android_set_num_prop(int32_t nodeId, int32_t propId, double value)
         /* No-op for placeholder — real map would toggle location layer */
         LOGI("setNumProp(node=%d, showUserLoc=%.0f)", nodeId, value);
         break;
+    case UI_PROP_TRANSLATE_X: {
+        jmethodID setTranslationX = (*env)->GetMethodID(env,
+            g_class_View, "setTranslationX", "(F)V");
+        (*env)->CallVoidMethod(env, view, setTranslationX, (jfloat)value);
+        LOGI("setNumProp(node=%d, translateX=%.1f)", nodeId, value);
+        break;
+    }
+    case UI_PROP_TRANSLATE_Y: {
+        jmethodID setTranslationY = (*env)->GetMethodID(env,
+            g_class_View, "setTranslationY", "(F)V");
+        (*env)->CallVoidMethod(env, view, setTranslationY, (jfloat)value);
+        LOGI("setNumProp(node=%d, translateY=%.1f)", nodeId, value);
+        break;
+    }
     default:
         LOGI("setNumProp: unknown propId %d", propId);
         break;

--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -57,6 +57,7 @@ static jclass   g_class_ImageView;
 static jclass   g_class_WebView;
 static jclass   g_class_FrameLayout;
 static jclass   g_class_BitmapFactory;
+static jclass   g_class_View;
 static jclass   g_class_ViewGroup;
 static jclass   g_class_ViewGroup_LayoutParams;
 static jclass   g_class_Integer;
@@ -171,6 +172,10 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     cls = (*env)->FindClass(env, "android/graphics/BitmapFactory");
     if (!cls) return -1;
     g_class_BitmapFactory = (*env)->NewGlobalRef(env, cls);
+
+    cls = (*env)->FindClass(env, "android/view/View");
+    if (!cls) return -1;
+    g_class_View = (*env)->NewGlobalRef(env, cls);
 
     cls = (*env)->FindClass(env, "android/view/ViewGroup");
     if (!cls) return -1;

--- a/include/UIBridge.h
+++ b/include/UIBridge.h
@@ -33,6 +33,8 @@
 #define UI_PROP_MAP_LON             6
 #define UI_PROP_MAP_ZOOM            7
 #define UI_PROP_MAP_SHOW_USER_LOC   8
+#define UI_PROP_TRANSLATE_X         9
+#define UI_PROP_TRANSLATE_Y         10
 
 /* Event types */
 #define UI_EVENT_CLICK       0

--- a/ios/HaskellMobile/UIBridgeIOS.m
+++ b/ios/HaskellMobile/UIBridgeIOS.m
@@ -591,6 +591,18 @@ static void ios_set_num_prop(int32_t nodeId, int32_t propId, double value)
         LOGI("setNumProp(node=%d, showUserLoc=%.0f)", nodeId, value);
         break;
     }
+    case UI_PROP_TRANSLATE_X: {
+        CGAffineTransform t = view.transform;
+        view.transform = CGAffineTransformMake(t.a, t.b, t.c, t.d, (CGFloat)value, t.ty);
+        LOGI("setNumProp(node=%d, translateX=%.1f)", nodeId, value);
+        break;
+    }
+    case UI_PROP_TRANSLATE_Y: {
+        CGAffineTransform t = view.transform;
+        view.transform = CGAffineTransformMake(t.a, t.b, t.c, t.d, t.tx, (CGFloat)value);
+        LOGI("setNumProp(node=%d, translateY=%.1f)", nodeId, value);
+        break;
+    }
     default:
         LOGI("setNumProp: unknown propId %d", propId);
         break;

--- a/src/HaskellMobile/Animation.hs
+++ b/src/HaskellMobile/Animation.hs
@@ -220,6 +220,24 @@ interpolateStyle nodeId fromStyle toStyle progress = do
       Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex toColor)
     (Just _fromColor, Nothing) -> pure ()
     (Nothing, Nothing) -> pure ()
+  -- TranslateX
+  case (wsTranslateX fromStyle, wsTranslateX toStyle) of
+    (Just fromTx, Just toTx) ->
+      Bridge.setNumProp nodeId Bridge.PropTranslateX
+        (interpolateDouble fromTx toTx progress)
+    (Nothing, Just toTx) ->
+      Bridge.setNumProp nodeId Bridge.PropTranslateX toTx
+    (Just _fromTx, Nothing) -> pure ()
+    (Nothing, Nothing) -> pure ()
+  -- TranslateY
+  case (wsTranslateY fromStyle, wsTranslateY toStyle) of
+    (Just fromTy, Just toTy) ->
+      Bridge.setNumProp nodeId Bridge.PropTranslateY
+        (interpolateDouble fromTy toTy progress)
+    (Nothing, Just toTy) ->
+      Bridge.setNumProp nodeId Bridge.PropTranslateY toTy
+    (Just _fromTy, Nothing) -> pure ()
+    (Nothing, Nothing) -> pure ()
 
 -- | Interpolate font size between two optional 'FontConfig' values.
 interpolateFontSize :: Int32 -> Maybe FontConfig -> Maybe FontConfig -> Double -> IO ()

--- a/src/HaskellMobile/Render.hs
+++ b/src/HaskellMobile/Render.hs
@@ -136,6 +136,12 @@ applyStyle nodeId style = do
   case wsBackgroundColor style of
     Just color -> Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex color)
     Nothing    -> pure ()
+  case wsTranslateX style of
+    Just tx -> Bridge.setNumProp nodeId Bridge.PropTranslateX tx
+    Nothing -> pure ()
+  case wsTranslateY style of
+    Just ty -> Bridge.setNumProp nodeId Bridge.PropTranslateY ty
+    Nothing -> pure ()
 
 -- ---------------------------------------------------------------------------
 -- Creating rendered nodes from scratch

--- a/src/HaskellMobile/UIBridge.hs
+++ b/src/HaskellMobile/UIBridge.hs
@@ -75,6 +75,8 @@ data PropId
   | PropMapLon
   | PropMapZoom
   | PropMapShowUserLoc
+  | PropTranslateX
+  | PropTranslateY
   deriving (Show, Eq, Enum, Bounded)
 
 -- | Map a 'PropId' to its C integer code.
@@ -95,6 +97,8 @@ propIdToInt PropMapLat        = 5
 propIdToInt PropMapLon        = 6
 propIdToInt PropMapZoom       = 7
 propIdToInt PropMapShowUserLoc = 8
+propIdToInt PropTranslateX    = 9
+propIdToInt PropTranslateY    = 10
 
 -- | Event types corresponding to @UI_EVENT_*@ in @UIBridge.h@.
 data EventType

--- a/src/HaskellMobile/Widget.hs
+++ b/src/HaskellMobile/Widget.hs
@@ -145,6 +145,14 @@ data WidgetStyle = WidgetStyle
     -- ^ Text color.
   , wsBackgroundColor :: Maybe Color
     -- ^ Background color.
+  , wsTranslateX      :: Maybe Double
+    -- ^ Horizontal translation offset in platform-native units.
+    -- Moves the widget without affecting sibling layout
+    -- (Android: @translationX@, iOS: @CGAffineTransform@,
+    -- watchOS: @.offset(x:y:)@).
+  , wsTranslateY      :: Maybe Double
+    -- ^ Vertical translation offset in platform-native units.
+    -- Moves the widget without affecting sibling layout.
   } deriving (Show, Eq)
 
 -- | No style overrides — all fields are 'Nothing'.
@@ -154,6 +162,8 @@ defaultStyle = WidgetStyle
   , wsTextAlign       = Nothing
   , wsTextColor       = Nothing
   , wsBackgroundColor = Nothing
+  , wsTranslateX      = Nothing
+  , wsTranslateY      = Nothing
   }
 
 -- | Easing function for animations.

--- a/test/CounterDemoMain.hs
+++ b/test/CounterDemoMain.hs
@@ -31,7 +31,7 @@ counterView :: IORef Int -> Action -> Action -> IO Widget
 counterView counterState onIncrement onDecrement = do
   n <- readIORef counterState
   pure $ Column
-    [ Styled (WidgetStyle (Just 16.0) (Just AlignCenter) (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)))
+    [ Styled (WidgetStyle (Just 16.0) (Just AlignCenter) (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)) Nothing Nothing)
         (Text TextConfig
           { tcLabel      = "Counter: " <> Text.pack (show n)
           , tcFontConfig = Just (FontConfig 24.0)

--- a/test/Test/ActionTests.hs
+++ b/test/Test/ActionTests.hs
@@ -288,7 +288,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
 
       , testCase "styled unchanged keeps same node ID" $ do
           ((), rs) <- withActions (pure ())
-          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing
+          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing Nothing Nothing
               widget = Styled style (Text TextConfig { tcLabel = "styled", tcFontConfig = Nothing })
           renderWidget rs widget
           tree1 <- readIORef (rsRenderedTree rs)
@@ -304,7 +304,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
 
       , testCase "styled child change updates child" $ do
           ((), rs) <- withActions (pure ())
-          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing
+          let style = WidgetStyle (Just 10.0) Nothing Nothing Nothing Nothing Nothing
               widget1 = Styled style (Text TextConfig { tcLabel = "before", tcFontConfig = Nothing })
           renderWidget rs widget1
           tree1 <- readIORef (rsRenderedTree rs)

--- a/test/Test/AnimationTests.hs
+++ b/test/Test/AnimationTests.hs
@@ -44,6 +44,7 @@ animationTests = testGroup "Animation"
   , tweenRegistryTests
   , animatedWidgetRenderTests
   , normalizeAnimatedTests
+  , translateAnimationTests
   ]
 
 -- ---------------------------------------------------------------------------
@@ -346,4 +347,40 @@ normalizeAnimatedTests = testGroup "normalizeAnimated"
       let nodeId2 = renderedNodeIdSafe tree2
       -- Container node ID should be the same (diff, not destroy+create)
       nodeId1 @?= nodeId2
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Translate animation
+-- ---------------------------------------------------------------------------
+
+translateAnimationTests :: TestTree
+translateAnimationTests = testGroup "Translate animation"
+  [ testCase "Animated translate change keeps same native node" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let child1 = Styled (defaultStyle { wsTranslateX = Just 0, wsTranslateY = Just 0 })
+                     (Text TextConfig { tcLabel = "t", tcFontConfig = Nothing })
+          child2 = Styled (defaultStyle { wsTranslateX = Just 100, wsTranslateY = Just 50 })
+                     (Text TextConfig { tcLabel = "t", tcFontConfig = Nothing })
+          widget1 = Animated (AnimatedConfig 300 EaseOut) child1
+          widget2 = Animated (AnimatedConfig 300 EaseOut) child2
+      renderWidget rs widget1
+      Just firstTree <- readIORef (rsRenderedTree rs)
+      let firstNodeId = renderedNodeIdSafe firstTree
+      renderWidget rs widget2
+      Just secondTree <- readIORef (rsRenderedTree rs)
+      let secondNodeId = renderedNodeIdSafe secondTree
+      firstNodeId @?= secondNodeId
+  , testCase "defaultStyle has no translate offsets" $ do
+      wsTranslateX defaultStyle @?= Nothing
+      wsTranslateY defaultStyle @?= Nothing
+  , testCase "Styled with translate renders without error" $ do
+      actionState <- newActionState
+      animState <- newAnimationState
+      rs <- newRenderState actionState animState
+      renderWidget rs $ Styled (defaultStyle { wsTranslateX = Just 10.5, wsTranslateY = Just (-20.0) })
+        (Text TextConfig { tcLabel = "offset", tcFontConfig = Nothing })
   ]

--- a/test/Test/WidgetTests.hs
+++ b/test/Test/WidgetTests.hs
@@ -442,14 +442,14 @@ styledTests :: TestTree
 styledTests = testGroup "Styled"
   [ testCase "Styled Text renders without error" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Styled (WidgetStyle (Just 8.0) Nothing Nothing Nothing)
+      renderWidget rs $ Styled (WidgetStyle (Just 8.0) Nothing Nothing Nothing Nothing Nothing)
         (Text TextConfig { tcLabel = "styled", tcFontConfig = Just (FontConfig 20.0) })
 
   , testCase "Styled Button fires callback" $ do
       ref <- newIORef (0 :: Int)
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (+ 1))
-      renderWidget rs $ Styled (WidgetStyle Nothing Nothing Nothing Nothing)
+      renderWidget rs $ Styled (WidgetStyle Nothing Nothing Nothing Nothing Nothing Nothing)
         (Button ButtonConfig
           { bcLabel = "tap", bcAction = clickHandle
           , bcFontConfig = Just (FontConfig 16.0) })
@@ -473,8 +473,8 @@ styledTests = testGroup "Styled"
   , testCase "nested Styled applies both styles" $ do
       ((), rs) <- withActions (pure ())
       renderWidget rs $
-        Styled (WidgetStyle (Just 12.0) Nothing Nothing Nothing)
-          (Styled (WidgetStyle Nothing Nothing Nothing Nothing)
+        Styled (WidgetStyle (Just 12.0) Nothing Nothing Nothing Nothing Nothing)
+          (Styled (WidgetStyle Nothing Nothing Nothing Nothing Nothing Nothing)
             (Text TextConfig { tcLabel = "double styled", tcFontConfig = Just (FontConfig 18.0) }))
 
   , testCase "defaultStyle is a no-op" $ do
@@ -502,14 +502,14 @@ textAlignTests :: TestTree
 textAlignTests = testGroup "TextAlignment"
   [ testCase "Styled with AlignCenter renders without error" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignCenter) Nothing Nothing)
+      renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignCenter) Nothing Nothing Nothing Nothing)
         (Text TextConfig { tcLabel = "centered", tcFontConfig = Nothing })
 
   , testCase "Styled with AlignCenter on Button fires callback" $ do
       ref <- newIORef (0 :: Int)
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (+ 1))
-      renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignCenter) Nothing Nothing)
+      renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignCenter) Nothing Nothing Nothing Nothing)
         (Button ButtonConfig
           { bcLabel = "tap", bcAction = clickHandle, bcFontConfig = Nothing })
       dispatchEvent rs (actionId clickHandle)
@@ -521,7 +521,7 @@ textAlignTests = testGroup "TextAlignment"
 
   , testCase "Styled with AlignEnd renders without error" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignEnd) Nothing Nothing)
+      renderWidget rs $ Styled (WidgetStyle Nothing (Just AlignEnd) Nothing Nothing Nothing Nothing)
         (Text TextConfig { tcLabel = "end aligned", tcFontConfig = Nothing })
   ]
 
@@ -532,7 +532,7 @@ colorTests = testGroup "Colors"
       ref <- newIORef (0 :: Int)
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (+ 1))
-      renderWidget rs $ Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) Nothing)
+      renderWidget rs $ Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) Nothing Nothing Nothing)
         (Button ButtonConfig
           { bcLabel = "red", bcAction = clickHandle, bcFontConfig = Nothing })
       dispatchEvent rs (actionId clickHandle)
@@ -541,14 +541,14 @@ colorTests = testGroup "Colors"
 
   , testCase "Styled with backgroundColor renders without error" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Styled (WidgetStyle Nothing Nothing Nothing (Just (Color 0 255 0 255)))
+      renderWidget rs $ Styled (WidgetStyle Nothing Nothing Nothing (Just (Color 0 255 0 255)) Nothing Nothing)
         (Text TextConfig { tcLabel = "green bg", tcFontConfig = Nothing })
 
   , testCase "both textColor and backgroundColor together" $ do
       ref <- newIORef (0 :: Int)
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (+ 1))
-      renderWidget rs $ Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)))
+      renderWidget rs $ Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)) Nothing Nothing)
         (Button ButtonConfig
           { bcLabel = "colored", bcAction = clickHandle, bcFontConfig = Nothing })
       dispatchEvent rs (actionId clickHandle)
@@ -562,8 +562,8 @@ colorTests = testGroup "Colors"
   , testCase "nested Styled with different colors renders" $ do
       ((), rs) <- withActions (pure ())
       renderWidget rs $
-        Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) Nothing)
-          (Styled (WidgetStyle Nothing Nothing Nothing (Just (Color 0 0 255 255)))
+        Styled (WidgetStyle Nothing Nothing (Just (Color 255 0 0 255)) Nothing Nothing Nothing)
+          (Styled (WidgetStyle Nothing Nothing Nothing (Just (Color 0 0 255 255)) Nothing Nothing)
             (Text TextConfig { tcLabel = "nested colors", tcFontConfig = Nothing }))
 
   , testCase "colorFromText parses #RRGGBB" $

--- a/watchos/HaskellMobile/ContentView.swift
+++ b/watchos/HaskellMobile/ContentView.swift
@@ -18,6 +18,7 @@ struct NodeView: View {
             .ifLet(node.backgroundColor.flatMap { Color(hex: $0) }) { view, color in
                 view.background(color)
             }
+            .offset(x: node.translateX, y: node.translateY)
         return content
     }
 

--- a/watchos/HaskellMobile/WatchUIBridgeState.swift
+++ b/watchos/HaskellMobile/WatchUIBridgeState.swift
@@ -79,6 +79,12 @@ class WatchUIBridgeState: ObservableObject {
             node.mapZoom = value
         case 8: // UI_PROP_MAP_SHOW_USER_LOC (no-op on watchOS)
             os_log("setNumProp(node=%d, showUserLoc=%.0f)", log: bridgeLog, type: .info, nodeId, value)
+        case 9: // UI_PROP_TRANSLATE_X
+            os_log("setNumProp(node=%d, translateX=%.1f)", log: bridgeLog, type: .info, nodeId, value)
+            node.translateX = CGFloat(value)
+        case 10: // UI_PROP_TRANSLATE_Y
+            os_log("setNumProp(node=%d, translateY=%.1f)", log: bridgeLog, type: .info, nodeId, value)
+            node.translateY = CGFloat(value)
         default:
             os_log("setNumProp: unknown propId %d", log: bridgeLog, type: .info, propId)
         }

--- a/watchos/HaskellMobile/WatchUINode.swift
+++ b/watchos/HaskellMobile/WatchUINode.swift
@@ -22,6 +22,8 @@ class WatchUINode: ObservableObject, Identifiable {
     @Published var mapLatitude: Double?
     @Published var mapLongitude: Double?
     @Published var mapZoom: Double?
+    @Published var translateX: CGFloat = 0
+    @Published var translateY: CGFloat = 0
     @Published var children: [WatchUINode] = []
 
     init(id: Int32, nodeType: Int32) {


### PR DESCRIPTION
## Summary
- Adds `wsTranslateX` / `wsTranslateY` fields to `WidgetStyle` for positional offset without affecting sibling layout
- Fully animatable via existing `Animated` wrapper — enables sliding transitions, confetti effects, etc.
- Platform implementations: Android (`setTranslationX/Y`), iOS (`CGAffineTransform`), watchOS (`.offset(x:y:)`)

## Test plan
- [x] 3 new translate animation tests (node reuse, defaultStyle, render)
- [x] All 236 tests pass
- [ ] CI: all 5 jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)