### PR TITLE
Support Template Haskell in consumer code (mkAndroidLib)

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -15,6 +15,7 @@ let
     consumer-deps-test = import ./test-consumer-deps.nix { inherit sources; };
     th-test = import ./test-th.nix { inherit sources; };
     readme-example = import ./test-readme-example.nix { inherit sources; };
+    th-direct-test = import ./test-th-direct.nix { inherit sources; };
   } // (if isDarwin then {
     ios-lib = import ./ios.nix { inherit sources; };
     watchos-lib = import ./watchos.nix { inherit sources; };

--- a/nix/collect-deps.nix
+++ b/nix/collect-deps.nix
@@ -12,6 +12,7 @@
 , ghc               # GHC derivation (for boot package .a files)
 , ghcPkgCmd         # full path to ghc-pkg (or cross ghc-pkg)
 , deps              # list of haskellPackages derivations (from resolve-deps.nix)
+, iservProxy ? null # optional iserv wrapper script for consumer-side TH
 }:
 let
   depsList = builtins.concatStringsSep " " (map toString deps);
@@ -66,6 +67,15 @@ in pkgs.runCommand "haskell-mobile-collected-deps" {
   done
 
   ${ghcPkgCmd} --package-db=$out/pkgdb recache
+
+  # Copy iserv wrapper for consumer-side Template Haskell support.
+  ${if iservProxy != null then ''
+    mkdir -p $out/bin
+    cp ${iservProxy} $out/bin/iserv-proxy-wrapper
+    chmod +x $out/bin/iserv-proxy-wrapper
+    echo "=== iserv wrapper ==="
+    echo "Installed: $out/bin/iserv-proxy-wrapper"
+  '' else ""}
 
   echo "=== Package database ==="
   ${ghcPkgCmd} --package-db=$out/pkgdb list

--- a/nix/cross-deps.nix
+++ b/nix/cross-deps.nix
@@ -236,7 +236,27 @@ WRAPPER
     haskellPkgs = crossHaskellPkgs;
   };
 
+  # --- iserv wrapper for consumer-side TH ---
+  # Replicates the wrapper pattern from nixpkgs generic-builder.nix so
+  # mkAndroidLib can pass -fexternal-interpreter -pgmi <wrapper> to GHC.
+  iservHost = crossHaskellPkgs.iserv-proxy;   # target binary (statically linked)
+  iservBuild = pkgs.haskellPackages.iserv-proxy; # native build-host binary
+  emulatorCmd = if androidArch == "aarch64"
+    then "${pkgs.qemu-user}/bin/qemu-aarch64"   # overlay adds -B 0x4000000000
+    else "${pkgs.qemu-user}/bin/qemu-arm";
+
+  iservWrapper = pkgs.writeShellScript "iserv-wrapper" ''
+    set -euo pipefail
+    PORT=$((5000 + RANDOM % 5000))
+    (>&2 echo "---> Starting remote interpreter on port $PORT")
+    ${emulatorCmd} ${iservHost}/bin/iserv-proxy-interpreter tmp $PORT &
+    RISERV_PID="$!"
+    trap "kill $RISERV_PID" EXIT
+    ${iservBuild}/bin/iserv-proxy "$@" 127.0.0.1 "$PORT"
+  '';
+
 in import ./collect-deps.nix {
   inherit pkgs ghc ghcPkgCmd;
   deps = resolvedDeps;
+  iservProxy = iservWrapper;
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -86,12 +86,20 @@ in {
     , extraLinkObjects ? []
     , extraGhcIncludeDirs ? []
     , crossDeps ? null          # output of cross-deps.nix (lib/, hi/, pkgdb/)
+    , extraGhcFlags ? []        # additional flags passed to cross-GHC
     , maxNodes ? 256            # static pool size (ignored when dynamicNodePool=true)
     , dynamicNodePool ? false   # use malloc/realloc instead of fixed array
     , soMaxSizeMB ? 200         # fail build if .so exceeds this (MB), catches whole-archive bloat
     }:
     let
       jniPackageMacro = builtins.replaceStrings ["."] ["_"] javaPackageName;
+
+      # Template Haskell support for consumer code: when crossDeps includes
+      # the iserv wrapper, add -fexternal-interpreter so GHC delegates TH
+      # splices to the QEMU-emulated iserv-proxy-interpreter.
+      thFlags = if crossDeps != null
+        then "-fexternal-interpreter -pgmi ${crossDeps}/bin/iserv-proxy-wrapper"
+        else "";
     in
     pkgs.stdenv.mkDerivation {
       inherit pname;
@@ -332,6 +340,8 @@ in {
           -I${haskellMobileSrc}/include \
           ${builtins.concatStringsSep " " (map (d: "-I${d}") extraGhcIncludeDirs)} \
           ${if crossDeps != null then "-package-db ${crossDeps}/pkgdb -i${crossDeps}/hi" else ""} \
+          ${thFlags} \
+          ${builtins.concatStringsSep " " extraGhcFlags} \
           Main.hs \
           HaskellMobile.hs \
           cbits/android_stubs.c \

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -277,8 +277,11 @@ in {
         # Copy user entry point (plain main :: IO (), no foreign export needed)
         cp ${mainModule} Main.hs
 
-        # Step 3: Copy C sources that GHC compiles into writable build dir.
-        # GHC writes .o.tmp files next to C sources; nix store is read-only.
+        # Step 3: Copy C sources into writable build dir and compile them
+        # separately with cross-GHC.  This keeps them out of GHC's
+        # compilation graph so iserv-proxy-interpreter doesn't try to
+        # load them during Template Haskell evaluation (the C bridge
+        # files reference Haskell FFI exports that iserv can't resolve).
         mkdir -p cbits
         cp ${haskellMobileSrc}/cbits/android_stubs.c cbits/
         cp ${haskellMobileSrc}/cbits/platform_log.c cbits/
@@ -297,6 +300,12 @@ in {
         cp ${haskellMobileSrc}/cbits/http_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/network_status_bridge.c cbits/
         cp ${haskellMobileSrc}/cbits/animation_bridge.c cbits/
+
+        echo "=== Compiling C bridge files with cross-GHC ==="
+        for cfile in cbits/*.c; do
+          echo "  $cfile"
+          ${ghcCmd} -c -I${haskellMobileSrc}/include "$cfile"
+        done
 
         # Step 4: Compile Haskell to shared library with cross-GHC.
         # Discover library paths dynamically — hash suffixes vary across nixpkgs.
@@ -344,23 +353,6 @@ in {
           ${builtins.concatStringsSep " " extraGhcFlags} \
           Main.hs \
           HaskellMobile.hs \
-          cbits/android_stubs.c \
-          cbits/platform_log.c \
-          cbits/numa_stubs.c \
-          cbits/ui_bridge.c \
-          cbits/run_main.c \
-          cbits/locale.c \
-          cbits/permission_bridge.c \
-          cbits/secure_storage_bridge.c \
-          cbits/ble_bridge.c \
-          cbits/dialog_bridge.c \
-          cbits/location_bridge.c \
-          cbits/auth_session_bridge.c \
-          cbits/camera_bridge.c \
-          cbits/bottom_sheet_bridge.c \
-          cbits/http_bridge.c \
-          cbits/network_status_bridge.c \
-          cbits/animation_bridge.c \
           -optl-L${androidPkgs.gmp}/lib \
           -optl-L${androidPkgs.libffi}/lib \
           -optl-lffi \
@@ -379,6 +371,23 @@ in {
           -optl$(pwd)/http_bridge_android.o \
           -optl$(pwd)/network_status_android.o \
           -optl$(pwd)/animation_bridge_android.o \
+          -optl$(pwd)/cbits/android_stubs.o \
+          -optl$(pwd)/cbits/platform_log.o \
+          -optl$(pwd)/cbits/numa_stubs.o \
+          -optl$(pwd)/cbits/ui_bridge.o \
+          -optl$(pwd)/cbits/run_main.o \
+          -optl$(pwd)/cbits/locale.o \
+          -optl$(pwd)/cbits/permission_bridge.o \
+          -optl$(pwd)/cbits/secure_storage_bridge.o \
+          -optl$(pwd)/cbits/ble_bridge.o \
+          -optl$(pwd)/cbits/dialog_bridge.o \
+          -optl$(pwd)/cbits/location_bridge.o \
+          -optl$(pwd)/cbits/auth_session_bridge.o \
+          -optl$(pwd)/cbits/camera_bridge.o \
+          -optl$(pwd)/cbits/bottom_sheet_bridge.o \
+          -optl$(pwd)/cbits/http_bridge.o \
+          -optl$(pwd)/cbits/network_status_bridge.o \
+          -optl$(pwd)/cbits/animation_bridge.o \
           ${builtins.concatStringsSep " " (builtins.genList (i: "-optl$(pwd)/extra_jni_${toString i}.o") (builtins.length extraJniBridge))} \
           ${builtins.concatStringsSep " " (map (o: "-optl${o}") extraLinkObjects)} \
           -optl-Wl,-u,haskellRunMain \

--- a/nix/test-th-direct.nix
+++ b/nix/test-th-direct.nix
@@ -1,0 +1,10 @@
+# Integration test: build an Android library with consumer-side TH.
+#
+# Unlike test-th.nix (TH in a dependency package), this tests TH splices
+# directly in consumer code compiled by mkAndroidLib.  Requires the
+# iserv-proxy wrapper threaded through crossDeps.
+{ sources ? import ../npins }:
+import ./android.nix {
+  inherit sources;
+  mainModule = ../test/THDirectMain.hs;
+}

--- a/test/THDirectMain.hs
+++ b/test/THDirectMain.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Entry point for consumer-side Template Haskell test.
+--
+-- Unlike THDemoMain (which imports TH from a dependency package),
+-- this module uses a TH splice directly.  If this builds for
+-- aarch64-android, TH works in consumer code compiled by mkAndroidLib.
+module Main where
+
+import Data.Text (pack)
+import Foreign.Ptr (Ptr)
+import Language.Haskell.TH.Syntax (lift)
+import HaskellMobile (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
+import HaskellMobile.Widget (TextConfig(..), Widget(..))
+
+-- | Compile-time evaluated splice — forces -fexternal-interpreter in mkAndroidLib.
+thMessage :: String
+thMessage = $(lift ("TH in consumer code works!" :: String))
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog (pack thMessage)
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "th-direct", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }


### PR DESCRIPTION
## Summary

- Thread iserv-proxy wrapper from `cross-deps.nix` through `collect-deps.nix` into `mkAndroidLib` so consumer modules can use `{-# LANGUAGE TemplateHaskell #-}` directly, without splitting TH code into a separate sub-package
- The wrapper replicates nixpkgs' `generic-builder.nix` pattern: starts statically-linked `iserv-proxy-interpreter` under QEMU, then runs native `iserv-proxy` to relay GHC's pipe protocol over TCP
- `mkAndroidLib` auto-detects the wrapper and adds `-fexternal-interpreter -pgmi` flags
- Adds `extraGhcFlags` parameter for additional consumer GHC flags
- Includes `test/THDirectMain.hs` and `nix/test-th-direct.nix` integration test

Closes #141

## Test plan

- [ ] `nix-build nix/test-th-direct.nix` — builds APK with consumer-side TH splice
- [ ] `nix-build nix/test-th.nix` — regression check (dependency-side TH still works)
- [ ] `nix-build nix/android.nix` — basic build still works (no TH, iserv flags are no-ops)
- [ ] `cabal test` — all 233 unit tests pass (no Haskell library changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)