### PR TITLE
CI-compile the Readme example against library master

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -14,6 +14,7 @@ let
     consumer-link-test = import ./test-link-consumer.nix { inherit sources; };
     consumer-deps-test = import ./test-consumer-deps.nix { inherit sources; };
     th-test = import ./test-th.nix { inherit sources; };
+    readme-example = import ./test-readme-example.nix { inherit sources; };
   } // (if isDarwin then {
     ios-lib = import ./ios.nix { inherit sources; };
     watchos-lib = import ./watchos.nix { inherit sources; };

--- a/nix/test-readme-example.nix
+++ b/nix/test-readme-example.nix
@@ -1,0 +1,31 @@
+{ sources ? import ../npins }:
+let
+  pkgs = import sources.nixpkgs {};
+  hpkgs = import ./hpkgs.nix { inherit pkgs; };
+  readme = ../Readme.md;
+
+  # Extract the first ```haskell block after "## Writing your app"
+  extractedMain = pkgs.runCommand "extract-readme-main" {} ''
+    ${pkgs.gawk}/bin/awk '
+      /^## Writing your app/ { found_section=1 }
+      found_section && /^```haskell/ { capture=1; next }
+      capture && /^```/ { capture=0 }
+      capture { print }
+    ' ${readme} > $out
+
+    if [ ! -s "$out" ]; then
+      echo "ERROR: Failed to extract Haskell code block from Readme.md"
+      echo "Expected a \`\`\`haskell fenced block under '## Writing your app'"
+      exit 1
+    fi
+  '';
+in
+  pkgs.runCommand "readme-example-typecheck" {
+    nativeBuildInputs = [
+      (hpkgs.ghcWithPackages (p: [ p.haskell-mobile-project ]))
+    ];
+  } ''
+    cp ${extractedMain} Main.hs
+    ghc -fno-code -c Main.hs
+    touch $out
+  ''


### PR DESCRIPTION
## Summary
- Adds `nix/test-readme-example.nix` that extracts the ```haskell code block from the "Writing your app" section of `Readme.md` and typechecks it with `ghc -fno-code`
- Fails loudly if the code block is missing or the markdown fencing changes
- Registers the target in `nix/ci.nix` under `buildTargets` so it runs on every push via `all-builds`

## Test plan
- [x] `nix-build nix/test-readme-example.nix` succeeds
- [x] `nix-build nix/ci.nix -A readme-example` succeeds
- [ ] Temporarily breaking the Readme example (e.g. renaming `maView`) causes a type error
- [ ] Removing the code block causes the extraction error

🤖 Generated with [Claude Code](https://claude.com/claude-code)