### PR TITLE
Reorganize Hatter haddock documentation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,38 @@
 # Change log for hatter
 
-## Version 1.0.0
+## Version 0.2.0
 
-Initial release of hatter.
+### Breaking changes
+
+- Platform-specific types are no longer re-exported from `Hatter`.
+  Import them from their own modules instead:
+  `Hatter.Permission`, `Hatter.SecureStorage`, `Hatter.Ble`,
+  `Hatter.Dialog`, `Hatter.Location`, `Hatter.AuthSession`,
+  `Hatter.Camera`, `Hatter.BottomSheet`, `Hatter.Http`,
+  `Hatter.NetworkStatus`, `Hatter.Locale`, `Hatter.I18n`,
+  `Hatter.FilesDir`.
+- `AppContext`, `derefAppContext`, `freeAppContext`, and `newAppContext`
+  moved to `Hatter.AppContext` (no longer re-exported from `Hatter`).
+- `newMobileContext` and `freeMobileContext` are no longer re-exported
+  from `Hatter` (available from `Hatter.Lifecycle`).
+- FFI dispatch functions (`haskellOnPermissionResult`,
+  `haskellOnBleScanResult`, etc.) are no longer in the Haskell export
+  list.  They remain available as C symbols via `foreign export ccall`.
+- Removed `haskellGreet` (dead hello-world smoke test, unused by any
+  app code).
+
+### Added
+
+- `Hatter` module now has a haddock header with overview, usage example,
+  and a directory of platform subsystem modules.
+- Export list organised under haddock section headers: App setup, Widget,
+  Actions, Animation, Lifecycle, Error handling, Internal.
+- Full `Hatter.Widget` re-exports in the main module: `WidgetStyle`,
+  `defaultStyle`, `Color`, `colorFromText`, `colorToHex`, `ImageConfig`,
+  `ImageSource`, `ResourceName`, `ScaleType`, `TextAlignment`,
+  `TextInputConfig`, `InputType`, `WebViewConfig`, `MapViewConfig`,
+  `button`, `text`.
+
+## Version 0.1.0
+
+Initial release of hatter (renamed from haskell-mobile).

--- a/android/java/me/jappie/hatter/HatterActivity.java
+++ b/android/java/me/jappie/hatter/HatterActivity.java
@@ -58,7 +58,6 @@ public class HatterActivity extends Activity implements View.OnClickListener {
         System.loadLibrary("hatter");
     }
 
-    private native String greet(String name);
     private native void renderUI();
     private native void onButtonClick(View view);
     private native void onTextChange(View view, String text);

--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -39,7 +39,6 @@ extern void haskellLogLocale(void);
 extern void setAppFilesDir(const char *path);
 
 /* Haskell foreign exports */
-extern char* haskellGreet(const char* name);
 extern void haskellOnLifecycle(void *ctx, int eventType);
 extern void haskellRenderUI(void *ctx);
 extern void haskellOnUIEvent(void *ctx, int callbackId);
@@ -172,23 +171,6 @@ JNIEXPORT void JNICALL
 JNI_OnUnload(JavaVM *vm, void *reserved)
 {
     hs_exit();
-}
-
-JNIEXPORT jstring JNICALL
-JNI_METHOD(greet)(JNIEnv *env, jobject thiz, jstring jname)
-{
-    const char *cname = (*env)->GetStringUTFChars(env, jname, NULL);
-    if (cname == NULL) {
-        return NULL; /* OutOfMemoryError already thrown */
-    }
-
-    char *cresult = haskellGreet(cname);
-    (*env)->ReleaseStringUTFChars(env, jname, cname);
-
-    jstring jresult = (*env)->NewStringUTF(env, cresult);
-    free(cresult);
-
-    return jresult;
 }
 
 /* --- UI bridge JNI methods --- */

--- a/hatter.cabal
+++ b/hatter.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 
 name:           hatter
-version:        0.1.0
+version:        0.2.0
 category:       Mobile
 homepage:       https://github.com/jappeace/hatter#readme
 bug-reports:    https://github.com/jappeace/hatter/issues

--- a/include/Hatter.h
+++ b/include/Hatter.h
@@ -6,9 +6,6 @@
 /* GHC RTS initialization (call before any Haskell function) */
 void hs_init(int *argc, char **argv[]);
 
-/* Haskell FFI exports */
-char *haskellGreet(const char *name);
-
 /* Run the user's Haskell main :: IO (Ptr AppContext).
  * Uses the GHC RTS API to evaluate ZCMain_main_closure and capture
  * the returned context pointer — no foreign export ccall needed in

--- a/ios/Hatter/HaskellBridge.swift
+++ b/ios/Hatter/HaskellBridge.swift
@@ -35,15 +35,6 @@ class HaskellBridge {
         setup_ios_animation_bridge(context)
     }
 
-    /// Call Haskell's haskellGreet and return the result as a Swift String.
-    /// The C-allocated string is freed after copying.
-    static func greet(_ name: String) -> String {
-        let result = haskellGreet(name)!
-        let greeting = String(cString: result)
-        free(result)
-        return greeting
-    }
-
     /// Notify Haskell of a lifecycle event.
     static func onLifecycle(_ event: Int32) {
         haskellOnLifecycle(context, event)

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -395,7 +395,6 @@ in {
           ${builtins.concatStringsSep " " (builtins.genList (i: "-optl$(pwd)/extra_jni_${toString i}.o") (builtins.length extraJniBridge))} \
           ${builtins.concatStringsSep " " (map (o: "-optl${o}") extraLinkObjects)} \
           -optl-Wl,-u,haskellRunMain \
-          -optl-Wl,-u,haskellGreet \
           -optl-Wl,-u,haskellOnLifecycle \
           -optl-Wl,-u,haskellRenderUI \
           -optl-Wl,-u,haskellOnUIEvent \
@@ -650,7 +649,6 @@ in {
           ${if crossDeps != null then "-package-db ${crossDeps}/pkgdb -i${crossDeps}/hi" else ""} \
           -optl-lffi \
           -optl-Wl,-u,_haskellRunMain \
-          -optl-Wl,-u,_haskellGreet \
           -optl-Wl,-u,_haskellOnLifecycle \
           -optl-Wl,-u,_haskellRenderUI \
           -optl-Wl,-u,_haskellOnUIEvent \
@@ -863,7 +861,6 @@ open(sys.argv[1], "w").write(yml)
           ${if crossDeps != null then "-package-db ${crossDeps}/pkgdb -i${crossDeps}/hi" else ""} \
           -optl-lffi \
           -optl-Wl,-u,_haskellRunMain \
-          -optl-Wl,-u,_haskellGreet \
           -optl-Wl,-u,_haskellOnLifecycle \
           -optl-Wl,-u,_haskellRenderUI \
           -optl-Wl,-u,_haskellOnUIEvent \

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -97,7 +97,6 @@ module Hatter
     -- should not need them.  The remaining @foreign export ccall@
     -- functions (permission, BLE, camera, etc.) are visible to the
     -- C linker but not re-exported as Haskell API.
-  , haskellGreet
   , haskellRenderUI
   , haskellOnUIEvent
   , haskellOnLifecycle
@@ -107,7 +106,7 @@ where
 import Control.Exception (SomeException, catch)
 import Data.IORef (readIORef, writeIORef)
 import Data.Text (Text, pack)
-import Foreign.C.String (CString, newCString, peekCString)
+import Foreign.C.String (CString, peekCString)
 import Foreign.C.Types (CDouble(..), CInt(..))
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
 import Data.ByteString qualified as BS
@@ -257,15 +256,6 @@ errorWidget dismissAction exc = Column
       , bcFontConfig = Nothing
       }
   ]
-
--- | Takes a name as CString, returns "Hello from Haskell, <name>!" as CString.
--- Caller is responsible for freeing the returned CString.
-haskellGreet :: CString -> IO CString
-haskellGreet cname = do
-  name <- peekCString cname
-  newCString ("Hello from Haskell, " ++ name ++ "!")
-
-foreign export ccall haskellGreet :: CString -> IO CString
 
 -- | Render the UI tree. Dereferences the context pointer to obtain the
 -- 'RenderState', reads the view function from 'AppContext'

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -1,10 +1,78 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
+-- |
+-- Module      : Hatter
+-- Description : Cross-platform mobile UI framework for Haskell
+--
+-- Hatter lets you build native mobile apps in Haskell.  Define your UI
+-- as a pure 'Widget' tree, wire up callbacks with 'Action' handles, and
+-- the framework takes care of rendering on Android, iOS, and watchOS.
+--
+-- = Getting started
+--
+-- @
+-- import Hatter
+-- import Hatter.Widget
+--
+-- main :: IO ()
+-- main = do
+--   acts <- 'newActionState'
+--   greet <- 'runActionM' acts $ 'createAction' (putStrLn \"tapped!\")
+--   _ <- 'startMobileApp' MobileApp
+--     { maContext     = 'defaultMobileContext'
+--     , maView        = \\_ -> pure ('button' greet \"Tap me\")
+--     , maActionState = acts
+--     }
+--   pure ()
+-- @
+--
+-- = Platform subsystems
+--
+-- Domain-specific APIs live in their own modules.  Import them when you
+-- need a particular capability:
+--
+-- * "Hatter.Permission" — runtime permission requests
+-- * "Hatter.SecureStorage" — encrypted key-value storage
+-- * "Hatter.Ble" — Bluetooth Low Energy scanning
+-- * "Hatter.Dialog" — native alert dialogs
+-- * "Hatter.Location" — GPS \/ location updates
+-- * "Hatter.AuthSession" — OAuth browser sessions
+-- * "Hatter.Camera" — photo & video capture
+-- * "Hatter.BottomSheet" — modal bottom sheets
+-- * "Hatter.Http" — HTTP requests
+-- * "Hatter.NetworkStatus" — connectivity monitoring
+-- * "Hatter.Locale" — device locale & language
+-- * "Hatter.I18n" — internationalisation helpers
+-- * "Hatter.FilesDir" — app-private file storage path
+-- * "Hatter.AppContext" — low-level context pointer (advanced)
 module Hatter
-  ( MobileApp(..)
+  ( -- * App setup
+    MobileApp(..)
   , UserState(..)
   , startMobileApp
-  -- Action handles
+    -- * Widget
+  , Widget(..)
+  , WidgetStyle(..)
+  , defaultStyle
+  , ButtonConfig(..)
+  , TextConfig(..)
+  , FontConfig(..)
+  , TextInputConfig(..)
+  , InputType(..)
+  , ImageConfig(..)
+  , ImageSource(..)
+  , ResourceName(..)
+  , ScaleType(..)
+  , TextAlignment(..)
+  , WebViewConfig(..)
+  , MapViewConfig(..)
+  , Color(..)
+  , colorFromText
+  , colorToHex
+    -- ** Smart constructors
+  , button
+  , text
+    -- * Actions
   , Action(..)
   , OnChange(..)
   , ActionState
@@ -13,120 +81,26 @@ module Hatter
   , createOnChange
   , newActionState
   , runActionM
-  -- FFI exports
-  , haskellGreet
-  , haskellRenderUI
-  , haskellOnUIEvent
-  , haskellOnLifecycle
-  , haskellOnPermissionResult
-  , haskellOnSecureStorageResult
-  , haskellOnBleScanResult
-  , haskellOnDialogResult
-  , haskellOnLocationUpdate
-  , haskellOnAuthSessionResult
-  , haskellOnCameraResult
-  , haskellOnBottomSheetResult
-  , haskellOnHttpResult
-  , haskellOnNetworkStatusChange
-  , haskellOnAnimationFrame
-  -- Error handling
-  , errorWidget
-  -- Re-exports from Lifecycle
+    -- * Animation
+  , Easing(..)
+  , AnimatedConfig(..)
+    -- * Lifecycle
   , LifecycleEvent(..)
   , MobileContext(..)
   , defaultMobileContext
   , loggingMobileContext
   , platformLog
-  , newMobileContext
-  , freeMobileContext
-  -- Re-exports from AppContext
-  , AppContext(..)
-  , newAppContext
-  , freeAppContext
-  , derefAppContext
-  -- Re-exports from Locale
-  , Language(..)
-  , Locale(..)
-  , LocaleFailure(..)
-  , getSystemLocale
-  , parseLocale
-  , localeToText
-  , languageToCode
-  , languageFromCode
-  -- Re-exports from FilesDir
-  , getAppFilesDir
-  -- Re-exports from I18n
-  , Key(..)
-  , TranslateFailure(..)
-  , translate
-  -- Re-exports from Permission
-  , Permission(..)
-  , PermissionStatus(..)
-  , PermissionState(..)
-  , requestPermission
-  , checkPermission
-  -- Re-exports from SecureStorage
-  , SecureStorageStatus(..)
-  , SecureStorageState(..)
-  , secureStorageWrite
-  , secureStorageRead
-  , secureStorageDelete
-  -- Re-exports from Ble
-  , BleAdapterStatus(..)
-  , BleScanResult(..)
-  , BleState(..)
-  , checkBleAdapter
-  , startBleScan
-  , stopBleScan
-  -- Re-exports from Dialog
-  , DialogAction(..)
-  , DialogConfig(..)
-  , DialogState(..)
-  , showDialog
-  -- Re-exports from Location
-  , LocationData(..)
-  , LocationState(..)
-  , startLocationUpdates
-  , stopLocationUpdates
-  -- Re-exports from AuthSession
-  , AuthSessionResult(..)
-  , AuthSessionState(..)
-  , startAuthSession
-  -- Re-exports from Camera
-  , CameraSource(..)
-  , CameraStatus(..)
-  , Picture(..)
-  , CameraResult(..)
-  , CameraState(..)
-  , startCameraSession
-  , stopCameraSession
-  , capturePhoto
-  , startVideoCapture
-  , stopVideoCapture
-  , haskellOnVideoFrame
-  , haskellOnAudioChunk
-  -- Re-exports from BottomSheet
-  , BottomSheetAction(..)
-  , BottomSheetConfig(..)
-  , BottomSheetState(..)
-  , showBottomSheet
-  -- Re-exports from Http
-  , HttpMethod(..)
-  , HttpRequest(..)
-  , HttpResponse(..)
-  , HttpError(..)
-  , HttpState(..)
-  , performRequest
-  -- Re-exports from Animation
-  , AnimationState(..)
-  , Easing(..)
-  , AnimatedConfig(..)
-  -- Re-exports from NetworkStatus
-  , NetworkTransport(..)
-  , NetworkStatus(..)
-  , NetworkStatusState(..)
-  , startNetworkMonitoring
-  , stopNetworkMonitoring
+    -- * Error handling
+  , errorWidget
+    -- * Internal
+    -- | FFI entry points used by the test suite.  Application code
+    -- should not need them.  The remaining @foreign export ccall@
+    -- functions (permission, BLE, camera, etc.) are visible to the
+    -- C linker but not re-exported as Haskell API.
+  , haskellGreet
+  , haskellRenderUI
+  , haskellOnUIEvent
+  , haskellOnLifecycle
   )
 where
 
@@ -136,6 +110,8 @@ import Data.Text (Text, pack)
 import Foreign.C.String (CString, newCString, peekCString)
 import Foreign.C.Types (CDouble(..), CInt(..))
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Data.ByteString qualified as BS
+import Data.Word (Word8)
 import Hatter.Action
   ( Action(..)
   , OnChange(..)
@@ -146,113 +122,56 @@ import Hatter.Action
   , newActionState
   , runActionM
   )
-import Hatter.Animation
-  ( AnimationState(..)
-  , dispatchAnimationFrame
-  )
-import Hatter.AppContext (AppContext(..), newAppContext, freeAppContext, derefAppContext)
-import Hatter.AuthSession
-  ( AuthSessionResult(..)
-  , AuthSessionState(..)
-  , startAuthSession
-  , dispatchAuthSessionResult
-  )
-import Hatter.BottomSheet
-  ( BottomSheetAction(..)
-  , BottomSheetConfig(..)
-  , BottomSheetState(..)
-  , showBottomSheet
-  , dispatchBottomSheetResult
-  )
-import Hatter.Ble
-  ( BleAdapterStatus(..)
-  , BleScanResult(..)
-  , BleState(..)
-  , checkBleAdapter
-  , startBleScan
-  , stopBleScan
-  , dispatchBleScanResult
-  )
-import Data.ByteString qualified as BS
-import Data.Word (Word8)
+import Hatter.Animation (dispatchAnimationFrame)
+import Hatter.AppContext (AppContext(..), newAppContext, derefAppContext)
+import Hatter.AuthSession (dispatchAuthSessionResult)
+import Hatter.Ble (dispatchBleScanResult)
+import Hatter.BottomSheet (dispatchBottomSheetResult)
 import Hatter.Camera
-  ( CameraSource(..)
-  , CameraStatus(..)
-  , Picture(..)
-  , CameraResult(..)
-  , CameraState(..)
-  , startCameraSession
-  , stopCameraSession
-  , capturePhoto
-  , startVideoCapture
-  , stopVideoCapture
-  , dispatchCameraResult
+  ( dispatchCameraResult
   , dispatchVideoFrame
   , dispatchAudioChunk
   )
-import Hatter.Http
-  ( HttpMethod(..)
-  , HttpRequest(..)
-  , HttpResponse(..)
-  , HttpError(..)
-  , HttpState(..)
-  , performRequest
-  , dispatchHttpResult
-  )
-import Hatter.Dialog
-  ( DialogAction(..)
-  , DialogConfig(..)
-  , DialogState(..)
-  , showDialog
-  , dispatchDialogResult
-  )
-import Hatter.Location
-  ( LocationData(..)
-  , LocationState(..)
-  , startLocationUpdates
-  , stopLocationUpdates
-  , dispatchLocationUpdate
-  )
-import Hatter.NetworkStatus
-  ( NetworkTransport(..)
-  , NetworkStatus(..)
-  , NetworkStatusState(..)
-  , startNetworkMonitoring
-  , stopNetworkMonitoring
-  , dispatchNetworkStatusChange
-  )
+import Hatter.Dialog (dispatchDialogResult)
+import Hatter.Http (dispatchHttpResult)
 import Hatter.Lifecycle
   ( LifecycleEvent(..)
   , MobileContext(..)
   , defaultMobileContext
   , loggingMobileContext
   , platformLog
-  , newMobileContext
-  , freeMobileContext
   , lifecycleFromInt
   )
-import Hatter.FilesDir (getAppFilesDir)
-import Hatter.I18n (Key(..), TranslateFailure(..), translate)
-import Hatter.Locale (Language(..), Locale(..), LocaleFailure(..), getSystemLocale, parseLocale, localeToText, languageToCode, languageFromCode)
-import Hatter.Permission
-  ( Permission(..)
-  , PermissionStatus(..)
-  , PermissionState(..)
-  , requestPermission
-  , checkPermission
-  , dispatchPermissionResult
-  )
+import Hatter.Location (dispatchLocationUpdate)
+import Hatter.NetworkStatus (dispatchNetworkStatusChange)
+import Hatter.Permission (dispatchPermissionResult)
 import Hatter.Render (renderWidget, dispatchEvent, dispatchTextEvent)
-import Hatter.SecureStorage
-  ( SecureStorageStatus(..)
-  , SecureStorageState(..)
-  , secureStorageWrite
-  , secureStorageRead
-  , secureStorageDelete
-  , dispatchSecureStorageResult
-  )
+import Hatter.SecureStorage (dispatchSecureStorageResult)
 import Hatter.Types (MobileApp(..), UserState(..))
-import Hatter.Widget (AnimatedConfig(..), ButtonConfig(..), Easing(..), FontConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget
+  ( AnimatedConfig(..)
+  , ButtonConfig(..)
+  , Color(..)
+  , Easing(..)
+  , FontConfig(..)
+  , ImageConfig(..)
+  , ImageSource(..)
+  , InputType(..)
+  , MapViewConfig(..)
+  , ResourceName(..)
+  , ScaleType(..)
+  , TextAlignment(..)
+  , TextConfig(..)
+  , TextInputConfig(..)
+  , WebViewConfig(..)
+  , Widget(..)
+  , WidgetStyle(..)
+  , button
+  , colorFromText
+  , colorToHex
+  , defaultStyle
+  , text
+  )
 
 -- | Create an 'AppContext' from a 'MobileApp' and return it as a typed
 -- pointer suitable for the C FFI. This is the user-facing API: the user's
@@ -382,7 +301,7 @@ haskellOnUITextChange ctxPtr callbackId cstr =
 foreign export ccall haskellOnUITextChange :: Ptr AppContext -> CInt -> CString -> IO ()
 
 -- | Handle a permission result from native code. Dispatches to the
--- callback registered by 'requestPermission'.
+-- callback registered by 'Hatter.Permission.requestPermission'.
 haskellOnPermissionResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 haskellOnPermissionResult ctxPtr requestId statusCode =
   withExceptionHandler ctxPtr $ do
@@ -392,7 +311,7 @@ haskellOnPermissionResult ctxPtr requestId statusCode =
 foreign export ccall haskellOnPermissionResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 
 -- | Handle a BLE scan result from native code. Dispatches to the
--- callback registered by 'startBleScan'.
+-- callback registered by 'Hatter.Ble.startBleScan'.
 haskellOnBleScanResult :: Ptr AppContext -> CString -> CString -> CInt -> IO ()
 haskellOnBleScanResult ctxPtr cName cAddr cRssi =
   withExceptionHandler ctxPtr $ do
@@ -402,7 +321,7 @@ haskellOnBleScanResult ctxPtr cName cAddr cRssi =
 foreign export ccall haskellOnBleScanResult :: Ptr AppContext -> CString -> CString -> CInt -> IO ()
 
 -- | Handle a dialog result from native code. Dispatches to the
--- callback registered by 'showDialog'.
+-- callback registered by 'Hatter.Dialog.showDialog'.
 haskellOnDialogResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 haskellOnDialogResult ctxPtr requestId actionCode =
   withExceptionHandler ctxPtr $ do
@@ -412,7 +331,7 @@ haskellOnDialogResult ctxPtr requestId actionCode =
 foreign export ccall haskellOnDialogResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 
 -- | Handle a location update from native code. Dispatches to the
--- callback registered by 'startLocationUpdates'.
+-- callback registered by 'Hatter.Location.startLocationUpdates'.
 haskellOnLocationUpdate :: Ptr AppContext -> CDouble -> CDouble -> CDouble -> CDouble -> IO ()
 haskellOnLocationUpdate ctxPtr cLat cLon cAlt cAcc =
   withExceptionHandler ctxPtr $ do
@@ -438,8 +357,9 @@ haskellOnLifecycle ctxPtr code =
 foreign export ccall haskellOnLifecycle :: Ptr AppContext -> CInt -> IO ()
 
 -- | Handle a secure storage result from native code. Dispatches to the
--- callback registered by 'secureStorageWrite', 'secureStorageRead', or
--- 'secureStorageDelete'.  The @cValue@ parameter is non-null only for
+-- callback registered by 'Hatter.SecureStorage.secureStorageWrite',
+-- 'Hatter.SecureStorage.secureStorageRead', or
+-- 'Hatter.SecureStorage.secureStorageDelete'.  The @cValue@ parameter is non-null only for
 -- successful read operations.
 haskellOnSecureStorageResult :: Ptr AppContext -> CInt -> CInt -> CString -> IO ()
 haskellOnSecureStorageResult ctxPtr requestId statusCode cValue =
@@ -451,7 +371,7 @@ haskellOnSecureStorageResult ctxPtr requestId statusCode cValue =
 foreign export ccall haskellOnSecureStorageResult :: Ptr AppContext -> CInt -> CInt -> CString -> IO ()
 
 -- | Handle an auth session result from native code. Dispatches to the
--- callback registered by 'startAuthSession'. The @cRedirectUrl@ parameter
+-- callback registered by 'Hatter.AuthSession.startAuthSession'. The @cRedirectUrl@ parameter
 -- is non-null only for successful sessions. The @cErrorMsg@ parameter
 -- is non-null only for error sessions.
 haskellOnAuthSessionResult :: Ptr AppContext -> CInt -> CInt -> CString -> CString -> IO ()
@@ -465,7 +385,7 @@ haskellOnAuthSessionResult ctxPtr requestId statusCode cRedirectUrl cErrorMsg =
 foreign export ccall haskellOnAuthSessionResult :: Ptr AppContext -> CInt -> CInt -> CString -> CString -> IO ()
 
 -- | Handle a camera result from native code. Dispatches to the
--- callback registered by 'capturePhoto' or 'startVideoCapture'.
+-- callback registered by 'Hatter.Camera.capturePhoto' or 'Hatter.Camera.startVideoCapture'.
 -- The @imageDataPtr@/@imageDataLen@/@width@/@height@ parameters carry
 -- raw JPEG bytes for photo captures; null\/0 for video completions and
 -- error results.
@@ -486,7 +406,7 @@ foreign export ccall haskellOnCameraResult
   -> Ptr Word8 -> CInt -> CInt -> CInt -> IO ()
 
 -- | Handle a video frame from native code. Dispatches to the
--- per-frame callback registered by 'startVideoCapture'.
+-- per-frame callback registered by 'Hatter.Camera.startVideoCapture'.
 haskellOnVideoFrame :: Ptr AppContext -> CInt
                     -> Ptr Word8 -> CInt -> CInt -> CInt -> IO ()
 haskellOnVideoFrame ctxPtr requestId frameDataPtr frameDataLen width height =
@@ -499,7 +419,7 @@ foreign export ccall haskellOnVideoFrame
   :: Ptr AppContext -> CInt -> Ptr Word8 -> CInt -> CInt -> CInt -> IO ()
 
 -- | Handle an audio chunk from native code. Dispatches to the
--- per-audio-chunk callback registered by 'startVideoCapture'.
+-- per-audio-chunk callback registered by 'Hatter.Camera.startVideoCapture'.
 haskellOnAudioChunk :: Ptr AppContext -> CInt
                     -> Ptr Word8 -> CInt -> IO ()
 haskellOnAudioChunk ctxPtr requestId audioDataPtr audioDataLen =
@@ -511,7 +431,7 @@ haskellOnAudioChunk ctxPtr requestId audioDataPtr audioDataLen =
 foreign export ccall haskellOnAudioChunk
   :: Ptr AppContext -> CInt -> Ptr Word8 -> CInt -> IO ()
 -- | Handle a bottom sheet result from native code. Dispatches to the
--- callback registered by 'showBottomSheet'.
+-- callback registered by 'Hatter.BottomSheet.showBottomSheet'.
 haskellOnBottomSheetResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 haskellOnBottomSheetResult ctxPtr requestId actionCode =
   withExceptionHandler ctxPtr $ do
@@ -521,7 +441,7 @@ haskellOnBottomSheetResult ctxPtr requestId actionCode =
 foreign export ccall haskellOnBottomSheetResult :: Ptr AppContext -> CInt -> CInt -> IO ()
 
 -- | Handle an HTTP result from native code. Dispatches to the
--- callback registered by 'performRequest'. The @cHeaders@ parameter
+-- callback registered by 'Hatter.Http.performRequest'. The @cHeaders@ parameter
 -- is newline-delimited key-value pairs for success, or an error message
 -- for network errors. The @bodyPtr@/@bodyLen@ carry the response body.
 haskellOnHttpResult :: Ptr AppContext -> CInt -> CInt -> CInt
@@ -542,7 +462,7 @@ foreign export ccall haskellOnHttpResult
   -> CString -> Ptr Word8 -> CInt -> IO ()
 
 -- | Handle a network status change from native code. Dispatches to the
--- callback registered by 'startNetworkMonitoring'.
+-- callback registered by 'Hatter.NetworkStatus.startNetworkMonitoring'.
 haskellOnNetworkStatusChange :: Ptr AppContext -> CInt -> CInt -> IO ()
 haskellOnNetworkStatusChange ctxPtr cConnected cTransport =
   withExceptionHandler ctxPtr $ do

--- a/test/AuthSessionDemoMain.hs
+++ b/test/AuthSessionDemoMain.hs
@@ -10,19 +10,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , AuthSessionResult(..)
-  , AuthSessionState(..)
   , startMobileApp
-  , derefAppContext
   , platformLog
   , loggingMobileContext
-  , AppContext
-  , startAuthSession
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.AuthSession (AuthSessionResult(..), AuthSessionState(..), startAuthSession)
 import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -15,20 +15,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , BleState(..)
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , checkBleAdapter
-  , startBleScan
-  , stopBleScan
   , loggingMobileContext
-  , AppContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Ble (BleState(..), checkBleAdapter, startBleScan, stopBleScan)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/BottomSheetDemoMain.hs
+++ b/test/BottomSheetDemoMain.hs
@@ -11,19 +11,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , BottomSheetConfig(..)
-  , BottomSheetState(..)
-  , AppContext
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , showBottomSheet
   , loggingMobileContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.BottomSheet (BottomSheetConfig(..), BottomSheetState(..), showBottomSheet)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/CameraDemoMain.hs
+++ b/test/CameraDemoMain.hs
@@ -14,21 +14,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , CameraResult(..)
-  , CameraStatus(..)
-  , CameraState(..)
-  , Picture(..)
   , startMobileApp
-  , derefAppContext
   , platformLog
   , loggingMobileContext
-  , AppContext
-  , capturePhoto
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Camera (CameraResult(..), CameraStatus(..), CameraState(..), Picture(..), capturePhoto)
 import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)

--- a/test/ConsumerDepsMain.hs
+++ b/test/ConsumerDepsMain.hs
@@ -9,7 +9,8 @@
 module Main where
 
 import Foreign.Ptr (Ptr)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/CounterDemoMain.hs
+++ b/test/CounterDemoMain.hs
@@ -8,7 +8,8 @@ module Main where
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState, runActionM, createAction, Action)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (ButtonConfig(..), Color(..), FontConfig(..), TextAlignment(..), TextConfig(..), Widget(..), WidgetStyle(..))
 
 main :: IO (Ptr AppContext)

--- a/test/DialogDemoMain.hs
+++ b/test/DialogDemoMain.hs
@@ -11,20 +11,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , DialogAction(..)
-  , DialogConfig(..)
-  , DialogState(..)
-  , AppContext
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , showDialog
   , loggingMobileContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Dialog (DialogAction(..), DialogConfig(..), DialogState(..), showDialog)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/FilesDirDemoMain.hs
+++ b/test/FilesDirDemoMain.hs
@@ -13,13 +13,13 @@ import Foreign.Ptr (Ptr)
 import System.FilePath ((</>))
 import Hatter
   ( MobileApp(..)
-  , AppContext
   , startMobileApp
   , platformLog
-  , getAppFilesDir
   , loggingMobileContext
   , newActionState
   )
+import Hatter.AppContext (AppContext)
+import Hatter.FilesDir (getAppFilesDir)
 import Hatter.Widget (TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/HttpDemoMain.hs
+++ b/test/HttpDemoMain.hs
@@ -14,21 +14,14 @@ import Hatter
   ( MobileApp(..)
   , Action
   , startMobileApp
-  , derefAppContext
   , platformLog
   , loggingMobileContext
-  , AppContext
-  , HttpState(..)
-  , HttpRequest(..)
-  , HttpResponse(..)
-  , HttpMethod(..)
-  , HttpError(..)
-  , performRequest
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Http (HttpState(..), HttpRequest(..), HttpResponse(..), HttpMethod(..), HttpError(..), performRequest)
 import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)

--- a/test/ImageDemoMain.hs
+++ b/test/ImageDemoMain.hs
@@ -7,7 +7,8 @@ module Main where
 
 import Data.ByteString qualified as BS
 import Foreign.Ptr (Ptr)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (ImageConfig(..), ImageSource(..), ResourceName(..), ScaleType(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/LocationDemoMain.hs
+++ b/test/LocationDemoMain.hs
@@ -15,19 +15,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , LocationState(..)
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , startLocationUpdates
-  , stopLocationUpdates
   , loggingMobileContext
-  , AppContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Location (LocationState(..), startLocationUpdates, stopLocationUpdates)
 import Hatter.Location (LocationData(..))
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 

--- a/test/MapViewDemoMain.hs
+++ b/test/MapViewDemoMain.hs
@@ -14,11 +14,11 @@ import Hatter
   , startMobileApp
   , platformLog
   , loggingMobileContext
-  , AppContext
   , newActionState
   , runActionM
   , createOnChange
   )
+import Hatter.AppContext (AppContext)
 import Hatter.Widget
   ( MapViewConfig(..)
   , TextConfig(..)

--- a/test/NetworkStatusDemoMain.hs
+++ b/test/NetworkStatusDemoMain.hs
@@ -16,20 +16,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , NetworkStatusState(..)
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , startNetworkMonitoring
-  , stopNetworkMonitoring
   , loggingMobileContext
-  , AppContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
-import Hatter.NetworkStatus (NetworkStatus(..), NetworkTransport(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.NetworkStatus (NetworkStatusState(..), NetworkStatus(..), NetworkTransport(..), startNetworkMonitoring, stopNetworkMonitoring)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/NodePoolTestMain.hs
+++ b/test/NodePoolTestMain.hs
@@ -8,7 +8,8 @@ module Main where
 
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
-import Hatter (MobileApp(..), UserState(..), startMobileApp, AppContext, newActionState)
+import Hatter (MobileApp(..), UserState(..), startMobileApp, newActionState)
+import Hatter.AppContext (AppContext)
 import Hatter.Lifecycle (loggingMobileContext)
 import Hatter.Widget (TextConfig(..), Widget(..))
 

--- a/test/PermissionDemoMain.hs
+++ b/test/PermissionDemoMain.hs
@@ -11,19 +11,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , Permission(..)
-  , PermissionState(..)
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , requestPermission
   , loggingMobileContext
-  , AppContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Permission (Permission(..), PermissionState(..), requestPermission)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/ScrollDemoMain.hs
+++ b/test/ScrollDemoMain.hs
@@ -7,7 +7,8 @@ module Main where
 
 import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState, runActionM, createAction, Action)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/SecureStorageDemoMain.hs
+++ b/test/SecureStorageDemoMain.hs
@@ -11,19 +11,15 @@ import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
   , Action
-  , SecureStorageState(..)
-  , AppContext
   , startMobileApp
-  , derefAppContext
   , platformLog
-  , secureStorageWrite
-  , secureStorageRead
   , loggingMobileContext
   , newActionState
   , runActionM
   , createAction
   )
-import Hatter.AppContext (AppContext(..))
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.SecureStorage (SecureStorageState(..), secureStorageWrite, secureStorageRead)
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/THDemoMain.hs
+++ b/test/THDemoMain.hs
@@ -10,7 +10,8 @@ module Main where
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import THConsumer (thGreeting)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (TextConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/THDirectMain.hs
+++ b/test/THDirectMain.hs
@@ -10,7 +10,8 @@ module Main where
 import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import Language.Haskell.TH.Syntax (lift)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (TextConfig(..), Widget(..))
 
 -- | Compile-time evaluated splice — forces -fexternal-interpreter in mkAndroidLib.

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,7 +2,8 @@ module Main where
 
 import Test.Tasty
 
-import Hatter (startMobileApp, derefAppContext, AppContext(..))
+import Hatter (startMobileApp)
+import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Permission (PermissionState)
 import Hatter.SecureStorage (SecureStorageState)
 import Hatter.Dialog (DialogState)

--- a/test/Test/AppContextTests.hs
+++ b/test/Test/AppContextTests.hs
@@ -22,11 +22,8 @@ import Hatter
   , haskellRenderUI
   , haskellOnUIEvent
   , haskellOnLifecycle
-  , freeAppContext
-  , derefAppContext
-  , AppContext(..)
   )
-import Hatter.AppContext (newAppContext)
+import Hatter.AppContext (AppContext(..), newAppContext, freeAppContext, derefAppContext)
 import Hatter.Lifecycle
   ( LifecycleEvent(..)
   , MobileContext(..)

--- a/test/Test/CoreTests.hs
+++ b/test/Test/CoreTests.hs
@@ -17,9 +17,7 @@ import Data.IORef (newIORef, readIORef, modifyIORef')
 import Data.List (sort)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as Text
-import Foreign.C.String (newCString, peekCString)
-import Foreign.Marshal.Alloc (free)
-import Hatter (MobileApp(..), haskellGreet, haskellOnLifecycle)
+import Hatter (MobileApp(..), haskellOnLifecycle)
 import Hatter.Lifecycle
   ( LifecycleEvent(..)
   , loggingMobileContext
@@ -64,20 +62,6 @@ unitTests = testGroup "Unit tests"
   -- the following test does not hold
   , testCase "List comparison (same length)" $
       oneTwoThree `compare` [1,2,3] @?= EQ
-  , testCase "haskellGreet returns correct greeting" $ do
-      cname <- newCString "World"
-      cresult <- haskellGreet cname
-      result <- peekCString cresult
-      free cresult
-      free cname
-      result @?= "Hello from Haskell, World!"
-  , testCase "haskellGreet with different input" $ do
-      cname <- newCString "Android"
-      cresult <- haskellGreet cname
-      result <- peekCString cresult
-      free cresult
-      free cname
-      result @?= "Hello from Haskell, Android!"
   ]
 
 lifecycleTests :: TestTree

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -18,11 +18,8 @@ import Hatter
   , ActionM
   , newActionState
   , runActionM
-  , freeAppContext
-  , derefAppContext
-  , AppContext(..)
   )
-import Hatter.AppContext (newAppContext)
+import Hatter.AppContext (AppContext(..), newAppContext, freeAppContext, derefAppContext)
 import Hatter.Lifecycle
   ( LifecycleEvent(..)
   , MobileContext(..)

--- a/test/Test/PlatformTests.hs
+++ b/test/Test/PlatformTests.hs
@@ -23,7 +23,7 @@ import Data.Text qualified as Text
 import Foreign.C.String (newCString)
 import Foreign.Marshal.Alloc (free)
 import Foreign.Ptr (nullPtr)
-import Hatter (freeAppContext, derefAppContext, AppContext(..))
+import Hatter.AppContext (AppContext(..), freeAppContext, derefAppContext)
 import Hatter.AppContext (newAppContext)
 import Hatter.Widget (TextConfig(..), Widget(..))
 import Hatter.Permission

--- a/test/TextInputDemoMain.hs
+++ b/test/TextInputDemoMain.hs
@@ -6,7 +6,8 @@
 module Main where
 
 import Foreign.Ptr (Ptr)
-import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), AppContext, newActionState, runActionM, createOnChange, OnChange)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createOnChange, OnChange)
+import Hatter.AppContext (AppContext)
 import Hatter.Widget (InputType(..), TextConfig(..), TextInputConfig(..), Widget(..))
 
 main :: IO (Ptr AppContext)

--- a/test/WebViewDemoMain.hs
+++ b/test/WebViewDemoMain.hs
@@ -15,11 +15,11 @@ import Hatter
   , startMobileApp
   , platformLog
   , loggingMobileContext
-  , AppContext
   , newActionState
   , runActionM
   , createAction
   )
+import Hatter.AppContext (AppContext)
 import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)

--- a/watchos/Hatter/HaskellBridge.swift
+++ b/watchos/Hatter/HaskellBridge.swift
@@ -24,15 +24,6 @@ class HaskellBridge {
         haskellLogLocale()
     }
 
-    /// Call Haskell's haskellGreet and return the result as a Swift String.
-    /// The C-allocated string is freed after copying.
-    static func greet(_ name: String) -> String {
-        let result = haskellGreet(name)!
-        let greeting = String(cString: result)
-        free(result)
-        return greeting
-    }
-
     /// Notify Haskell of a lifecycle event.
     static func onLifecycle(_ event: Int32) {
         haskellOnLifecycle(context, event)


### PR DESCRIPTION
## Summary
- Rewrite `Hatter` main module with haddock section headers, module overview, usage example, and platform subsystem directory
- Move platform-specific types (Permission, BLE, Camera, Dialog, Location, AuthSession, SecureStorage, BottomSheet, Http, NetworkStatus, Locale, I18n, FilesDir, AppContext) out of the main module — users import from submodules directly
- Add full Widget type re-exports (WidgetStyle, Color, ImageConfig, smart constructors, etc.) making the widget API prominent
- Trim FFI exports to only test-visible functions; the rest remain as C symbols via `foreign export ccall` but don't pollute haddock
- Update 22 test files to import from appropriate submodules

## Test plan
- [x] `cabal build` passes (library + tests, no warnings)
- [x] `cabal test` — all 239 tests pass
- [x] `cabal haddock` builds (no new warnings from our changes)
- [x] CI: `nix-build nix/ci.nix` — pre-existing armv7a linker failure (`haskellLogLocale`), unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)