### PR TITLE
Remove configurable soName from mkAndroidLib

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -78,7 +78,6 @@ in {
     { hatterSrc
     , mainModule
     , pname ? "hatter-android"
-    , soName ? "libhatter.so"
     , javaPackageName ? "me.jappie.hatter"
     , extraJniBridge ? []
     , extraNdkCompile ? (_: _: "")
@@ -92,6 +91,10 @@ in {
     , soMaxSizeMB ? 200         # fail build if .so exceeds this (MB), catches whole-archive bloat
     }:
     let
+      # Must match HatterActivity.java's System.loadLibrary("hatter").
+      # Not configurable — any other name guarantees UnsatisfiedLinkError.
+      soName = "libhatter.so";
+
       jniPackageMacro = builtins.replaceStrings ["."] ["_"] javaPackageName;
 
       # Template Haskell support for consumer code: when crossDeps includes


### PR DESCRIPTION
## Summary
- Remove `soName` parameter from `mkAndroidLib` — it's now a hardcoded `let` binding (`"libhatter.so"`)
- Any value other than `"libhatter.so"` guarantees `UnsatisfiedLinkError` because `HatterActivity.java` hardcodes `System.loadLibrary("hatter")`

## Context
prrrrrrrrr PR #35 updated the haskell-mobile pin (renaming to hatter) but kept `soName = "libhaskellmobile.so"` in its `android.nix`. This caused a runtime crash on device that CI didn't catch (separate `pipefail` bug). Making `soName` configurable when only one value works is a footgun.

## Test plan
- [ ] CI passes (nix eval + existing android/emulator tests)
- Consumers that were passing `soName = "libhatter.so"` (or not passing it at all) are unaffected
- Consumers passing a different `soName` will get a nix eval error, which is better than a runtime crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)