### PR TITLE
Fix ScrollView SIGABRT + regression test

### DIFF
--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -101,6 +101,7 @@ static jmethodID g_method_loadUrl;
 static jmethodID g_method_getSettings;
 static jmethodID g_method_setJavaScriptEnabled;
 static jmethodID g_method_registerWebViewClient;
+static jmethodID g_method_getChildAt;
 
 /* LinearLayout orientation constants */
 static jint ORIENTATION_VERTICAL   = 1;
@@ -224,6 +225,8 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
         "removeView", "(Landroid/view/View;)V");
     g_method_removeAllViews = (*env)->GetMethodID(env, g_class_ViewGroup,
         "removeAllViews", "()V");
+    g_method_getChildAt = (*env)->GetMethodID(env, g_class_ViewGroup,
+        "getChildAt", "(I)Landroid/view/View;");
 
     /* Activity.setContentView(View) */
     jclass activityClass = (*env)->GetObjectClass(env, activity);
@@ -439,9 +442,19 @@ static int32_t android_create_node(int32_t nodeType)
     case UI_NODE_TEXT_INPUT:
         view = (*env)->NewObject(env, g_class_EditText, g_ctor_EditText, g_activity);
         break;
-    case UI_NODE_SCROLL_VIEW:
+    case UI_NODE_SCROLL_VIEW: {
         view = (*env)->NewObject(env, g_class_ScrollView, g_ctor_ScrollView, g_activity);
+        /* Android ScrollView only accepts one direct child.
+         * Create an inner vertical LinearLayout so that multiple
+         * Haskell children can be added via addChild(). */
+        jobject innerLayout = (*env)->NewObject(env, g_class_LinearLayout,
+            g_ctor_LinearLayout, g_activity);
+        (*env)->CallVoidMethod(env, innerLayout, g_method_setOrientation,
+            ORIENTATION_VERTICAL);
+        (*env)->CallVoidMethod(env, view, g_method_addView, innerLayout);
+        (*env)->DeleteLocalRef(env, innerLayout);
         break;
+    }
     case UI_NODE_IMAGE:
         view = (*env)->NewObject(env, g_class_ImageView, g_ctor_ImageView, g_activity);
         break;
@@ -798,6 +811,19 @@ static void android_add_child(int32_t parentId, int32_t childId)
     jobject child  = get_node(childId);
     if (!parent || !child) return;
 
+    /* Android ScrollView only accepts one direct child.
+     * Redirect to the inner LinearLayout wrapper (child 0)
+     * that was created in android_create_node. */
+    if ((*env)->IsInstanceOf(env, parent, g_class_ScrollView)) {
+        jobject innerLayout = (*env)->CallObjectMethod(env, parent,
+            g_method_getChildAt, (jint)0);
+        if (innerLayout) {
+            (*env)->CallVoidMethod(env, innerLayout, g_method_addView, child);
+            (*env)->DeleteLocalRef(env, innerLayout);
+            return;
+        }
+    }
+
     (*env)->CallVoidMethod(env, parent, g_method_addView, child);
 }
 
@@ -807,6 +833,17 @@ static void android_remove_child(int32_t parentId, int32_t childId)
     jobject parent = get_node(parentId);
     jobject child  = get_node(childId);
     if (!parent || !child) return;
+
+    /* ScrollView: redirect to inner LinearLayout wrapper. */
+    if ((*env)->IsInstanceOf(env, parent, g_class_ScrollView)) {
+        jobject innerLayout = (*env)->CallObjectMethod(env, parent,
+            g_method_getChildAt, (jint)0);
+        if (innerLayout) {
+            (*env)->CallVoidMethod(env, innerLayout, g_method_removeView, child);
+            (*env)->DeleteLocalRef(env, innerLayout);
+            return;
+        }
+    }
 
     (*env)->CallVoidMethod(env, parent, g_method_removeView, child);
 }

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -63,6 +63,17 @@ let
     name = "hatter-textinput-apk";
   };
 
+  scrollTextInputAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/ScrollTextInputDemoMain.hs;
+  };
+  scrollTextInputApk = lib.mkApk {
+    sharedLibs = [{ lib = scrollTextInputAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-scrolltextinput.apk";
+    name = "hatter-scrolltextinput-apk";
+  };
+
   permissionAndroid = import ./android.nix {
     inherit sources androidArch;
     mainModule = ../test/PermissionDemoMain.hs;
@@ -292,6 +303,7 @@ AVDMANAGER="${sdk}/bin/avdmanager"
 COUNTER_APK="${counterApk}/hatter.apk"
 SCROLL_APK="${scrollApk}/hatter-scroll.apk"
 TEXTINPUT_APK="${textinputApk}/hatter-textinput.apk"
+SCROLL_TEXTINPUT_APK="${scrollTextInputApk}/hatter-scrolltextinput.apk"
 PERMISSION_APK="${permissionApk}/hatter-permission.apk"
 SECURE_STORAGE_APK="${secureStorageApk}/hatter-securestorage.apk"
 IMAGE_APK="${imageApk}/hatter-image.apk"
@@ -323,6 +335,7 @@ for so_path in \
     "${counterAndroid}/lib/${abiDir}/libhatter.so" \
     "${scrollAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputAndroid}/lib/${abiDir}/libhatter.so" \
+    "${scrollTextInputAndroid}/lib/${abiDir}/libhatter.so" \
     "${permissionAndroid}/lib/${abiDir}/libhatter.so" \
     "${secureStorageAndroid}/lib/${abiDir}/libhatter.so" \
     "${imageAndroid}/lib/${abiDir}/libhatter.so" \
@@ -522,7 +535,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -584,6 +597,8 @@ echo "--- locale ---"
 run_with_retry "locale"    bash "$TEST_SCRIPTS/android/locale.sh"    || PHASE1_EXIT=1
 echo "--- textinput ---"
 run_with_retry "textinput" bash "$TEST_SCRIPTS/android/textinput.sh" || PHASE3_EXIT=1
+echo "--- scroll_textinput ---"
+run_with_retry "scroll_textinput" bash "$TEST_SCRIPTS/android/scroll_textinput.sh" || PHASE3_EXIT=1
 echo "--- permission ---"
 run_with_retry "permission" bash "$TEST_SCRIPTS/android/permission.sh" || PHASE4_EXIT=1
 echo "--- securestorage ---"

--- a/test/ScrollTextInputDemoMain.hs
+++ b/test/ScrollTextInputDemoMain.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Minimal reproducer for DeadObjectException when ScrollView wraps
+-- TextInput widgets on Android.
+--
+-- Mirrors the prrrrrrrrr enterPRView layout: ScrollView containing Text
+-- labels, TextInput fields, and Buttons inside a Row.
+module Main where
+
+import Foreign.Ptr (Ptr)
+import Hatter
+  ( startMobileApp, platformLog, loggingMobileContext
+  , MobileApp(..), newActionState, runActionM
+  , createAction, createOnChange, Action, OnChange
+  )
+import Hatter.AppContext (AppContext)
+import Hatter.Widget
+  ( ButtonConfig(..), InputType(..), TextConfig(..)
+  , TextInputConfig(..), Widget(..)
+  )
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "ScrollTextInput demo app registered"
+  actionState <- newActionState
+  (save, back, onWeight, onNotes) <- runActionM actionState $ do
+    saveAction <- createAction (platformLog "save pressed")
+    backAction <- createAction (platformLog "back pressed")
+    weightChange <- createOnChange (\_ -> pure ())
+    notesChange <- createOnChange (\_ -> pure ())
+    pure (saveAction, backAction, weightChange, notesChange)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> scrollTextInputView save back onWeight onNotes
+    , maActionState = actionState
+    }
+
+-- | ScrollView containing TextInput widgets — reproduces the
+-- prrrrrrrrr layout that triggers DeadObjectException.
+scrollTextInputView :: Action -> Action -> OnChange -> OnChange -> IO Widget
+scrollTextInputView save back onWeight onNotes = pure $ ScrollView
+  [ Text TextConfig { tcLabel = "Enter data", tcFontConfig = Nothing }
+  , TextInput TextInputConfig
+      { tiInputType  = InputNumber
+      , tiHint       = "Weight (kg)"
+      , tiValue      = ""
+      , tiOnChange   = onWeight
+      , tiFontConfig = Nothing
+      }
+  , TextInput TextInputConfig
+      { tiInputType  = InputText
+      , tiHint       = "Notes"
+      , tiValue      = ""
+      , tiOnChange   = onNotes
+      , tiFontConfig = Nothing
+      }
+  , Row
+    [ Button ButtonConfig
+        { bcLabel = "Save", bcAction = save, bcFontConfig = Nothing }
+    , Button ButtonConfig
+        { bcLabel = "Back", bcAction = back, bcFontConfig = Nothing }
+    ]
+  ]

--- a/test/android/helpers.sh
+++ b/test/android/helpers.sh
@@ -35,22 +35,26 @@ install_apk() {
     return 0
 }
 
-# Fatal patterns that indicate the native library failed to load.
+# Fatal patterns that indicate the app crashed.
 # When any of these appear in logcat, further retries are pointless.
 FATAL_PATTERNS="UnsatisfiedLinkError|dlopen failed|cannot locate symbol|SIGABRT|SIGSEGV|Fatal signal"
 
 # check_fatal_logcat
-# Checks logcat for fatal native-library errors.
-# If found, prints the relevant lines and returns 0 (meaning "fatal found").
-# Returns 1 if no fatal error detected.
+# Checks logcat for fatal crash indicators.
+# If found, dumps the full unfiltered logcat so the native backtrace
+# (from debuggerd) is visible in CI output.
+# Returns 0 if fatal found, 1 if no fatal error detected.
 check_fatal_logcat() {
     local logcat_poll="$WORK_DIR/logcat_fatal.txt"
-    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:E' > "$logcat_poll" 2>&1 || true
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$logcat_poll" 2>&1 || true
     if grep -qE "$FATAL_PATTERNS" "$logcat_poll" 2>/dev/null; then
         echo ""
-        echo "=== FATAL: Native library loading error detected ==="
-        grep -E "$FATAL_PATTERNS" "$logcat_poll" | tail -20
-        echo "=== End fatal logcat ==="
+        echo "=== FATAL: App crashed ==="
+        # Print the full logcat so the debuggerd native backtrace,
+        # Java stack traces, and Haskell RTS errors are all visible.
+        # Last 200 lines covers the crash dump + context.
+        tail -200 "$logcat_poll"
+        echo "=== End crash logcat ==="
         echo ""
         return 0
     fi
@@ -58,14 +62,14 @@ check_fatal_logcat() {
 }
 
 # dump_logcat LABEL
-# Dumps recent logcat errors to stdout for CI visibility.
+# Dumps recent logcat (all levels) to stdout for CI visibility.
 dump_logcat() {
     local label="$1"
     local logcat_dump="$WORK_DIR/logcat_dump_${label}.txt"
-    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' > "$logcat_dump" 2>&1 || true
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$logcat_dump" 2>&1 || true
     echo ""
-    echo "=== Logcat dump ($label) — last 40 warning/error lines ==="
-    tail -40 "$logcat_dump"
+    echo "=== Logcat dump ($label) — last 200 lines ==="
+    tail -200 "$logcat_dump"
     echo "=== End logcat dump ==="
     echo ""
 }
@@ -195,7 +199,7 @@ wait_for_render() {
     local wait_rc=$?
     if [ $wait_rc -eq 2 ]; then
         dump_logcat "$label"
-        echo "FATAL: Native library failed to load — aborting"
+        echo "FATAL: App crashed before rendering — aborting $label"
         exit 1
     fi
 }

--- a/test/android/scroll_textinput.sh
+++ b/test/android/scroll_textinput.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Android ScrollView + TextInput crash reproducer.
+# Android ScrollView + TextInput regression test.
 #
-# Reproduces DeadObjectException when ScrollView wraps TextInput widgets.
-# Installs the app, waits for render, then checks logcat for:
+# Regression test for the SIGABRT that occurred when ScrollView wrapped
+# multiple children (including TextInput) on Android. Android's ScrollView
+# only accepts one direct child; the fix adds an inner LinearLayout wrapper.
+# Installs the app, waits for render, taps TextInput, then checks logcat for:
 #   - WindowManager errors (DeadObjectException, EXITING)
 #   - App crashes / ANR
 #

--- a/test/android/scroll_textinput.sh
+++ b/test/android/scroll_textinput.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Android ScrollView + TextInput crash reproducer.
+#
+# Reproduces DeadObjectException when ScrollView wraps TextInput widgets.
+# Installs the app, waits for render, then checks logcat for:
+#   - WindowManager errors (DeadObjectException, EXITING)
+#   - App crashes / ANR
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, SCROLL_TEXTINPUT_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$SCROLL_TEXTINPUT_APK" "scroll_textinput"
+wait_for_render "scroll_textinput"
+sleep 3
+collect_logcat "scroll_textinput"
+
+# Basic checks: app started and rendered
+assert_logcat "$LOGCAT_FILE" "setRoot" "setRoot called"
+assert_logcat "$LOGCAT_FILE" "ScrollTextInput demo app registered" "demo app registered"
+
+# Verify ScrollView is in view hierarchy
+DUMP_FILE="$WORK_DIR/scroll_textinput_ui.xml"
+dump_ok=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP_FILE" 2>/dev/null
+        dump_ok=1
+        break
+    fi
+    echo "  uiautomator dump attempt $attempt failed, retrying in 5s..."
+    sleep 5
+done
+
+if [ $dump_ok -eq 1 ]; then
+    if grep -q 'android.widget.ScrollView' "$DUMP_FILE" 2>/dev/null; then
+        echo "PASS: ScrollView in view hierarchy"
+    else
+        echo "FAIL: ScrollView not in view hierarchy"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy"
+    EXIT_CODE=1
+fi
+
+# Tap the first TextInput to bring up the keyboard
+echo "=== Tapping TextInput to open keyboard ==="
+tap_done=0
+if [ $dump_ok -eq 1 ]; then
+    tap_button "Weight (kg)" && tap_done=1 || true
+fi
+if [ $tap_done -eq 0 ]; then
+    # Fallback: tap near the top-center where the first TextInput should be
+    "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 300
+fi
+sleep 5
+
+# Collect logcat again to capture any crash/exception
+collect_logcat "scroll_textinput"
+
+# Check for the DeadObjectException that was reported in prrrrrrrrr PR #39
+DEAD_OBJ=$(grep -c "DeadObjectException" "$LOGCAT_FILE" 2>/dev/null || echo "0")
+EXITING=$(grep -c "EXITING" "$LOGCAT_FILE" 2>/dev/null || echo "0")
+FATAL=$(grep -c "FATAL EXCEPTION" "$LOGCAT_FILE" 2>/dev/null || echo "0")
+
+if [ "$DEAD_OBJ" -gt 0 ]; then
+    echo "FAIL: DeadObjectException found in logcat ($DEAD_OBJ occurrences)"
+    grep "DeadObjectException" "$LOGCAT_FILE" | head -5
+    EXIT_CODE=1
+else
+    echo "PASS: No DeadObjectException in logcat"
+fi
+
+if [ "$FATAL" -gt 0 ]; then
+    echo "FAIL: FATAL EXCEPTION found in logcat"
+    grep -A3 "FATAL EXCEPTION" "$LOGCAT_FILE" | head -10
+    EXIT_CODE=1
+else
+    echo "PASS: No FATAL EXCEPTION in logcat"
+fi
+
+# Dismiss keyboard and verify app is still alive
+echo "=== Pressing back to dismiss keyboard ==="
+"$ADB" -s "$EMULATOR_SERIAL" shell input keyevent KEYCODE_BACK
+sleep 3
+
+# Check the app is still running
+APP_PID=$("$ADB" -s "$EMULATOR_SERIAL" shell pidof "$PACKAGE" 2>/dev/null || echo "")
+if [ -n "$APP_PID" ]; then
+    echo "PASS: App still running (PID $APP_PID)"
+else
+    echo "FAIL: App crashed — no longer running"
+    EXIT_CODE=1
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Adds a ScrollView + TextInput crash reproducer (minimal demo app mirroring prrrrrrrrr PR #39's layout)
- Improves crash diagnostics in test helpers (full unfiltered logcat with 200 lines, clearer error messages)
- **Fixes the root cause**: Android `ScrollView` only accepts one direct child; adding multiple children via `addView()` threw `IllegalStateException`, poisoning JNI and causing `art::JavaVMExt::JniAbort` → SIGABRT

## Root Cause
The Haskell `ScrollView [child1, child2, ...]` rendered each child as a direct child of the Android `ScrollView`. Android's `ScrollView` throws `IllegalStateException: ScrollView can host only one direct child` on the second `addView()`. The unchecked JNI exception then caused a JNI abort on the next JNI call.

## Fix
In `cbits/ui_bridge_android.c`, `ScrollView` creation now inserts an inner vertical `LinearLayout` as its sole child. `addChild`/`removeChild` calls on a `ScrollView` parent are transparently redirected to this inner layout. This matches standard Android practice and is invisible to the Haskell rendering/diff algorithm.

## Test plan
- [ ] `cabal build` passes
- [ ] `cabal test` passes
- [ ] `nix-build nix/ci.nix` passes (cross-compilation for all platforms)
- [ ] Emulator test `scroll_textinput.sh` passes (previously SIGABRT 10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)