### PR TITLE
TEST: TextInput re-render test fails without fix

### DIFF
--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -262,6 +262,17 @@ let
     name = "hatter-filesdir-apk";
   };
 
+  textinputRerenderAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/TextInputReRenderDemoMain.hs;
+  };
+  textinputRerenderApk = lib.mkApk {
+    sharedLibs = [{ lib = textinputRerenderAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-textinput-rerender.apk";
+    name = "hatter-textinput-rerender-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -321,6 +332,7 @@ NETWORK_STATUS_APK="${networkStatusApk}/hatter-networkstatus.apk"
 MAPVIEW_APK="${mapviewApk}/hatter-mapview.apk"
 ANIMATION_APK="${animationApk}/hatter-animation.apk"
 FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
+TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -351,7 +363,8 @@ for so_path in \
     "${networkStatusAndroid}/lib/${abiDir}/libhatter.so" \
     "${mapviewAndroid}/lib/${abiDir}/libhatter.so" \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
-    "${filesDirAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
+    "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -419,6 +432,7 @@ PHASE11_OK=0
 PHASE12_OK=0
 PHASE13_OK=0
 PHASE14_OK=0
+PHASE15_OK=0
 
 cleanup() {
     echo ""
@@ -535,7 +549,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -551,6 +565,7 @@ PHASE11_EXIT=0
 PHASE12_EXIT=0
 PHASE13_EXIT=0
 PHASE14_EXIT=0
+PHASE15_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -633,6 +648,8 @@ echo "--- animation ---"
 run_with_retry "animation" bash "$TEST_SCRIPTS/android/animation.sh" || PHASE13_EXIT=1
 echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/android/filesdir.sh" || PHASE14_EXIT=1
+echo "--- textinput_rerender ---"
+run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/android/textinput_rerender.sh" || PHASE15_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -773,6 +790,16 @@ else
     echo "PHASE 14 FAILED"
 fi
 
+if [ $PHASE15_EXIT -eq 0 ]; then
+    PHASE15_OK=1
+    echo ""
+    echo "PHASE 15 PASSED"
+else
+    PHASE15_OK=0
+    echo ""
+    echo "PHASE 15 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -878,6 +905,13 @@ if [ $PHASE14_OK -eq 1 ]; then
     echo "PASS  Phase 14 — FilesDir demo app"
 else
     echo "FAIL  Phase 14 — FilesDir demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE15_OK -eq 1 ]; then
+    echo "PASS  Phase 15 — TextInput re-render demo app"
+else
+    echo "FAIL  Phase 15 — TextInput re-render demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -241,6 +241,17 @@ let
     name = "hatter-filesdir-simulator-app";
   };
 
+  textinputRerenderIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/TextInputReRenderDemoMain.hs;
+    simulator = true;
+  };
+  textinputRerenderSimApp = lib.mkSimulatorApp {
+    iosLib = textinputRerenderIos;
+    iosSrc = ../ios;
+    name = "hatter-textinput-rerender-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -281,6 +292,7 @@ NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/ios"
 MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/ios"
 ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
+TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -302,6 +314,7 @@ PHASE11_OK=0
 PHASE12_OK=0
 PHASE13_OK=0
 PHASE14_OK=0
+PHASE15_OK=0
 
 cleanup() {
     echo ""
@@ -342,7 +355,8 @@ for share_dir in \
     "$CAMERA_SHARE_DIR" \
     "$BOTTOM_SHEET_SHARE_DIR" \
     "$HTTP_SHARE_DIR" \
-    "$MAPVIEW_SHARE_DIR"; do
+    "$MAPVIEW_SHARE_DIR" \
+    "$TEXTINPUT_RERENDER_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1289,6 +1303,52 @@ if [ -z "$FILES_DIR_APP" ]; then
 fi
 echo "FilesDir app: $FILES_DIR_APP"
 
+# --- Stage and build textinput-rerender demo app ---
+echo "=== Staging textinput-rerender demo app ==="
+mkdir -p "$WORK_DIR/textinput-rerender/lib" "$WORK_DIR/textinput-rerender/include"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/lib/libHatter.a" "$WORK_DIR/textinput-rerender/lib/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/Hatter.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/PlatformSignInBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp -r "$TEXTINPUT_RERENDER_SHARE_DIR/Hatter" "$WORK_DIR/textinput-rerender/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/project.yml" "$WORK_DIR/textinput-rerender/"
+chmod -R u+w "$WORK_DIR/textinput-rerender"
+
+echo "=== Generating textinput-rerender Xcode project ==="
+cd "$WORK_DIR/textinput-rerender"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building textinput-rerender demo app for simulator ==="
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/textinput-rerender-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+TEXTINPUT_RERENDER_APP=$(find "$WORK_DIR/textinput-rerender-build" -name "*.app" -type d | head -1)
+if [ -z "$TEXTINPUT_RERENDER_APP" ]; then
+    echo "ERROR: Could not find textinput-rerender .app bundle"
+    exit 1
+fi
+echo "TextInputReRender app: $TEXTINPUT_RERENDER_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1350,7 +1410,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1366,6 +1426,7 @@ PHASE11_EXIT=0
 PHASE12_EXIT=0
 PHASE13_EXIT=0
 PHASE14_EXIT=0
+PHASE15_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1446,6 +1507,8 @@ echo "--- animation ---"
 run_with_retry "animation" bash "$TEST_SCRIPTS/ios/animation.sh" || PHASE13_EXIT=1
 echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/ios/filesdir.sh" || PHASE14_EXIT=1
+echo "--- textinput_rerender ---"
+run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/ios/textinput_rerender.sh" || PHASE15_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1586,6 +1649,16 @@ else
     echo "PHASE 14 FAILED"
 fi
 
+if [ $PHASE15_EXIT -eq 0 ]; then
+    PHASE15_OK=1
+    echo ""
+    echo "PHASE 15 PASSED"
+else
+    PHASE15_OK=0
+    echo ""
+    echo "PHASE 15 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1691,6 +1764,13 @@ if [ $PHASE14_OK -eq 1 ]; then
     echo "PASS  Phase 14 — FilesDir demo app"
 else
     echo "FAIL  Phase 14 — FilesDir demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE15_OK -eq 1 ]; then
+    echo "PASS  Phase 15 — TextInput re-render demo app"
+else
+    echo "FAIL  Phase 15 — TextInput re-render demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -220,6 +220,17 @@ let
     name = "hatter-watchos-filesdir-simulator-app";
   };
 
+  textinputRerenderWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/TextInputReRenderDemoMain.hs;
+    simulator = true;
+  };
+  textinputRerenderSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = textinputRerenderWatchos;
+    watchosSrc = ../watchos;
+    name = "hatter-watchos-textinput-rerender-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -258,6 +269,7 @@ NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/watchos"
 MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/watchos"
 ANIMATION_SHARE_DIR="${animationSimApp}/share/watchos"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/watchos"
+TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -279,6 +291,7 @@ PHASE11_OK=0
 PHASE12_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
+PHASE16_OK=0
 
 cleanup() {
     echo ""
@@ -317,7 +330,8 @@ for share_dir in \
     "$CAMERA_SHARE_DIR" \
     "$BOTTOM_SHEET_SHARE_DIR" \
     "$NETWORK_STATUS_SHARE_DIR" \
-    "$MAPVIEW_SHARE_DIR"; do
+    "$MAPVIEW_SHARE_DIR" \
+    "$TEXTINPUT_RERENDER_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1153,6 +1167,51 @@ if [ -z "$FILES_DIR_APP" ]; then
 fi
 echo "FilesDir app: $FILES_DIR_APP"
 
+# --- Stage and build textinput-rerender demo app ---
+echo "=== Staging textinput-rerender demo app ==="
+mkdir -p "$WORK_DIR/textinput-rerender/lib" "$WORK_DIR/textinput-rerender/include"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/lib/libHatter.a" "$WORK_DIR/textinput-rerender/lib/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/Hatter.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/PlatformSignInBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/textinput-rerender/include/"
+cp -r "$TEXTINPUT_RERENDER_SHARE_DIR/Hatter" "$WORK_DIR/textinput-rerender/"
+cp "$TEXTINPUT_RERENDER_SHARE_DIR/project.yml" "$WORK_DIR/textinput-rerender/"
+chmod -R u+w "$WORK_DIR/textinput-rerender"
+
+echo "=== Generating textinput-rerender Xcode project ==="
+cd "$WORK_DIR/textinput-rerender"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building textinput-rerender demo app for simulator ==="
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/textinput-rerender-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+TEXTINPUT_RERENDER_APP=$(find "$WORK_DIR/textinput-rerender-build" -name "*.app" -type d | head -1)
+if [ -z "$TEXTINPUT_RERENDER_APP" ]; then
+    echo "ERROR: Could not find textinput-rerender .app bundle"
+    exit 1
+fi
+echo "TextInputReRender app: $TEXTINPUT_RERENDER_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1216,7 +1275,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.hatter"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1233,6 +1292,7 @@ PHASE12_EXIT=0
 PHASE13_EXIT=0
 PHASE14_EXIT=0
 PHASE15_EXIT=0
+PHASE16_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1302,6 +1362,8 @@ echo "--- animation ---"
 run_with_retry "animation" bash "$TEST_SCRIPTS/watchos/animation.sh" || PHASE14_EXIT=1
 echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/watchos/filesdir.sh" || PHASE15_EXIT=1
+echo "--- textinput_rerender ---"
+run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/watchos/textinput_rerender.sh" || PHASE16_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1452,6 +1514,16 @@ else
     echo "PHASE 15 FAILED"
 fi
 
+if [ $PHASE16_EXIT -eq 0 ]; then
+    PHASE16_OK=1
+    echo ""
+    echo "PHASE 16 PASSED"
+else
+    PHASE16_OK=0
+    echo ""
+    echo "PHASE 16 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1564,6 +1636,13 @@ if [ $PHASE15_OK -eq 1 ]; then
     echo "PASS  Phase 15 — FilesDir demo app"
 else
     echo "FAIL  Phase 15 — FilesDir demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE16_OK -eq 1 ]; then
+    echo "PASS  Phase 16 — TextInput re-render demo app"
+else
+    echo "FAIL  Phase 16 — TextInput re-render demo app"
     FINAL_EXIT=1
 fi
 

--- a/test/TextInputReRenderDemoMain.hs
+++ b/test/TextInputReRenderDemoMain.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Mobile entry point for the text-input-rerender test app.
+--
+-- Reproduces jappeace/prrrrrrrrr#47: typing in a TextInput should
+-- trigger a re-render so that a dependent Text widget updates.
+-- On master (before the fix) the Text stays at its initial value
+-- because haskellOnUITextChange did not call renderView.
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Text (Text, pack, unpack)
+import Foreign.Ptr (Ptr)
+import Hatter
+  ( startMobileApp, platformLog, loggingMobileContext
+  , MobileApp(..), newActionState, runActionM, createOnChange, OnChange
+  )
+import Hatter.AppContext (AppContext)
+import Hatter.Widget
+  ( InputType(..), TextConfig(..), TextInputConfig(..), Widget(..)
+  )
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "TextInputReRender demo app registered"
+  actionState <- newActionState
+  typedRef <- newIORef ("" :: Text)
+  onChange <- runActionM actionState $
+    createOnChange (\newText -> writeIORef typedRef newText)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> textInputReRenderView typedRef onChange
+    , maActionState = actionState
+    }
+
+-- | A TextInput paired with a Text that mirrors the typed value.
+-- The Text label should update on every keystroke if OnChange
+-- triggers a re-render.
+textInputReRenderView :: IORef Text -> OnChange -> IO Widget
+textInputReRenderView typedRef onChange = do
+  typed <- readIORef typedRef
+  let displayLabel = "Typed: " <> typed
+  platformLog ("view rebuilt: " <> displayLabel)
+  pure $ Column
+    [ TextInput TextInputConfig
+        { tiInputType  = InputText
+        , tiHint       = "type here"
+        , tiValue      = typed
+        , tiOnChange   = onChange
+        , tiFontConfig = Nothing
+        }
+    , Text TextConfig
+        { tcLabel      = displayLabel
+        , tcFontConfig = Nothing
+        }
+    ]

--- a/test/android/textinput_rerender.sh
+++ b/test/android/textinput_rerender.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Android textinput_rerender test: verify that typing in a TextInput
+# triggers a re-render so that a dependent Text widget updates.
+#
+# Reproduces jappeace/prrrrrrrrr#47.
+#
+# The demo app has a TextInput + a Text showing "Typed: <value>".
+# After typing text via adb, the logcat should show setStrProp
+# updating the Text to "Typed: hello".
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, TEXTINPUT_RERENDER_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$TEXTINPUT_RERENDER_APK" "textinput-rerender"
+
+LOGCAT_STREAM_FILE="$WORK_DIR/textinput_rerender_log.txt"
+: > "$LOGCAT_STREAM_FILE"
+"$ADB" -s "$EMULATOR_SERIAL" logcat '*:I' > "$LOGCAT_STREAM_FILE" 2>&1 &
+LOGCAT_STREAM_PID=$!
+
+# Wait for initial render
+wait_for_logcat "setRoot" 120
+WAIT_RC=$?
+if [ $WAIT_RC -eq 2 ]; then
+    dump_logcat "textinput-rerender"
+    echo "FATAL: Native library failed to load — aborting"
+    kill "$LOGCAT_STREAM_PID" 2>/dev/null || true
+    exit 1
+fi
+sleep 5
+
+# Verify initial state: "Typed: " (empty)
+assert_logcat "$LOGCAT_STREAM_FILE" 'view rebuilt: Typed:' "Initial render shows empty Typed label"
+
+# Tap the TextInput to focus it
+TAP_DUMP="$WORK_DIR/textinput_rerender_ui.xml"
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$TAP_DUMP" 2>/dev/null
+        break
+    fi
+    sleep 3
+done
+
+# Find and tap the EditText
+EDIT_BOUNDS=$(grep -o 'class="android.widget.EditText"[^>]*bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' "$TAP_DUMP" 2>/dev/null | head -1 || echo "")
+if [ -n "$EDIT_BOUNDS" ]; then
+    COORDS=$(echo "$EDIT_BOUNDS" | grep -o '\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]')
+    LEFT=$(echo "$COORDS" | sed 's/^\[//;s/,.*//')
+    TOP=$(echo "$COORDS" | sed 's/^\[[0-9]*,//;s/\].*//')
+    RIGHT=$(echo "$COORDS" | sed 's/.*\]\[//;s/,.*//')
+    BOTTOM=$(echo "$COORDS" | sed 's/.*,//;s/\]//')
+    TAP_X=$(( (LEFT + RIGHT) / 2 ))
+    TAP_Y=$(( (TOP + BOTTOM) / 2 ))
+    echo "Tapping EditText at ($TAP_X, $TAP_Y)"
+    "$ADB" -s "$EMULATOR_SERIAL" shell input tap "$TAP_X" "$TAP_Y"
+    sleep 2
+else
+    echo "WARNING: Could not find EditText, tapping center of screen"
+    "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 400
+    sleep 2
+fi
+
+# Type "hello" via adb
+"$ADB" -s "$EMULATOR_SERIAL" shell input text "hello"
+sleep 3
+
+# The key assertion: after typing, the view function should have been
+# called with the updated state, producing a logcat line like:
+#   view rebuilt: Typed: hello
+# AND a setStrProp call updating the Text widget:
+#   setStrProp(..., value="Typed: hello")
+#
+# On master (broken): neither of these appear because OnChange
+# does not trigger renderView.
+assert_logcat "$LOGCAT_STREAM_FILE" 'view rebuilt: Typed: hello' "View rebuilt with typed text after OnChange"
+assert_logcat "$LOGCAT_STREAM_FILE" 'setStrProp.*Typed: hello' "Text widget updated to show typed text"
+
+kill "$LOGCAT_STREAM_PID" 2>/dev/null || true
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/textinput_rerender.sh
+++ b/test/ios/textinput_rerender.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# iOS textinput_rerender test: verify that typing in a TextInput
+# triggers a re-render so that a dependent Text widget updates.
+#
+# Reproduces jappeace/prrrrrrrrr#47.
+#
+# On iOS simulator we cannot inject keyboard input easily, so we
+# verify the structural requirement: the app renders, and the
+# UIBridge stub logs show the view function is called with re-render
+# after a simulated text change.  The actual typing interaction is
+# verified on Android.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, TEXTINPUT_RERENDER_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$TEXTINPUT_RERENDER_APP" "textinput-rerender"
+
+wait_for_render "textinput-rerender"
+sleep 5
+
+collect_logs "textinput-rerender"
+
+# Verify app started and rendered
+assert_log "$FULL_LOG" "setRoot" "setRoot rendered"
+assert_log "$FULL_LOG" "view rebuilt: Typed:" "Initial view shows Typed label"
+
+# Verify the TextInput node was created
+assert_log "$FULL_LOG" "createNode.*type=4" "TextInput node created"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/textinput_rerender.sh
+++ b/test/watchos/textinput_rerender.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# watchOS textinput_rerender test: verify app starts and renders.
+# Full typing interaction is verified on Android; this just confirms
+# the app builds and renders on watchOS.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, TEXTINPUT_RERENDER_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$TEXTINPUT_RERENDER_APP" "textinput-rerender"
+
+wait_for_render "textinput-rerender"
+sleep 5
+
+collect_logs "textinput-rerender"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot rendered"
+assert_log "$FULL_LOG" "view rebuilt: Typed:" "Initial view shows Typed label"
+
+cleanup_app
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Adds integration test for TextInput re-render (demo app + Android/iOS/watchOS test scripts + nix CI wiring)
- **This PR is expected to FAIL on CI** — specifically the Android `textinput_rerender` phase
- On master, `haskellOnUITextChange` does not call `renderView`, so typing in a TextInput never triggers a re-render. The test types "hello" via adb and asserts `view rebuilt: Typed: hello` appears in logcat, which it won't without the fix.

## Purpose
Demonstrates that the test from PR #158 correctly catches the bug described in jappeace/prrrrrrrrr#47. The fix is in PR #158; this PR shows the test fails without it.

## Expected failures
- **Android Phase 15** — `view rebuilt: Typed: hello` never appears (no re-render after text change)
- **iOS/watchOS** — may pass since they only check initial render, not typing interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)