### PR TITLE
Add tiAutoFocus property to TextInputConfig

### DIFF
--- a/android/java/me/jappie/hatter/HatterActivity.java
+++ b/android/java/me/jappie/hatter/HatterActivity.java
@@ -1040,6 +1040,15 @@ public class HatterActivity extends Activity implements View.OnClickListener {
     }
 
     /**
+     * Request focus on a view, deferred via View.post() to ensure the
+     * view is attached to the hierarchy first. Called from native code
+     * when a TextInput has autoFocus enabled.
+     */
+    public void requestFocusOnView(final View view) {
+        view.post(view::requestFocus);
+    }
+
+    /**
      * Register a TextWatcher on an EditText. Called from native code
      * when a TextInput widget has an EventTextChange handler.
      * The watcher forwards text changes to the native onTextChange method.

--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -102,6 +102,7 @@ static jmethodID g_method_getSettings;
 static jmethodID g_method_setJavaScriptEnabled;
 static jmethodID g_method_registerWebViewClient;
 static jmethodID g_method_getChildAt;
+static jmethodID g_method_requestFocusOnView;
 
 /* LinearLayout orientation constants */
 static jint ORIENTATION_VERTICAL   = 1;
@@ -327,6 +328,14 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
         "registerWebViewClient", "(Landroid/webkit/WebView;)V");
     if (!g_method_registerWebViewClient) {
         LOGE("registerWebViewClient not found — webview page-load events disabled");
+        (*env)->ExceptionClear(env);
+    }
+
+    /* Activity.requestFocusOnView(View) — our custom Java method */
+    g_method_requestFocusOnView = (*env)->GetMethodID(env, actClass,
+        "requestFocusOnView", "(Landroid/view/View;)V");
+    if (!g_method_requestFocusOnView) {
+        LOGE("requestFocusOnView not found — auto-focus disabled");
         (*env)->ExceptionClear(env);
     }
 
@@ -726,6 +735,15 @@ static void android_set_num_prop(int32_t nodeId, int32_t propId, double value)
             g_class_View, "setTranslationY", "(F)V");
         (*env)->CallVoidMethod(env, view, setTranslationY, (jfloat)value);
         LOGI("setNumProp(node=%d, translateY=%.1f)", nodeId, value);
+        break;
+    }
+    case UI_PROP_AUTO_FOCUS: {
+        if (g_method_requestFocusOnView) {
+            (*env)->CallVoidMethod(env, g_activity, g_method_requestFocusOnView, view);
+            LOGI("setNumProp(node=%d, autoFocus=%.0f)", nodeId, value);
+        } else {
+            LOGE("setNumProp: requestFocusOnView unavailable, skipping node=%d", nodeId);
+        }
         break;
     }
     default:

--- a/include/UIBridge.h
+++ b/include/UIBridge.h
@@ -35,6 +35,7 @@
 #define UI_PROP_MAP_SHOW_USER_LOC   8
 #define UI_PROP_TRANSLATE_X         9
 #define UI_PROP_TRANSLATE_Y         10
+#define UI_PROP_AUTO_FOCUS          11
 
 /* Event types */
 #define UI_EVENT_CLICK       0

--- a/ios/Hatter/UIBridgeIOS.m
+++ b/ios/Hatter/UIBridgeIOS.m
@@ -603,6 +603,15 @@ static void ios_set_num_prop(int32_t nodeId, int32_t propId, double value)
         LOGI("setNumProp(node=%d, translateY=%.1f)", nodeId, value);
         break;
     }
+    case UI_PROP_AUTO_FOCUS: {
+        if ([view isKindOfClass:[UITextField class]]) {
+            [(UITextField *)view becomeFirstResponder];
+            LOGI("setNumProp(node=%d, autoFocus=%.0f)", nodeId, value);
+        } else {
+            LOGI("setNumProp: autoFocus ignored on non-UITextField node=%d", nodeId);
+        }
+        break;
+    }
     default:
         LOGI("setNumProp: unknown propId %d", propId);
         break;

--- a/src/Hatter/Render.hs
+++ b/src/Hatter/Render.hs
@@ -20,6 +20,7 @@ module Hatter.Render
   )
 where
 
+import Control.Monad (when)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Int (Int32)
 import Data.Text (Text, pack)
@@ -168,6 +169,8 @@ createRenderedNode _animState widget@(TextInput config) = do
   Bridge.setNumProp nodeId Bridge.PropInputType (fromIntegral (inputTypeToInt (tiInputType config)))
   Bridge.setHandler nodeId Bridge.EventTextChange (onChangeId (tiOnChange config))
   applyFontConfig nodeId (tiFontConfig config)
+  when (tiAutoFocus config) $
+    Bridge.setNumProp nodeId Bridge.PropAutoFocus 1.0
   pure (RenderedLeaf widget nodeId)
 createRenderedNode animState widget@(Column children) = do
   nodeId <- Bridge.createNode Bridge.NodeColumn

--- a/src/Hatter/UIBridge.hs
+++ b/src/Hatter/UIBridge.hs
@@ -77,6 +77,7 @@ data PropId
   | PropMapShowUserLoc
   | PropTranslateX
   | PropTranslateY
+  | PropAutoFocus
   deriving (Show, Eq, Enum, Bounded)
 
 -- | Map a 'PropId' to its C integer code.
@@ -99,6 +100,7 @@ propIdToInt PropMapZoom       = 7
 propIdToInt PropMapShowUserLoc = 8
 propIdToInt PropTranslateX    = 9
 propIdToInt PropTranslateY    = 10
+propIdToInt PropAutoFocus     = 11
 
 -- | Event types corresponding to @UI_EVENT_*@ in @UIBridge.h@.
 data EventType

--- a/src/Hatter/Widget.hs
+++ b/src/Hatter/Widget.hs
@@ -84,16 +84,21 @@ data InputType
 -- | Configuration for a text input field.
 -- Follows a controlled-component pattern: Haskell owns the state.
 data TextInputConfig = TextInputConfig
-  { tiInputType :: InputType
+  { tiInputType  :: InputType
     -- ^ Which on-screen keyboard to present.
-  , tiHint      :: Text
+  , tiHint       :: Text
     -- ^ Placeholder text shown when the field is empty.
-  , tiValue     :: Text
+  , tiValue      :: Text
     -- ^ Current text value (controlled by Haskell).
-  , tiOnChange  :: OnChange
+  , tiOnChange   :: OnChange
     -- ^ Handle for the callback fired when the user edits the field.
   , tiFontConfig :: Maybe FontConfig
     -- ^ Optional font override.
+  , tiAutoFocus  :: Bool
+    -- ^ Whether this input should receive focus when rendered.
+    -- On Android, defers @requestFocus()@ via @View.post()@ to ensure the
+    -- view is attached to the hierarchy first. On iOS, calls
+    -- @becomeFirstResponder@. No-op on watchOS.
   } deriving (Show, Eq)
 
 -- | Horizontal text alignment for text-bearing widgets.

--- a/test/ScrollTextInputDemoMain.hs
+++ b/test/ScrollTextInputDemoMain.hs
@@ -45,6 +45,7 @@ scrollTextInputView save back onWeight onNotes = pure $ ScrollView
       , tiValue      = ""
       , tiOnChange   = onWeight
       , tiFontConfig = Nothing
+      , tiAutoFocus  = False
       }
   , TextInput TextInputConfig
       { tiInputType  = InputText
@@ -52,6 +53,7 @@ scrollTextInputView save back onWeight onNotes = pure $ ScrollView
       , tiValue      = ""
       , tiOnChange   = onNotes
       , tiFontConfig = Nothing
+      , tiAutoFocus  = False
       }
   , Row
     [ Button ButtonConfig

--- a/test/Test/WidgetTests.hs
+++ b/test/Test/WidgetTests.hs
@@ -242,7 +242,7 @@ textInputTests = testGroup "TextInput"
       let widget = TextInput TextInputConfig
             { tiInputType = InputText, tiHint = "hint", tiValue = ""
             , tiOnChange = changeHandle
-            , tiFontConfig = Nothing }
+            , tiFontConfig = Nothing, tiAutoFocus = False }
       renderWidget rs widget
       dispatchTextEvent rs (onChangeId changeHandle) "hello"
       val <- readIORef ref
@@ -255,7 +255,7 @@ textInputTests = testGroup "TextInput"
       let widget = TextInput TextInputConfig
             { tiInputType = InputText, tiHint = "enter weight", tiValue = "80"
             , tiOnChange = changeHandle
-            , tiFontConfig = Nothing }
+            , tiFontConfig = Nothing, tiAutoFocus = False }
       renderWidget rs widget
       dispatchTextEvent rs (onChangeId changeHandle) "95.5"
       val <- readIORef ref
@@ -281,7 +281,7 @@ textInputTests = testGroup "TextInput"
             , TextInput TextInputConfig
                 { tiInputType = InputText, tiHint = "hint", tiValue = ""
                 , tiOnChange = changeHandle
-                , tiFontConfig = Nothing }
+                , tiFontConfig = Nothing, tiAutoFocus = False }
             ]
       renderWidget rs widget
       dispatchEvent rs (actionId clickHandle)
@@ -298,11 +298,11 @@ textInputTests = testGroup "TextInput"
       renderWidget rs $ TextInput TextInputConfig
         { tiInputType = InputText, tiHint = "old", tiValue = ""
         , tiOnChange = changeHandle
-        , tiFontConfig = Nothing }
+        , tiFontConfig = Nothing, tiAutoFocus = False }
       renderWidget rs $ TextInput TextInputConfig
         { tiInputType = InputText, tiHint = "new", tiValue = ""
         , tiOnChange = changeHandle
-        , tiFontConfig = Nothing }
+        , tiFontConfig = Nothing, tiAutoFocus = False }
       dispatchTextEvent rs (onChangeId changeHandle) "val"
       val <- readIORef ref
       val @?= show ("val" :: String)
@@ -314,7 +314,7 @@ textInputTests = testGroup "TextInput"
       let widget = TextInput TextInputConfig
             { tiInputType = InputNumber, tiHint = "weight", tiValue = ""
             , tiOnChange = changeHandle
-            , tiFontConfig = Nothing }
+            , tiFontConfig = Nothing, tiAutoFocus = False }
       renderWidget rs widget
       dispatchTextEvent rs (onChangeId changeHandle) "72.5"
       val <- readIORef ref
@@ -331,11 +331,11 @@ textInputTests = testGroup "TextInput"
             [ TextInput TextInputConfig
                 { tiInputType = InputText, tiHint = "name", tiValue = ""
                 , tiOnChange = textHandle
-                , tiFontConfig = Nothing }
+                , tiFontConfig = Nothing, tiAutoFocus = False }
             , TextInput TextInputConfig
                 { tiInputType = InputNumber, tiHint = "weight", tiValue = ""
                 , tiOnChange = numberHandle
-                , tiFontConfig = Nothing }
+                , tiFontConfig = Nothing, tiAutoFocus = False }
             ]
       renderWidget rs widget
       dispatchTextEvent rs (onChangeId textHandle) "Alice"

--- a/test/TextInputDemoMain.hs
+++ b/test/TextInputDemoMain.hs
@@ -34,6 +34,7 @@ textInputDemoView onWeightChange onNameChange = pure $ Column
       , tiValue      = ""
       , tiOnChange   = onWeightChange
       , tiFontConfig = Nothing
+      , tiAutoFocus  = True
       }
   , TextInput TextInputConfig
       { tiInputType  = InputText
@@ -41,5 +42,6 @@ textInputDemoView onWeightChange onNameChange = pure $ Column
       , tiValue      = ""
       , tiOnChange   = onNameChange
       , tiFontConfig = Nothing
+      , tiAutoFocus  = False
       }
   ]

--- a/watchos/Hatter/WatchUIBridgeState.swift
+++ b/watchos/Hatter/WatchUIBridgeState.swift
@@ -85,6 +85,8 @@ class WatchUIBridgeState: ObservableObject {
         case 10: // UI_PROP_TRANSLATE_Y
             os_log("setNumProp(node=%d, translateY=%.1f)", log: bridgeLog, type: .info, nodeId, value)
             node.translateY = CGFloat(value)
+        case 11: // UI_PROP_AUTO_FOCUS (no-op on watchOS — no keyboard focus)
+            os_log("setNumProp(node=%d, autoFocus=%.0f) — no-op on watchOS", log: bridgeLog, type: .info, nodeId, value)
         default:
             os_log("setNumProp: unknown propId %d", log: bridgeLog, type: .info, propId)
         }


### PR DESCRIPTION
## Summary
- Adds `tiAutoFocus :: Bool` field to `TextInputConfig` so consumers can control which `TextInput` receives focus when multiple exist in a view
- Android: defers `requestFocus()` via `View.post()` (ensures view is attached first)
- iOS: calls `becomeFirstResponder` on `UITextField`
- watchOS: no-op with log message (no keyboard focus concept)
- All existing call sites updated with `tiAutoFocus = False` to preserve behavior

Closes prrrrrrrrr#48, closes #161.

## Test plan
- [x] `cabal build` passes with no warnings
- [x] `cabal test` — all 248 tests pass
- [ ] Emulator test: TextInputDemoMain still passes (existing behavior preserved)
- [ ] TextInputDemoMain weight field (first input) should receive focus instead of name field

🤖 Generated with [Claude Code](https://claude.com/claude-code)