### PR TITLE
Add async OOM reproducer for Android (issue #163)

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -45,8 +45,25 @@ let
   # (GHC #14291, haskell.nix #1544).  ARM32 support is effectively
   # abandoned in GHC — GHCup dropped it, haskell.nix closed as wontfix.
   # Regular armv7a cross-compilation (without TH) works fine.
+  #
+  # async-oom-test: Adding the async package as a cross-compilation
+  # dependency causes the Android app to OOM-kill during .so loading
+  # (~5.3 GB RSS before any Haskell code executes).  forkIO from base
+  # works fine; async from Hackage triggers the bloat.  See issue #163.
   knownFailing = {
     th-direct-test-armv7a = import ./test-th-direct.nix { inherit sources; androidArch = "armv7a"; };
+    async-oom-test = import ./android.nix {
+      inherit sources;
+      mainModule = ../test/AsyncOomDemoMain.hs;
+      consumerCabal2Nix =
+        { mkDerivation, base, lib, async, text }:
+        mkDerivation {
+          pname = "async-oom-test";
+          version = "0.1.0.0";
+          libraryHaskellDepends = [ base async text ];
+          license = lib.licenses.mit;
+        };
+    };
   };
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -273,6 +273,27 @@ let
     name = "hatter-textinput-rerender-apk";
   };
 
+  # Reproducer for issue #163: the async package causes the .so to
+  # balloon during dlopen, OOM-killing the process on Android.
+  asyncOomAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/AsyncOomDemoMain.hs;
+    consumerCabal2Nix =
+      { mkDerivation, base, lib, async, text }:
+      mkDerivation {
+        pname = "async-oom-test";
+        version = "0.1.0.0";
+        libraryHaskellDepends = [ base async text ];
+        license = lib.licenses.mit;
+      };
+  };
+  asyncOomApk = lib.mkApk {
+    sharedLibs = [{ lib = asyncOomAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-asyncoom.apk";
+    name = "hatter-asyncoom-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -333,6 +354,7 @@ MAPVIEW_APK="${mapviewApk}/hatter-mapview.apk"
 ANIMATION_APK="${animationApk}/hatter-animation.apk"
 FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
+ASYNC_OOM_APK="${asyncOomApk}/hatter-asyncoom.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -364,7 +386,8 @@ for so_path in \
     "${mapviewAndroid}/lib/${abiDir}/libhatter.so" \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
-    "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
+    "${asyncOomAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -433,6 +456,7 @@ PHASE12_OK=0
 PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
+PHASE16_OK=0
 
 cleanup() {
     echo ""
@@ -549,7 +573,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK ASYNC_OOM_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -566,6 +590,7 @@ PHASE12_EXIT=0
 PHASE13_EXIT=0
 PHASE14_EXIT=0
 PHASE15_EXIT=0
+PHASE16_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -650,6 +675,8 @@ echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/android/filesdir.sh" || PHASE14_EXIT=1
 echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/android/textinput_rerender.sh" || PHASE15_EXIT=1
+echo "--- async_oom ---"
+run_with_retry "async_oom" bash "$TEST_SCRIPTS/android/async_oom.sh" || PHASE16_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -800,6 +827,16 @@ else
     echo "PHASE 15 FAILED"
 fi
 
+if [ $PHASE16_EXIT -eq 0 ]; then
+    PHASE16_OK=1
+    echo ""
+    echo "PHASE 16 PASSED"
+else
+    PHASE16_OK=0
+    echo ""
+    echo "PHASE 16 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -912,6 +949,13 @@ if [ $PHASE15_OK -eq 1 ]; then
     echo "PASS  Phase 15 — TextInput re-render demo app"
 else
     echo "FAIL  Phase 15 — TextInput re-render demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE16_OK -eq 1 ]; then
+    echo "PASS  Phase 16 — Async OOM reproducer (issue #163)"
+else
+    echo "FAIL  Phase 16 — Async OOM reproducer (issue #163)"
     FINAL_EXIT=1
 fi
 

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -675,8 +675,8 @@ echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/android/filesdir.sh" || PHASE14_EXIT=1
 echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/android/textinput_rerender.sh" || PHASE15_EXIT=1
-echo "--- async_oom ---"
-run_with_retry "async_oom" bash "$TEST_SCRIPTS/android/async_oom.sh" || PHASE16_EXIT=1
+echo "--- async_oom (known-failing reproducer, issue #163) ---"
+bash "$TEST_SCRIPTS/android/async_oom.sh" || PHASE16_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -952,11 +952,14 @@ else
     FINAL_EXIT=1
 fi
 
+# Phase 16 is a known-failing reproducer (issue #163).
+# It does NOT contribute to FINAL_EXIT — it's informational only.
+# When the async OOM bug is fixed upstream, this will flip to PASS
+# and can be promoted to a real test.
 if [ $PHASE16_OK -eq 1 ]; then
-    echo "PASS  Phase 16 — Async OOM reproducer (issue #163)"
+    echo "PASS  Phase 16 — Async OOM reproducer (issue #163) [known-failing]"
 else
-    echo "FAIL  Phase 16 — Async OOM reproducer (issue #163)"
-    FINAL_EXIT=1
+    echo "XFAIL Phase 16 — Async OOM reproducer (issue #163) [known-failing]"
 fi
 
 echo ""

--- a/test/AsyncOomDemoMain.hs
+++ b/test/AsyncOomDemoMain.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Minimal demo app that depends on the @async@ package.
+--
+-- Reproducer for issue #163: adding @async@ as a cross-compilation
+-- dependency causes the Android app to OOM-kill during @.so@ loading
+-- at runtime (~5.3 GB RSS before any Haskell code executes).
+--
+-- The app will never actually reach @main@ on Android — the process
+-- is killed during @dlopen@.  The code is valid so it compiles and
+-- links; the emulator test asserts that the crash happens.
+module Main where
+
+import Control.Concurrent.Async (async, wait)
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (TextConfig(..), Widget(..))
+
+main :: IO (Ptr AppContext)
+main = do
+  -- Trivial use of async to ensure it is linked in.
+  handle <- async (pure "async loaded")
+  result <- wait handle
+  platformLog result
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "Async loaded", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }

--- a/test/android/async_oom.sh
+++ b/test/android/async_oom.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Android async-OOM reproducer (issue #163).
+#
+# The async package causes the .so to balloon during dlopen, OOM-killing
+# the process before any Haskell code executes.  This test installs the
+# APK, launches it, and asserts that the app starts successfully.
+# Expected result: FAIL (the app never starts — proving the bug).
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, ASYNC_OOM_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$ASYNC_OOM_APK" "async_oom"
+
+# Wait for the platformLog output that proves Haskell code ran.
+# Expected: this never arrives because the process is OOM-killed during
+# .so loading.
+wait_for_logcat "async loaded" 60
+WAIT_RC=$?
+if [ $WAIT_RC -eq 2 ]; then
+    dump_logcat "async_oom"
+    echo "FATAL: Native library failed to load (expected for async OOM reproducer)"
+    exit 1
+fi
+if [ $WAIT_RC -eq 1 ]; then
+    echo "FAIL: Timed out waiting for 'async loaded' (app likely OOM-killed)"
+    # Check logcat for OOM indicators
+    LOGCAT_OOM="$WORK_DIR/async_oom_logcat.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' > "$LOGCAT_OOM" 2>&1 || true
+    if grep -qE "oom-kill|Out of memory|lowmemorykiller|Killing.*adj" "$LOGCAT_OOM" 2>/dev/null; then
+        echo "OOM-kill indicators found in logcat:"
+        grep -E "oom-kill|Out of memory|lowmemorykiller|Killing.*adj" "$LOGCAT_OOM" | tail -10
+    fi
+    EXIT_CODE=1
+fi
+
+# Collect final logcat
+collect_logcat "async_oom"
+
+# Assert the app actually started (this is the key assertion — it should FAIL)
+assert_logcat "$LOGCAT_FILE" "async loaded" "async package loaded successfully"
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/android/async_oom.sh
+++ b/test/android/async_oom.sh
@@ -8,7 +8,11 @@
 #
 # Required env vars (set by emulator-all.nix harness):
 #   ADB, EMULATOR_SERIAL, ASYNC_OOM_APK, PACKAGE, ACTIVITY, WORK_DIR
-set -euo pipefail
+
+# NOTE: we intentionally use set -uo pipefail WITHOUT -e here.
+# With errexit, diagnostic commands that find nothing (grep returns 1)
+# would kill the script before we can report what happened.
+set -uo pipefail
 source "$(dirname "$0")/helpers.sh"
 
 EXIT_CODE=0
@@ -21,23 +25,20 @@ start_app "$ASYNC_OOM_APK" "async_oom"
 wait_for_logcat "async loaded" 60
 WAIT_RC=$?
 
-# --- Diagnostics (always run, even on success) ---
-# Temporarily disable errexit so diagnostic commands can't kill the script.
-set +e
-
+# --- Diagnostics (always run) ---
 echo ""
 echo "=== async_oom: logcat warnings/errors (last 80 lines) ==="
-"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' 2>&1 | tail -80
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' 2>&1 | tail -80 || true
 echo "=== end async_oom logcat ==="
 
 echo ""
 echo "=== async_oom: process status ==="
-"$ADB" -s "$EMULATOR_SERIAL" shell "ps -A 2>/dev/null | grep -i jappie || echo 'Process not found (likely killed)'"
+"$ADB" -s "$EMULATOR_SERIAL" shell "ps -A 2>/dev/null | grep -i jappie || echo 'Process not found (likely killed)'" || true
 echo "=== end process status ==="
 
 # Check for OOM/kill indicators
 LOGCAT_OOM="$WORK_DIR/async_oom_logcat.txt"
-"$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$LOGCAT_OOM" 2>&1
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$LOGCAT_OOM" 2>&1 || true
 echo ""
 echo "=== async_oom: OOM/kill indicators ==="
 grep -iE "oom|out of memory|lowmemory|am_kill|am_proc_died|killing|lmk" "$LOGCAT_OOM" | grep -i "jappie\|hatter\|oom\|kill\|memory" | tail -20 || echo "(none found)"
@@ -48,15 +49,13 @@ echo ""
 echo "=== async_oom: native crash indicators ==="
 grep -E "UnsatisfiedLinkError|dlopen failed|cannot locate symbol|SIGABRT|SIGSEGV|Fatal signal" "$LOGCAT_OOM" | tail -10 || echo "(none found)"
 echo "=== end native crash indicators ==="
-
-set -e
 # --- End diagnostics ---
 
-if [ $WAIT_RC -eq 2 ]; then
+if [ "$WAIT_RC" -eq 2 ]; then
     echo ""
     echo "FATAL: Native library failed to load (expected for async OOM reproducer)"
     EXIT_CODE=1
-elif [ $WAIT_RC -eq 1 ]; then
+elif [ "$WAIT_RC" -eq 1 ]; then
     echo ""
     echo "FAIL: Timed out waiting for 'async loaded' (app likely OOM-killed)"
     EXIT_CODE=1

--- a/test/android/async_oom.sh
+++ b/test/android/async_oom.sh
@@ -20,19 +20,38 @@ start_app "$ASYNC_OOM_APK" "async_oom"
 # .so loading.
 wait_for_logcat "async loaded" 60
 WAIT_RC=$?
+
+# Always dump logcat for diagnostics — this is a reproducer, we want
+# to see exactly what happens.
+echo ""
+echo "=== async_oom: full logcat dump ==="
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' 2>&1 | tail -80
+echo "=== end async_oom logcat ==="
+echo ""
+
+# Also check process status
+echo "=== async_oom: process status ==="
+"$ADB" -s "$EMULATOR_SERIAL" shell "ps -A 2>/dev/null | grep -i jappie || echo 'Process not found (likely killed)'"
+echo "=== end process status ==="
+echo ""
+
 if [ $WAIT_RC -eq 2 ]; then
-    dump_logcat "async_oom"
     echo "FATAL: Native library failed to load (expected for async OOM reproducer)"
-    exit 1
+    EXIT_CODE=1
 fi
 if [ $WAIT_RC -eq 1 ]; then
     echo "FAIL: Timed out waiting for 'async loaded' (app likely OOM-killed)"
+
     # Check logcat for OOM indicators
     LOGCAT_OOM="$WORK_DIR/async_oom_logcat.txt"
     "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' > "$LOGCAT_OOM" 2>&1 || true
-    if grep -qE "oom-kill|Out of memory|lowmemorykiller|Killing.*adj" "$LOGCAT_OOM" 2>/dev/null; then
-        echo "OOM-kill indicators found in logcat:"
-        grep -E "oom-kill|Out of memory|lowmemorykiller|Killing.*adj" "$LOGCAT_OOM" | tail -10
+    if grep -qE "oom-kill|Out of memory|lowmemorykiller|Killing.*adj|am_kill|am_proc_died" "$LOGCAT_OOM" 2>/dev/null; then
+        echo ""
+        echo "=== OOM/kill indicators found ==="
+        grep -E "oom-kill|Out of memory|lowmemorykiller|Killing.*adj|am_kill|am_proc_died" "$LOGCAT_OOM" | tail -20
+        echo "=== end OOM indicators ==="
+    else
+        echo "No OOM-kill indicators found in logcat (process may have been silently killed)"
     fi
     EXIT_CODE=1
 fi

--- a/test/android/async_oom.sh
+++ b/test/android/async_oom.sh
@@ -21,38 +21,44 @@ start_app "$ASYNC_OOM_APK" "async_oom"
 wait_for_logcat "async loaded" 60
 WAIT_RC=$?
 
-# Always dump logcat for diagnostics — this is a reproducer, we want
-# to see exactly what happens.
+# --- Diagnostics (always run, even on success) ---
+# Temporarily disable errexit so diagnostic commands can't kill the script.
+set +e
+
 echo ""
-echo "=== async_oom: full logcat dump ==="
+echo "=== async_oom: logcat warnings/errors (last 80 lines) ==="
 "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' 2>&1 | tail -80
 echo "=== end async_oom logcat ==="
-echo ""
 
-# Also check process status
+echo ""
 echo "=== async_oom: process status ==="
 "$ADB" -s "$EMULATOR_SERIAL" shell "ps -A 2>/dev/null | grep -i jappie || echo 'Process not found (likely killed)'"
 echo "=== end process status ==="
+
+# Check for OOM/kill indicators
+LOGCAT_OOM="$WORK_DIR/async_oom_logcat.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$LOGCAT_OOM" 2>&1
 echo ""
+echo "=== async_oom: OOM/kill indicators ==="
+grep -iE "oom|out of memory|lowmemory|am_kill|am_proc_died|killing|lmk" "$LOGCAT_OOM" | grep -i "jappie\|hatter\|oom\|kill\|memory" | tail -20 || echo "(none found)"
+echo "=== end OOM indicators ==="
+
+# Check for native crash indicators
+echo ""
+echo "=== async_oom: native crash indicators ==="
+grep -E "UnsatisfiedLinkError|dlopen failed|cannot locate symbol|SIGABRT|SIGSEGV|Fatal signal" "$LOGCAT_OOM" | tail -10 || echo "(none found)"
+echo "=== end native crash indicators ==="
+
+set -e
+# --- End diagnostics ---
 
 if [ $WAIT_RC -eq 2 ]; then
+    echo ""
     echo "FATAL: Native library failed to load (expected for async OOM reproducer)"
     EXIT_CODE=1
-fi
-if [ $WAIT_RC -eq 1 ]; then
+elif [ $WAIT_RC -eq 1 ]; then
+    echo ""
     echo "FAIL: Timed out waiting for 'async loaded' (app likely OOM-killed)"
-
-    # Check logcat for OOM indicators
-    LOGCAT_OOM="$WORK_DIR/async_oom_logcat.txt"
-    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' > "$LOGCAT_OOM" 2>&1 || true
-    if grep -qE "oom-kill|Out of memory|lowmemorykiller|Killing.*adj|am_kill|am_proc_died" "$LOGCAT_OOM" 2>/dev/null; then
-        echo ""
-        echo "=== OOM/kill indicators found ==="
-        grep -E "oom-kill|Out of memory|lowmemorykiller|Killing.*adj|am_kill|am_proc_died" "$LOGCAT_OOM" | tail -20
-        echo "=== end OOM indicators ==="
-    else
-        echo "No OOM-kill indicators found in logcat (process may have been silently killed)"
-    fi
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
## Summary
- Adds a minimal demo app (`test/AsyncOomDemoMain.hs`) that imports `Control.Concurrent.Async` and uses it trivially
- Adds an Android emulator test script (`test/android/async_oom.sh`) that asserts the app starts successfully (expected: FAIL — OOM during `.so` loading)
- Wires into `nix/emulator-all.nix` as phase 16 with `consumerCabal2Nix` adding `async` as a cross-compilation dependency
- Adds `async-oom-test` to `knownFailing` in `nix/ci.nix` so the regression is tracked without blocking CI

Reproduces issue #163: the `async` package causes the `.so` to balloon during `dlopen`, OOM-killing the process (~5.3 GB RSS) before any Haskell code executes.

## Test plan
- [x] `cabal build` passes
- [x] `cabal test` passes (252 tests)
- [x] `shellcheck` passes on new test script
- [ ] CI shows `async-oom-test` in `knownFailing`
- [ ] Android emulator phase 16 demonstrates the OOM (via `.so` size guard failure or runtime OOM-kill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)