### PR TITLE
test: reproducer for Column child removal

### DIFF
--- a/hatter.cabal
+++ b/hatter.cabal
@@ -149,6 +149,16 @@ executable scrollview-switch-demo
       hatter,
       text
 
+executable column-child-removal-demo
+  import: common-options
+  main-is: ColumnChildRemovalDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
 executable stack-demo
   import: common-options
   main-is: StackDemoMain.hs

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -295,6 +295,17 @@ let
     name = "hatter-scrollview-switch-apk";
   };
 
+  columnChildRemovalAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/ColumnChildRemovalDemoMain.hs;
+  };
+  columnChildRemovalApk = lib.mkApk {
+    sharedLibs = [{ lib = columnChildRemovalAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-column-child-removal.apk";
+    name = "hatter-column-child-removal-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -357,6 +368,7 @@ FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
+COLUMN_CHILD_REMOVAL_APK="${columnChildRemovalApk}/hatter-column-child-removal.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -389,7 +401,8 @@ for so_path in \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
-    "${stackAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${stackAndroid}/lib/${abiDir}/libhatter.so" \
+    "${columnChildRemovalAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -459,6 +472,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -575,7 +589,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK COLUMN_CHILD_REMOVAL_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -594,6 +608,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -682,6 +697,8 @@ echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/android/stack.sh" || PHASE16_EXIT=1
 echo "--- scrollview-switch ---"
 run_with_retry "scrollview-switch" bash "$TEST_SCRIPTS/android/scrollview-switch.sh" || PHASE17_EXIT=1
+echo "--- column-child-removal ---"
+run_with_retry "column-child-removal" bash "$TEST_SCRIPTS/android/column-child-removal.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -852,6 +869,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -978,6 +1005,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — ScrollView switch (issue #168 reproducer)"
 else
     echo "FAIL  Phase 17 — ScrollView switch (issue #168 reproducer)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Column child removal"
+else
+    echo "FAIL  Phase 18 — Column child removal"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -263,6 +263,17 @@ let
     name = "hatter-stack-simulator-app";
   };
 
+  columnChildRemovalIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/ColumnChildRemovalDemoMain.hs;
+    simulator = true;
+  };
+  columnChildRemovalSimApp = lib.mkSimulatorApp {
+    iosLib = columnChildRemovalIos;
+    iosSrc = ../ios;
+    name = "hatter-column-child-removal-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -305,6 +316,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 STACK_SHARE_DIR="${stackSimApp}/share/ios"
+COLUMN_CHILD_REMOVAL_SHARE_DIR="${columnChildRemovalSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -328,6 +340,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE17_OK=0
 
 cleanup() {
     echo ""
@@ -370,7 +383,8 @@ for share_dir in \
     "$HTTP_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$COLUMN_CHILD_REMOVAL_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1387,6 +1401,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building Column Child Removal app ==="
+cp -r "$COLUMN_CHILD_REMOVAL_SHARE_DIR" "$WORK_DIR/column-child-removal-proj"
+chmod -R u+w "$WORK_DIR/column-child-removal-proj"
+cd "$WORK_DIR/column-child-removal-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/column-child-removal-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+COLUMN_CHILD_REMOVAL_APP=$(find "$WORK_DIR/column-child-removal-build" -name "*.app" -type d | head -1)
+if [ -z "$COLUMN_CHILD_REMOVAL_APP" ]; then
+    echo "ERROR: Could not find column-child-removal .app bundle"
+    exit 1
+fi
+echo "Column Child Removal app: $COLUMN_CHILD_REMOVAL_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1448,7 +1486,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP COLUMN_CHILD_REMOVAL_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1466,6 +1504,7 @@ PHASE13_EXIT=0
 PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
+PHASE17_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1550,6 +1589,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/ios/textinput_rerender.sh" || PHASE15_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/ios/stack.sh" || PHASE16_EXIT=1
+echo "--- column-child-removal ---"
+run_with_retry "column-child-removal" bash "$TEST_SCRIPTS/ios/column-child-removal.sh" || PHASE17_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1710,6 +1751,16 @@ else
     echo "PHASE 16 FAILED"
 fi
 
+if [ $PHASE17_EXIT -eq 0 ]; then
+    PHASE17_OK=1
+    echo ""
+    echo "PHASE 17 PASSED"
+else
+    PHASE17_OK=0
+    echo ""
+    echo "PHASE 17 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1829,6 +1880,13 @@ if [ $PHASE16_OK -eq 1 ]; then
     echo "PASS  Phase 16 — Stack demo app"
 else
     echo "FAIL  Phase 16 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE17_OK -eq 1 ]; then
+    echo "PASS  Phase 17 — Column child removal reproducer"
+else
+    echo "FAIL  Phase 17 — Column child removal reproducer"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -242,6 +242,17 @@ let
     name = "hatter-watchos-stack-simulator-app";
   };
 
+  columnChildRemovalWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/ColumnChildRemovalDemoMain.hs;
+    simulator = true;
+  };
+  columnChildRemovalSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = columnChildRemovalWatchos;
+    watchosSrc = ../watchos;
+    name = "hatter-watchos-column-child-removal-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -282,6 +293,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/watchos"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/watchos"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/watchos"
 STACK_SHARE_DIR="${stackSimApp}/share/watchos"
+COLUMN_CHILD_REMOVAL_SHARE_DIR="${columnChildRemovalSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -304,6 +316,7 @@ PHASE12_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -344,7 +357,8 @@ for share_dir in \
     "$NETWORK_STATUS_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$COLUMN_CHILD_REMOVAL_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1250,6 +1264,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building Column Child Removal app ==="
+cp -r "$COLUMN_CHILD_REMOVAL_SHARE_DIR" "$WORK_DIR/column-child-removal-proj"
+chmod -R u+w "$WORK_DIR/column-child-removal-proj"
+cd "$WORK_DIR/column-child-removal-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/column-child-removal-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+COLUMN_CHILD_REMOVAL_APP=$(find "$WORK_DIR/column-child-removal-build" -name "*.app" -type d | head -1)
+if [ -z "$COLUMN_CHILD_REMOVAL_APP" ]; then
+    echo "ERROR: Could not find column-child-removal .app bundle"
+    exit 1
+fi
+echo "Column Child Removal app: $COLUMN_CHILD_REMOVAL_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1313,7 +1351,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.hatter"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP COLUMN_CHILD_REMOVAL_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1332,6 +1370,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1405,6 +1444,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/watchos/textinput_rerender.sh" || PHASE16_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/watchos/stack.sh" || PHASE17_EXIT=1
+echo "--- column-child-removal ---"
+run_with_retry "column-child-removal" bash "$TEST_SCRIPTS/watchos/column-child-removal.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1575,6 +1616,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1701,6 +1752,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — Stack demo app"
 else
     echo "FAIL  Phase 17 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Column child removal reproducer"
+else
+    echo "FAIL  Phase 18 — Column child removal reproducer"
     FINAL_EXIT=1
 fi
 

--- a/test/ColumnChildRemovalDemoMain.hs
+++ b/test/ColumnChildRemovalDemoMain.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Reproducer: removing children from a Column container.
+--
+-- Tests the childrenStable optimization path in diffContainer.
+-- When children are removed from the end, the stable path fires
+-- (remove excess, keep rest). When children are removed from the
+-- middle, positions shift and the unstable path fires (remove-all,
+-- re-add-all).
+--
+-- This test cycles through 3 states:
+--   State0: Column [A, B, C]        — 3 children
+--   State1: Column [A, C]           — B removed (middle removal)
+--   State2: Column [A]              — C removed (tail removal)
+--
+-- Verifies that only the correct children remain visible after each switch.
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
+import Data.Text qualified as Text
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (ButtonConfig(..), Widget(..), text)
+
+data TestState = State0 | State1 | State2
+  deriving (Show, Eq)
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "ColumnChildRemoval demo registered"
+  actionState <- newActionState
+  testState <- newIORef State0
+  advanceAction <- runActionM actionState $
+    createAction (modifyIORef' testState advance)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> childRemovalView testState advanceAction
+    , maActionState = actionState
+    }
+
+advance :: TestState -> TestState
+advance State0 = State1
+advance State1 = State2
+advance State2 = State0
+
+childRemovalView :: IORef TestState -> Action -> IO Widget
+childRemovalView testState advanceAction = do
+  state <- readIORef testState
+  platformLog ("Column state: " <> Text.pack (show state))
+  let children = case state of
+        State0 -> [ text "CHILD_A", text "CHILD_B", text "CHILD_C" ]
+        State1 -> [ text "CHILD_A", text "CHILD_C" ]
+        State2 -> [ text "CHILD_A" ]
+  pure $ Column
+    ( Button ButtonConfig
+        { bcLabel = "Advance"
+        , bcAction = advanceAction
+        , bcFontConfig = Nothing
+        }
+    : children
+    )

--- a/test/android/column-child-removal.sh
+++ b/test/android/column-child-removal.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Android column-child-removal test: reproducer for child removal from Column.
+#
+# Tests diffContainer's handling of child removal:
+#   State0 → State1: middle child removed (B gone, unstable path)
+#   State1 → State2: tail child removed (C gone, stable path)
+#
+# Verifies that only the correct children remain after each transition.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, COLUMN_CHILD_REMOVAL_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$COLUMN_CHILD_REMOVAL_APK" "column-child-removal"
+wait_for_render "column-child-removal"
+sleep 5
+collect_logcat "ccr-initial"
+
+assert_logcat "$LOGCAT_FILE" "Column state: State0" "Initial state is State0"
+
+# Verify all 3 children visible
+DUMP="$WORK_DIR/ccr_0.xml"
+dump_ok=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP" 2>/dev/null
+        dump_ok=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok -eq 1 ]; then
+    for child in CHILD_A CHILD_B CHILD_C; do
+        if grep -q "$child" "$DUMP" 2>/dev/null; then
+            echo "PASS: $child visible in State0"
+        else
+            echo "FAIL: $child not visible in State0"
+            EXIT_CODE=1
+        fi
+    done
+else
+    echo "FAIL: Could not dump view hierarchy (State0)"
+    EXIT_CODE=1
+fi
+
+# === Advance to State1 (middle removal: B gone) ===
+echo "=== Advancing to State1 ==="
+tap_button "Advance" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "ccr-state1"
+assert_logcat "$LOGCAT_FILE" "Column state: State1" "Advanced to State1"
+
+DUMP1="$WORK_DIR/ccr_1.xml"
+dump_ok1=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP1" 2>/dev/null
+        dump_ok1=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok1 -eq 1 ]; then
+    echo "=== State1 hierarchy ==="
+    cat "$DUMP1"
+    echo ""
+
+    if grep -q 'CHILD_A' "$DUMP1" 2>/dev/null; then
+        echo "PASS: CHILD_A visible in State1"
+    else
+        echo "FAIL: CHILD_A not visible in State1"
+        EXIT_CODE=1
+    fi
+
+    if grep -q 'CHILD_B' "$DUMP1" 2>/dev/null; then
+        echo "FAIL: CHILD_B still visible in State1 (should be removed)"
+        EXIT_CODE=1
+    else
+        echo "PASS: CHILD_B removed in State1"
+    fi
+
+    if grep -q 'CHILD_C' "$DUMP1" 2>/dev/null; then
+        echo "PASS: CHILD_C visible in State1"
+    else
+        echo "FAIL: CHILD_C not visible in State1"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (State1)"
+    EXIT_CODE=1
+fi
+
+# === Advance to State2 (tail removal: C gone) ===
+echo "=== Advancing to State2 ==="
+tap_button "Advance" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "ccr-state2"
+assert_logcat "$LOGCAT_FILE" "Column state: State2" "Advanced to State2"
+
+DUMP2="$WORK_DIR/ccr_2.xml"
+dump_ok2=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP2" 2>/dev/null
+        dump_ok2=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok2 -eq 1 ]; then
+    echo "=== State2 hierarchy ==="
+    cat "$DUMP2"
+    echo ""
+
+    if grep -q 'CHILD_A' "$DUMP2" 2>/dev/null; then
+        echo "PASS: CHILD_A visible in State2"
+    else
+        echo "FAIL: CHILD_A not visible in State2"
+        EXIT_CODE=1
+    fi
+
+    if grep -q 'CHILD_B' "$DUMP2" 2>/dev/null; then
+        echo "FAIL: CHILD_B still visible in State2 (orphaned)"
+        EXIT_CODE=1
+    else
+        echo "PASS: CHILD_B absent in State2"
+    fi
+
+    if grep -q 'CHILD_C' "$DUMP2" 2>/dev/null; then
+        echo "FAIL: CHILD_C still visible in State2 (should be removed)"
+        EXIT_CODE=1
+    else
+        echo "PASS: CHILD_C removed in State2"
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (State2)"
+    EXIT_CODE=1
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/column-child-removal.sh
+++ b/test/ios/column-child-removal.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# iOS column-child-removal test: removing children from a Column.
+#
+# Tests the childrenStable optimization in diffContainer.
+# Cycles: [A,B,C] → [A,C] → [A]
+#
+# --autotest fires callbackId=0 (the Advance button) after 3s.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, COLUMN_CHILD_REMOVAL_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$COLUMN_CHILD_REMOVAL_APP" "column-child-removal" --autotest
+wait_for_render "column-child-removal" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for State1
+wait_for_log "$STREAM_LOG" "Column state: State1" 30 || true
+sleep 5
+
+collect_logs "column-child-removal"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "Column state: State0" "Initial state is State0"
+assert_log "$FULL_LOG" "Column state: State1" "Advanced to State1"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/column-child-removal.sh
+++ b/test/watchos/column-child-removal.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# watchOS column-child-removal test: removing children from a Column.
+#
+# Tests the childrenStable optimization in diffContainer.
+# Cycles: [A,B,C] → [A,C] → [A]
+#
+# --autotest fires callbackId=0 (the Advance button) after 3s.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, LOG_SUBSYSTEM, COLUMN_CHILD_REMOVAL_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$COLUMN_CHILD_REMOVAL_APP" "column-child-removal" --autotest
+wait_for_render "column-child-removal" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for State1
+wait_for_log "$STREAM_LOG" "Column state: State1" 30 || true
+sleep 5
+
+collect_logs "column-child-removal"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "Column state: State0" "Initial state is State0"
+assert_log "$FULL_LOG" "Column state: State1" "Advanced to State1"
+
+cleanup_app
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Adds Phase 18 emulator test: removing children from a Column container
- Cycles through [A,B,C] → [A,C] (middle removal) → [A] (tail removal)
- Tests both the stable and unstable paths of `diffContainer`
- Verifies via uiautomator that removed children are gone and remaining children stay

## What this tests

The `childrenStable` optimization in `Render.hs:440-452`:
- **Middle removal** triggers the unstable path (full remove-all + re-add-all)
- **Tail removal** triggers the stable path (only remove excess)

Both paths should correctly detach native views.

## Test plan

- [ ] Phase 18 on Android emulator — verify children are correctly removed
- [ ] All other phases remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)