### PR TITLE
test: reproducer for Column child reordering

### DIFF
--- a/hatter.cabal
+++ b/hatter.cabal
@@ -149,6 +149,16 @@ executable scrollview-switch-demo
       hatter,
       text
 
+executable column-child-reorder-demo
+  import: common-options
+  main-is: ColumnChildReorderDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
 executable stack-demo
   import: common-options
   main-is: StackDemoMain.hs

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -295,6 +295,17 @@ let
     name = "hatter-scrollview-switch-apk";
   };
 
+  columnChildReorderAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/ColumnChildReorderDemoMain.hs;
+  };
+  columnChildReorderApk = lib.mkApk {
+    sharedLibs = [{ lib = columnChildReorderAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-column-child-reorder.apk";
+    name = "hatter-column-child-reorder-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -357,6 +368,7 @@ FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
+COLUMN_CHILD_REORDER_APK="${columnChildReorderApk}/hatter-column-child-reorder.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -389,7 +401,8 @@ for so_path in \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
-    "${stackAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${stackAndroid}/lib/${abiDir}/libhatter.so" \
+    "${columnChildReorderAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -459,6 +472,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -575,7 +589,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK COLUMN_CHILD_REORDER_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -594,6 +608,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -682,6 +697,8 @@ echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/android/stack.sh" || PHASE16_EXIT=1
 echo "--- scrollview-switch ---"
 run_with_retry "scrollview-switch" bash "$TEST_SCRIPTS/android/scrollview-switch.sh" || PHASE17_EXIT=1
+echo "--- column-child-reorder ---"
+run_with_retry "column-child-reorder" bash "$TEST_SCRIPTS/android/column-child-reorder.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -852,6 +869,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -978,6 +1005,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — ScrollView switch (issue #168 reproducer)"
 else
     echo "FAIL  Phase 17 — ScrollView switch (issue #168 reproducer)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Column child reordering"
+else
+    echo "FAIL  Phase 18 — Column child reordering"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -263,6 +263,17 @@ let
     name = "hatter-stack-simulator-app";
   };
 
+  columnChildReorderIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/ColumnChildReorderDemoMain.hs;
+    simulator = true;
+  };
+  columnChildReorderSimApp = lib.mkSimulatorApp {
+    iosLib = columnChildReorderIos;
+    iosSrc = ../ios;
+    name = "hatter-column-child-reorder-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -305,6 +316,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 STACK_SHARE_DIR="${stackSimApp}/share/ios"
+COLUMN_CHILD_REORDER_SHARE_DIR="${columnChildReorderSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -328,6 +340,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE17_OK=0
 
 cleanup() {
     echo ""
@@ -370,7 +383,8 @@ for share_dir in \
     "$HTTP_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$COLUMN_CHILD_REORDER_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1387,6 +1401,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building Column Child Reorder app ==="
+cp -r "$COLUMN_CHILD_REORDER_SHARE_DIR" "$WORK_DIR/column-child-reorder-proj"
+chmod -R u+w "$WORK_DIR/column-child-reorder-proj"
+cd "$WORK_DIR/column-child-reorder-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/column-child-reorder-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+COLUMN_CHILD_REORDER_APP=$(find "$WORK_DIR/column-child-reorder-build" -name "*.app" -type d | head -1)
+if [ -z "$COLUMN_CHILD_REORDER_APP" ]; then
+    echo "ERROR: Could not find column-child-reorder .app bundle"
+    exit 1
+fi
+echo "Column Child Reorder app: $COLUMN_CHILD_REORDER_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1448,7 +1486,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP COLUMN_CHILD_REORDER_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1466,6 +1504,7 @@ PHASE13_EXIT=0
 PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
+PHASE17_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1550,6 +1589,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/ios/textinput_rerender.sh" || PHASE15_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/ios/stack.sh" || PHASE16_EXIT=1
+echo "--- column-child-reorder ---"
+run_with_retry "column-child-reorder" bash "$TEST_SCRIPTS/ios/column-child-reorder.sh" || PHASE17_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1710,6 +1751,16 @@ else
     echo "PHASE 16 FAILED"
 fi
 
+if [ $PHASE17_EXIT -eq 0 ]; then
+    PHASE17_OK=1
+    echo ""
+    echo "PHASE 17 PASSED"
+else
+    PHASE17_OK=0
+    echo ""
+    echo "PHASE 17 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1829,6 +1880,13 @@ if [ $PHASE16_OK -eq 1 ]; then
     echo "PASS  Phase 16 — Stack demo app"
 else
     echo "FAIL  Phase 16 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE17_OK -eq 1 ]; then
+    echo "PASS  Phase 17 — Column child reorder reproducer"
+else
+    echo "FAIL  Phase 17 — Column child reorder reproducer"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -242,6 +242,17 @@ let
     name = "hatter-watchos-stack-simulator-app";
   };
 
+  columnChildReorderWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/ColumnChildReorderDemoMain.hs;
+    simulator = true;
+  };
+  columnChildReorderSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = columnChildReorderWatchos;
+    watchosSrc = ../watchos;
+    name = "hatter-watchos-column-child-reorder-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -282,6 +293,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/watchos"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/watchos"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/watchos"
 STACK_SHARE_DIR="${stackSimApp}/share/watchos"
+COLUMN_CHILD_REORDER_SHARE_DIR="${columnChildReorderSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -304,6 +316,7 @@ PHASE12_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -344,7 +357,8 @@ for share_dir in \
     "$NETWORK_STATUS_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$COLUMN_CHILD_REORDER_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1250,6 +1264,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building Column Child Reorder app ==="
+cp -r "$COLUMN_CHILD_REORDER_SHARE_DIR" "$WORK_DIR/column-child-reorder-proj"
+chmod -R u+w "$WORK_DIR/column-child-reorder-proj"
+cd "$WORK_DIR/column-child-reorder-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/column-child-reorder-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+COLUMN_CHILD_REORDER_APP=$(find "$WORK_DIR/column-child-reorder-build" -name "*.app" -type d | head -1)
+if [ -z "$COLUMN_CHILD_REORDER_APP" ]; then
+    echo "ERROR: Could not find column-child-reorder .app bundle"
+    exit 1
+fi
+echo "Column Child Reorder app: $COLUMN_CHILD_REORDER_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1313,7 +1351,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.hatter"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP COLUMN_CHILD_REORDER_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1332,6 +1370,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1405,6 +1444,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/watchos/textinput_rerender.sh" || PHASE16_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/watchos/stack.sh" || PHASE17_EXIT=1
+echo "--- column-child-reorder ---"
+run_with_retry "column-child-reorder" bash "$TEST_SCRIPTS/watchos/column-child-reorder.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1575,6 +1616,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1701,6 +1752,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — Stack demo app"
 else
     echo "FAIL  Phase 17 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Column child reorder reproducer"
+else
+    echo "FAIL  Phase 18 — Column child reorder reproducer"
     FINAL_EXIT=1
 fi
 

--- a/test/ColumnChildReorderDemoMain.hs
+++ b/test/ColumnChildReorderDemoMain.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Reproducer: reordering children in a Column container.
+--
+-- Tests diffContainer's unstable path (remove-all + re-add-all)
+-- when children swap positions. Uses different widget types at
+-- each position so we can verify visual order via uiautomator.
+--
+-- State0: Column [Button "FIRST", Text "SECOND", Text "THIRD"]
+-- State1: Column [Text "THIRD", Text "SECOND", Button "FIRST"]
+--
+-- After switch, verifies that THIRD appears before FIRST in the
+-- uiautomator dump (top-to-bottom order matches LinearLayout order).
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
+import Data.Text qualified as Text
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (ButtonConfig(..), Widget(..), text)
+
+data TestState = OrderABC | OrderCBA
+  deriving (Show, Eq)
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "ColumnChildReorder demo registered"
+  actionState <- newActionState
+  testState <- newIORef OrderABC
+  reorderAction <- runActionM actionState $
+    createAction (modifyIORef' testState toggle)
+  noopAction <- runActionM actionState $
+    createAction (pure ())
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> reorderView testState reorderAction noopAction
+    , maActionState = actionState
+    }
+
+toggle :: TestState -> TestState
+toggle OrderABC = OrderCBA
+toggle OrderCBA = OrderABC
+
+reorderView :: IORef TestState -> Action -> Action -> IO Widget
+reorderView testState reorderAction noopAction = do
+  state <- readIORef testState
+  platformLog ("Reorder state: " <> Text.pack (show state))
+  let children = case state of
+        OrderABC ->
+          [ Button ButtonConfig { bcLabel = "ITEM_FIRST", bcAction = noopAction, bcFontConfig = Nothing }
+          , text "ITEM_SECOND"
+          , text "ITEM_THIRD"
+          ]
+        OrderCBA ->
+          [ text "ITEM_THIRD"
+          , text "ITEM_SECOND"
+          , Button ButtonConfig { bcLabel = "ITEM_FIRST", bcAction = noopAction, bcFontConfig = Nothing }
+          ]
+  pure $ Column
+    ( Button ButtonConfig
+        { bcLabel = "Reorder"
+        , bcAction = reorderAction
+        , bcFontConfig = Nothing
+        }
+    : children
+    )

--- a/test/android/column-child-reorder.sh
+++ b/test/android/column-child-reorder.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Android column-child-reorder test: reproducer for child reordering in Column.
+#
+# Tests diffContainer's unstable path when children swap positions.
+# Uses mixed widget types (Button/Text) so type changes force replaceNode.
+#
+# State0: [ITEM_FIRST (Button), ITEM_SECOND (Text), ITEM_THIRD (Text)]
+# State1: [ITEM_THIRD (Text), ITEM_SECOND (Text), ITEM_FIRST (Button)]
+#
+# Verifies visual order by checking uiautomator bounds:
+# ITEM_THIRD should appear above (smaller Y) ITEM_FIRST after reorder.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, COLUMN_CHILD_REORDER_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$COLUMN_CHILD_REORDER_APK" "column-child-reorder"
+wait_for_render "column-child-reorder"
+sleep 5
+collect_logcat "ccreorder-initial"
+
+assert_logcat "$LOGCAT_FILE" "Reorder state: OrderABC" "Initial state is OrderABC"
+
+# Verify all items visible initially
+DUMP_A="$WORK_DIR/ccreorder_a.xml"
+dump_ok=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP_A" 2>/dev/null
+        dump_ok=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok -eq 1 ]; then
+    for item in ITEM_FIRST ITEM_SECOND ITEM_THIRD; do
+        if grep -q "$item" "$DUMP_A" 2>/dev/null; then
+            echo "PASS: $item visible in OrderABC"
+        else
+            echo "FAIL: $item not visible in OrderABC"
+            EXIT_CODE=1
+        fi
+    done
+else
+    echo "FAIL: Could not dump view hierarchy (OrderABC)"
+    EXIT_CODE=1
+fi
+
+# === Reorder ===
+echo "=== Tapping Reorder ==="
+tap_button "Reorder" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "ccreorder-after"
+assert_logcat "$LOGCAT_FILE" "Reorder state: OrderCBA" "Switched to OrderCBA"
+
+DUMP_B="$WORK_DIR/ccreorder_b.xml"
+dump_ok_b=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP_B" 2>/dev/null
+        dump_ok_b=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok_b -eq 1 ]; then
+    echo "=== Post-reorder hierarchy ==="
+    cat "$DUMP_B"
+    echo ""
+
+    # All items must still be present
+    for item in ITEM_FIRST ITEM_SECOND ITEM_THIRD; do
+        if grep -q "$item" "$DUMP_B" 2>/dev/null; then
+            echo "PASS: $item visible after reorder"
+        else
+            echo "FAIL: $item missing after reorder"
+            EXIT_CODE=1
+        fi
+    done
+
+    # Check visual order: ITEM_THIRD should appear BEFORE ITEM_FIRST
+    # Extract Y coordinate (top of bounds) for each item
+    THIRD_Y=$(grep -o 'text="ITEM_THIRD"[^>]*bounds="\[[0-9]*,\([0-9]*\)' "$DUMP_B" 2>/dev/null | grep -o '[0-9]*$' || echo "")
+    FIRST_Y=$(grep -o 'text="ITEM_FIRST"[^>]*bounds="\[[0-9]*,\([0-9]*\)' "$DUMP_B" 2>/dev/null | grep -o '[0-9]*$' || echo "")
+
+    if [ -n "$THIRD_Y" ] && [ -n "$FIRST_Y" ]; then
+        if [ "$THIRD_Y" -lt "$FIRST_Y" ]; then
+            echo "PASS: ITEM_THIRD (Y=$THIRD_Y) appears above ITEM_FIRST (Y=$FIRST_Y)"
+        else
+            echo "FAIL: ITEM_THIRD (Y=$THIRD_Y) should appear above ITEM_FIRST (Y=$FIRST_Y) — wrong order"
+            EXIT_CODE=1
+        fi
+    else
+        echo "WARN: Could not extract bounds for order check (THIRD_Y=$THIRD_Y, FIRST_Y=$FIRST_Y)"
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (OrderCBA)"
+    EXIT_CODE=1
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/column-child-reorder.sh
+++ b/test/ios/column-child-reorder.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# iOS column-child-reorder test: reordering children in a Column.
+#
+# Tests diffContainer's unstable path (remove-all + re-add-all)
+# when children swap positions with mixed widget types.
+#
+# State0: Column [FIRST, SECOND, THIRD]
+# State1: Column [THIRD, SECOND, FIRST]
+#
+# --autotest fires callbackId=0 (the Reorder button) after 3s.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, COLUMN_CHILD_REORDER_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$COLUMN_CHILD_REORDER_APP" "column-child-reorder" --autotest
+wait_for_render "column-child-reorder" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for reorder
+wait_for_log "$STREAM_LOG" "Reorder state: OrderCBA" 30 || true
+sleep 5
+
+collect_logs "column-child-reorder"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "Reorder state: OrderABC" "Initial order is ABC"
+assert_log "$FULL_LOG" "Reorder state: OrderCBA" "Reordered to CBA"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/column-child-reorder.sh
+++ b/test/watchos/column-child-reorder.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# watchOS column-child-reorder test: reordering children in a Column.
+#
+# Tests diffContainer's unstable path (remove-all + re-add-all)
+# when children swap positions with mixed widget types.
+#
+# State0: Column [FIRST, SECOND, THIRD]
+# State1: Column [THIRD, SECOND, FIRST]
+#
+# --autotest fires callbackId=0 (the Reorder button) after 3s.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, LOG_SUBSYSTEM, COLUMN_CHILD_REORDER_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$COLUMN_CHILD_REORDER_APP" "column-child-reorder" --autotest
+wait_for_render "column-child-reorder" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for reorder
+wait_for_log "$STREAM_LOG" "Reorder state: OrderCBA" 30 || true
+sleep 5
+
+collect_logs "column-child-reorder"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "Reorder state: OrderABC" "Initial order is ABC"
+assert_log "$FULL_LOG" "Reorder state: OrderCBA" "Reordered to CBA"
+
+cleanup_app
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Adds Phase 18 emulator test: reordering children in a Column container
- Switches between [FIRST, SECOND, THIRD] and [THIRD, SECOND, FIRST]
- Uses mixed widget types (Button/Text) so positions 0 and 2 change type, forcing replaceNode
- Verifies visual order via uiautomator bounds (Y coordinate comparison)

## What this tests

The unstable path of `diffContainer` (Render.hs:447-452): when `zipPadded` pairs produce different nodeIds, the full remove-all + re-add-all path fires. This test checks that the re-added children appear in the correct visual order on the native platform.

## Test plan

- [ ] Phase 18 on Android emulator — verify ITEM_THIRD appears above ITEM_FIRST after reorder
- [ ] All other phases remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)