### PR TITLE
test: reproducer for ScrollView child mutations

### DIFF
--- a/hatter.cabal
+++ b/hatter.cabal
@@ -149,6 +149,16 @@ executable scrollview-switch-demo
       hatter,
       text
 
+executable scrollview-mutations-demo
+  import: common-options
+  main-is: ScrollViewMutationsDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
 executable stack-demo
   import: common-options
   main-is: StackDemoMain.hs

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -295,6 +295,17 @@ let
     name = "hatter-scrollview-switch-apk";
   };
 
+  scrollviewMutationsAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/ScrollViewMutationsDemoMain.hs;
+  };
+  scrollviewMutationsApk = lib.mkApk {
+    sharedLibs = [{ lib = scrollviewMutationsAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-scrollview-mutations.apk";
+    name = "hatter-scrollview-mutations-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -357,6 +368,7 @@ FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
+SCROLLVIEW_MUTATIONS_APK="${scrollviewMutationsApk}/hatter-scrollview-mutations.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -389,7 +401,8 @@ for so_path in \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
-    "${stackAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${stackAndroid}/lib/${abiDir}/libhatter.so" \
+    "${scrollviewMutationsAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -459,6 +472,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -575,7 +589,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK SCROLLVIEW_MUTATIONS_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -594,6 +608,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -682,6 +697,8 @@ echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/android/stack.sh" || PHASE16_EXIT=1
 echo "--- scrollview-switch ---"
 run_with_retry "scrollview-switch" bash "$TEST_SCRIPTS/android/scrollview-switch.sh" || PHASE17_EXIT=1
+echo "--- scrollview-mutations ---"
+run_with_retry "scrollview-mutations" bash "$TEST_SCRIPTS/android/scrollview-mutations.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -852,6 +869,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -978,6 +1005,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — ScrollView switch (issue #168 reproducer)"
 else
     echo "FAIL  Phase 17 — ScrollView switch (issue #168 reproducer)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — ScrollView child mutations"
+else
+    echo "FAIL  Phase 18 — ScrollView child mutations"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -263,6 +263,17 @@ let
     name = "hatter-stack-simulator-app";
   };
 
+  scrollviewMutationsIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/ScrollViewMutationsDemoMain.hs;
+    simulator = true;
+  };
+  scrollviewMutationsSimApp = lib.mkSimulatorApp {
+    iosLib = scrollviewMutationsIos;
+    iosSrc = ../ios;
+    name = "hatter-scrollview-mutations-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -305,6 +316,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 STACK_SHARE_DIR="${stackSimApp}/share/ios"
+SCROLLVIEW_MUTATIONS_SHARE_DIR="${scrollviewMutationsSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -328,6 +340,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE17_OK=0
 
 cleanup() {
     echo ""
@@ -370,7 +383,8 @@ for share_dir in \
     "$HTTP_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$SCROLLVIEW_MUTATIONS_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1387,6 +1401,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building ScrollView Mutations app ==="
+cp -r "$SCROLLVIEW_MUTATIONS_SHARE_DIR" "$WORK_DIR/scrollview-mutations-proj"
+chmod -R u+w "$WORK_DIR/scrollview-mutations-proj"
+cd "$WORK_DIR/scrollview-mutations-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/scrollview-mutations-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+SCROLLVIEW_MUTATIONS_APP=$(find "$WORK_DIR/scrollview-mutations-build" -name "*.app" -type d | head -1)
+if [ -z "$SCROLLVIEW_MUTATIONS_APP" ]; then
+    echo "ERROR: Could not find scrollview-mutations .app bundle"
+    exit 1
+fi
+echo "ScrollView Mutations app: $SCROLLVIEW_MUTATIONS_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1448,7 +1486,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP SCROLLVIEW_MUTATIONS_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1466,6 +1504,7 @@ PHASE13_EXIT=0
 PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
+PHASE17_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1550,6 +1589,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/ios/textinput_rerender.sh" || PHASE15_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/ios/stack.sh" || PHASE16_EXIT=1
+echo "--- scrollview-mutations ---"
+run_with_retry "scrollview-mutations" bash "$TEST_SCRIPTS/ios/scrollview-mutations.sh" || PHASE17_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1710,6 +1751,16 @@ else
     echo "PHASE 16 FAILED"
 fi
 
+if [ $PHASE17_EXIT -eq 0 ]; then
+    PHASE17_OK=1
+    echo ""
+    echo "PHASE 17 PASSED"
+else
+    PHASE17_OK=0
+    echo ""
+    echo "PHASE 17 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1829,6 +1880,13 @@ if [ $PHASE16_OK -eq 1 ]; then
     echo "PASS  Phase 16 — Stack demo app"
 else
     echo "FAIL  Phase 16 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE17_OK -eq 1 ]; then
+    echo "PASS  Phase 17 — ScrollView child mutations reproducer"
+else
+    echo "FAIL  Phase 17 — ScrollView child mutations reproducer"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -242,6 +242,17 @@ let
     name = "hatter-watchos-stack-simulator-app";
   };
 
+  scrollviewMutationsWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/ScrollViewMutationsDemoMain.hs;
+    simulator = true;
+  };
+  scrollviewMutationsSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = scrollviewMutationsWatchos;
+    watchosSrc = ../watchos;
+    name = "hatter-watchos-scrollview-mutations-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -282,6 +293,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/watchos"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/watchos"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/watchos"
 STACK_SHARE_DIR="${stackSimApp}/share/watchos"
+SCROLLVIEW_MUTATIONS_SHARE_DIR="${scrollviewMutationsSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -304,6 +316,7 @@ PHASE12_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -344,7 +357,8 @@ for share_dir in \
     "$NETWORK_STATUS_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$SCROLLVIEW_MUTATIONS_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1250,6 +1264,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building ScrollView Mutations app ==="
+cp -r "$SCROLLVIEW_MUTATIONS_SHARE_DIR" "$WORK_DIR/scrollview-mutations-proj"
+chmod -R u+w "$WORK_DIR/scrollview-mutations-proj"
+cd "$WORK_DIR/scrollview-mutations-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/scrollview-mutations-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+SCROLLVIEW_MUTATIONS_APP=$(find "$WORK_DIR/scrollview-mutations-build" -name "*.app" -type d | head -1)
+if [ -z "$SCROLLVIEW_MUTATIONS_APP" ]; then
+    echo "ERROR: Could not find scrollview-mutations .app bundle"
+    exit 1
+fi
+echo "ScrollView Mutations app: $SCROLLVIEW_MUTATIONS_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1313,7 +1351,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.hatter"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP SCROLLVIEW_MUTATIONS_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1332,6 +1370,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1405,6 +1444,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/watchos/textinput_rerender.sh" || PHASE16_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/watchos/stack.sh" || PHASE17_EXIT=1
+echo "--- scrollview-mutations ---"
+run_with_retry "scrollview-mutations" bash "$TEST_SCRIPTS/watchos/scrollview-mutations.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1575,6 +1616,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1701,6 +1752,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — Stack demo app"
 else
     echo "FAIL  Phase 17 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — ScrollView child mutations reproducer"
+else
+    echo "FAIL  Phase 18 — ScrollView child mutations reproducer"
     FINAL_EXIT=1
 fi
 

--- a/test/ScrollViewMutationsDemoMain.hs
+++ b/test/ScrollViewMutationsDemoMain.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Reproducer: add/remove/reorder children inside a ScrollView.
+--
+-- Tests the inner LinearLayout/StackView wrapper handling:
+-- - addChild redirects to inner layout (getChildAt(0))
+-- - removeChild redirects to inner layout
+-- - If getChildAt(0) fails, addChild falls through to the raw ScrollView
+--
+-- State0: ScrollView [A, B, C]       — 3 children
+-- State1: ScrollView [A, B, C, D]    — add child
+-- State2: ScrollView [A, C, D]       — remove middle child
+-- State3: ScrollView [D, C, A]       — reorder
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
+import Data.Text qualified as Text
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (ButtonConfig(..), Widget(..), text)
+
+data TestState = SV0 | SV1 | SV2 | SV3
+  deriving (Show, Eq)
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "ScrollViewMutations demo registered"
+  actionState <- newActionState
+  testState <- newIORef SV0
+  advanceAction <- runActionM actionState $
+    createAction (modifyIORef' testState advance)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> scrollMutationsView testState advanceAction
+    , maActionState = actionState
+    }
+
+advance :: TestState -> TestState
+advance SV0 = SV1
+advance SV1 = SV2
+advance SV2 = SV3
+advance SV3 = SV0
+
+scrollMutationsView :: IORef TestState -> Action -> IO Widget
+scrollMutationsView testState advanceAction = do
+  state <- readIORef testState
+  platformLog ("ScrollView state: " <> Text.pack (show state))
+  let scrollChildren = case state of
+        SV0 -> [ text "SV_ITEM_A", text "SV_ITEM_B", text "SV_ITEM_C" ]
+        SV1 -> [ text "SV_ITEM_A", text "SV_ITEM_B", text "SV_ITEM_C", text "SV_ITEM_D" ]
+        SV2 -> [ text "SV_ITEM_A", text "SV_ITEM_C", text "SV_ITEM_D" ]
+        SV3 -> [ text "SV_ITEM_D", text "SV_ITEM_C", text "SV_ITEM_A" ]
+  pure $ Column
+    [ Button ButtonConfig
+        { bcLabel = "Advance"
+        , bcAction = advanceAction
+        , bcFontConfig = Nothing
+        }
+    , ScrollView scrollChildren
+    ]

--- a/test/android/scrollview-mutations.sh
+++ b/test/android/scrollview-mutations.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Android scrollview-mutations test: add/remove/reorder children in ScrollView.
+#
+# Tests the inner LinearLayout wrapper handling in addChild/removeChild.
+# Cycles through 4 states and verifies correct children visible at each step.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, SCROLLVIEW_MUTATIONS_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$SCROLLVIEW_MUTATIONS_APK" "scrollview-mutations"
+wait_for_render "scrollview-mutations"
+sleep 5
+collect_logcat "svm-initial"
+
+assert_logcat "$LOGCAT_FILE" "ScrollView state: SV0" "Initial state is SV0"
+
+# Helper: dump UI and check items
+check_items() {
+    local label="$1"
+    shift
+    local expected=("$@")
+
+    local dump_file="$WORK_DIR/svm_${label}.xml"
+    local dump_ok=0
+    for attempt in 1 2 3; do
+        if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+            "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$dump_file" 2>/dev/null
+            dump_ok=1
+            break
+        fi
+        sleep 5
+    done
+
+    if [ $dump_ok -eq 1 ]; then
+        echo "=== $label hierarchy ==="
+        cat "$dump_file"
+        echo ""
+
+        for item in "${expected[@]}"; do
+            if grep -q "$item" "$dump_file" 2>/dev/null; then
+                echo "PASS: $item visible in $label"
+            else
+                echo "FAIL: $item not visible in $label"
+                EXIT_CODE=1
+            fi
+        done
+
+        # Check no unexpected SV_ITEM_ items
+        for item in SV_ITEM_A SV_ITEM_B SV_ITEM_C SV_ITEM_D; do
+            local expected_here=0
+            for e in "${expected[@]}"; do
+                if [ "$e" = "$item" ]; then
+                    expected_here=1
+                    break
+                fi
+            done
+            if [ $expected_here -eq 0 ]; then
+                if grep -q "$item" "$dump_file" 2>/dev/null; then
+                    echo "FAIL: $item should NOT be visible in $label (orphaned)"
+                    EXIT_CODE=1
+                else
+                    echo "PASS: $item correctly absent in $label"
+                fi
+            fi
+        done
+    else
+        echo "FAIL: Could not dump view hierarchy ($label)"
+        EXIT_CODE=1
+    fi
+}
+
+# State0: A, B, C
+check_items "SV0" SV_ITEM_A SV_ITEM_B SV_ITEM_C
+
+# === Advance to SV1 (add D) ===
+echo "=== Advancing to SV1 (add child) ==="
+tap_button "Advance" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "svm-sv1"
+assert_logcat "$LOGCAT_FILE" "ScrollView state: SV1" "Advanced to SV1"
+check_items "SV1" SV_ITEM_A SV_ITEM_B SV_ITEM_C SV_ITEM_D
+
+# === Advance to SV2 (remove B) ===
+echo "=== Advancing to SV2 (remove middle child) ==="
+tap_button "Advance" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "svm-sv2"
+assert_logcat "$LOGCAT_FILE" "ScrollView state: SV2" "Advanced to SV2"
+check_items "SV2" SV_ITEM_A SV_ITEM_C SV_ITEM_D
+
+# === Advance to SV3 (reorder) ===
+echo "=== Advancing to SV3 (reorder) ==="
+tap_button "Advance" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "svm-sv3"
+assert_logcat "$LOGCAT_FILE" "ScrollView state: SV3" "Advanced to SV3"
+check_items "SV3" SV_ITEM_D SV_ITEM_C SV_ITEM_A
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/scrollview-mutations.sh
+++ b/test/ios/scrollview-mutations.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# iOS scrollview-mutations test: add/remove/reorder children inside a ScrollView.
+#
+# Tests the inner LinearLayout/StackView wrapper handling.
+# Cycles: [A,B,C] → [A,B,C,D] → [A,C,D] → [D,C,A]
+#
+# --autotest fires callbackId=0 (the Advance button) after 3s.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, SCROLLVIEW_MUTATIONS_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$SCROLLVIEW_MUTATIONS_APP" "scrollview-mutations" --autotest
+wait_for_render "scrollview-mutations" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for SV1
+wait_for_log "$STREAM_LOG" "ScrollView state: SV1" 30 || true
+sleep 5
+
+collect_logs "scrollview-mutations"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "ScrollView state: SV0" "Initial state is SV0"
+assert_log "$FULL_LOG" "ScrollView state: SV1" "Advanced to SV1"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/scrollview-mutations.sh
+++ b/test/watchos/scrollview-mutations.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# watchOS scrollview-mutations test: add/remove/reorder children inside a ScrollView.
+#
+# Tests the inner LinearLayout/StackView wrapper handling.
+# Cycles: [A,B,C] → [A,B,C,D] → [A,C,D] → [D,C,A]
+#
+# --autotest fires callbackId=0 (the Advance button) after 3s.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, LOG_SUBSYSTEM, SCROLLVIEW_MUTATIONS_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$SCROLLVIEW_MUTATIONS_APP" "scrollview-mutations" --autotest
+wait_for_render "scrollview-mutations" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for SV1
+wait_for_log "$STREAM_LOG" "ScrollView state: SV1" 30 || true
+sleep 5
+
+collect_logs "scrollview-mutations"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "ScrollView state: SV0" "Initial state is SV0"
+assert_log "$FULL_LOG" "ScrollView state: SV1" "Advanced to SV1"
+
+cleanup_app
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Adds Phase 18 emulator test: add/remove/reorder children inside a ScrollView
- Cycles through 4 states testing add, middle removal, and reorder
- Tests the inner LinearLayout wrapper redirection in `android_add_child`/`android_remove_child`
- Verifies no orphaned views remain after mutations

## What this tests

ScrollView has special handling: both Android and iOS wrap children in an inner container (LinearLayout / UIStackView). The `addChild` and `removeChild` callbacks redirect to this inner container via `getChildAt(0)`. This test exercises all mutation paths:
- **Add**: new child added to inner layout
- **Middle removal**: inner layout removeChild on correct view
- **Reorder**: full remove-all + re-add-all through inner layout

## Test plan

- [ ] Phase 18 on Android emulator — verify correct children at each state
- [ ] All other phases remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)