### PR TITLE
test: reproducer for Animated child type change

### DIFF
--- a/hatter.cabal
+++ b/hatter.cabal
@@ -149,6 +149,16 @@ executable scrollview-switch-demo
       hatter,
       text
 
+executable animated-type-change-demo
+  import: common-options
+  main-is: AnimatedTypeChangeDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
 executable stack-demo
   import: common-options
   main-is: StackDemoMain.hs

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -295,6 +295,17 @@ let
     name = "hatter-scrollview-switch-apk";
   };
 
+  animatedTypeChangeAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/AnimatedTypeChangeDemoMain.hs;
+  };
+  animatedTypeChangeApk = lib.mkApk {
+    sharedLibs = [{ lib = animatedTypeChangeAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-animated-type-change.apk";
+    name = "hatter-animated-type-change-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -357,6 +368,7 @@ FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
+ANIMATED_TYPE_CHANGE_APK="${animatedTypeChangeApk}/hatter-animated-type-change.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -389,7 +401,8 @@ for so_path in \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
-    "${stackAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${stackAndroid}/lib/${abiDir}/libhatter.so" \
+    "${animatedTypeChangeAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -459,6 +472,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -575,7 +589,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK ANIMATED_TYPE_CHANGE_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -594,6 +608,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -682,6 +697,8 @@ echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/android/stack.sh" || PHASE16_EXIT=1
 echo "--- scrollview-switch ---"
 run_with_retry "scrollview-switch" bash "$TEST_SCRIPTS/android/scrollview-switch.sh" || PHASE17_EXIT=1
+echo "--- animated-type-change ---"
+run_with_retry "animated-type-change" bash "$TEST_SCRIPTS/android/animated-type-change.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -852,6 +869,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -978,6 +1005,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — ScrollView switch (issue #168 reproducer)"
 else
     echo "FAIL  Phase 17 — ScrollView switch (issue #168 reproducer)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Animated child type change"
+else
+    echo "FAIL  Phase 18 — Animated child type change"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -263,6 +263,17 @@ let
     name = "hatter-stack-simulator-app";
   };
 
+  animatedTypeChangeIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/AnimatedTypeChangeDemoMain.hs;
+    simulator = true;
+  };
+  animatedTypeChangeSimApp = lib.mkSimulatorApp {
+    iosLib = animatedTypeChangeIos;
+    iosSrc = ../ios;
+    name = "hatter-animated-type-change-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -305,6 +316,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 STACK_SHARE_DIR="${stackSimApp}/share/ios"
+ANIMATED_TYPE_CHANGE_SHARE_DIR="${animatedTypeChangeSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -328,6 +340,7 @@ PHASE13_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE17_OK=0
 
 cleanup() {
     echo ""
@@ -370,7 +383,8 @@ for share_dir in \
     "$HTTP_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$ANIMATED_TYPE_CHANGE_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1387,6 +1401,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building Animated Type Change app ==="
+cp -r "$ANIMATED_TYPE_CHANGE_SHARE_DIR" "$WORK_DIR/animated-type-change-proj"
+chmod -R u+w "$WORK_DIR/animated-type-change-proj"
+cd "$WORK_DIR/animated-type-change-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/animated-type-change-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+ANIMATED_TYPE_CHANGE_APP=$(find "$WORK_DIR/animated-type-change-build" -name "*.app" -type d | head -1)
+if [ -z "$ANIMATED_TYPE_CHANGE_APP" ]; then
+    echo "ERROR: Could not find animated-type-change .app bundle"
+    exit 1
+fi
+echo "Animated Type Change app: $ANIMATED_TYPE_CHANGE_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1448,7 +1486,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP ANIMATED_TYPE_CHANGE_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1466,6 +1504,7 @@ PHASE13_EXIT=0
 PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
+PHASE17_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1550,6 +1589,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/ios/textinput_rerender.sh" || PHASE15_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/ios/stack.sh" || PHASE16_EXIT=1
+echo "--- animated-type-change ---"
+run_with_retry "animated-type-change" bash "$TEST_SCRIPTS/ios/animated-type-change.sh" || PHASE17_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1710,6 +1751,16 @@ else
     echo "PHASE 16 FAILED"
 fi
 
+if [ $PHASE17_EXIT -eq 0 ]; then
+    PHASE17_OK=1
+    echo ""
+    echo "PHASE 17 PASSED"
+else
+    PHASE17_OK=0
+    echo ""
+    echo "PHASE 17 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1829,6 +1880,13 @@ if [ $PHASE16_OK -eq 1 ]; then
     echo "PASS  Phase 16 — Stack demo app"
 else
     echo "FAIL  Phase 16 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE17_OK -eq 1 ]; then
+    echo "PASS  Phase 17 — Animated type change reproducer"
+else
+    echo "FAIL  Phase 17 — Animated type change reproducer"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -242,6 +242,17 @@ let
     name = "hatter-watchos-stack-simulator-app";
   };
 
+  animatedTypeChangeWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/AnimatedTypeChangeDemoMain.hs;
+    simulator = true;
+  };
+  animatedTypeChangeSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = animatedTypeChangeWatchos;
+    watchosSrc = ../watchos;
+    name = "hatter-watchos-animated-type-change-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -282,6 +293,7 @@ ANIMATION_SHARE_DIR="${animationSimApp}/share/watchos"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/watchos"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/watchos"
 STACK_SHARE_DIR="${stackSimApp}/share/watchos"
+ANIMATED_TYPE_CHANGE_SHARE_DIR="${animatedTypeChangeSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -304,6 +316,7 @@ PHASE12_OK=0
 PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -344,7 +357,8 @@ for share_dir in \
     "$NETWORK_STATUS_SHARE_DIR" \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
-    "$STACK_SHARE_DIR"; do
+    "$STACK_SHARE_DIR" \
+    "$ANIMATED_TYPE_CHANGE_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1250,6 +1264,30 @@ if [ -z "$STACK_APP" ]; then
 fi
 echo "Stack app: $STACK_APP"
 
+echo "=== Building Animated Type Change app ==="
+cp -r "$ANIMATED_TYPE_CHANGE_SHARE_DIR" "$WORK_DIR/animated-type-change-proj"
+chmod -R u+w "$WORK_DIR/animated-type-change-proj"
+cd "$WORK_DIR/animated-type-change-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/animated-type-change-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+ANIMATED_TYPE_CHANGE_APP=$(find "$WORK_DIR/animated-type-change-build" -name "*.app" -type d | head -1)
+if [ -z "$ANIMATED_TYPE_CHANGE_APP" ]; then
+    echo "ERROR: Could not find animated-type-change .app bundle"
+    exit 1
+fi
+echo "Animated Type Change app: $ANIMATED_TYPE_CHANGE_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1313,7 +1351,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.hatter"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP ANIMATED_TYPE_CHANGE_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1332,6 +1370,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1405,6 +1444,8 @@ echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/watchos/textinput_rerender.sh" || PHASE16_EXIT=1
 echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/watchos/stack.sh" || PHASE17_EXIT=1
+echo "--- animated-type-change ---"
+run_with_retry "animated-type-change" bash "$TEST_SCRIPTS/watchos/animated-type-change.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1575,6 +1616,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1701,6 +1752,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — Stack demo app"
 else
     echo "FAIL  Phase 17 — Stack demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Animated type change reproducer"
+else
+    echo "FAIL  Phase 18 — Animated type change reproducer"
     FINAL_EXIT=1
 fi
 

--- a/test/AnimatedTypeChangeDemoMain.hs
+++ b/test/AnimatedTypeChangeDemoMain.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Reproducer: changing widget type inside an Animated wrapper.
+--
+-- When an Animated wraps a child that changes widget type
+-- (e.g. Text→Button), the diff algorithm destroys the old node
+-- and creates a new one. The Animated config is preserved in the
+-- RenderedAnimated wrapper, but we need to verify the new child
+-- actually renders correctly on the native platform.
+--
+-- State0: Animated (Text "ANIM_TEXT")
+-- State1: Animated (Button "ANIM_BUTTON")
+--
+-- Verifies the new widget is visible and the old one is gone.
+module Main where
+
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
+import Data.Text qualified as Text
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), AnimatedConfig(..), Easing(..))
+
+data Screen = ScreenA | ScreenB
+  deriving (Show, Eq)
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "AnimatedTypeChange demo registered"
+  actionState <- newActionState
+  screenState <- newIORef ScreenA
+  switchAction <- runActionM actionState $
+    createAction (modifyIORef' screenState toggle)
+  noopAction <- runActionM actionState $
+    createAction (pure ())
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> animatedTypeChangeView screenState switchAction noopAction
+    , maActionState = actionState
+    }
+
+toggle :: Screen -> Screen
+toggle ScreenA = ScreenB
+toggle ScreenB = ScreenA
+
+animConfig :: AnimatedConfig
+animConfig = AnimatedConfig
+  { anDuration = 300
+  , anEasing   = EaseInOut
+  }
+
+animatedTypeChangeView :: IORef Screen -> Action -> Action -> IO Widget
+animatedTypeChangeView screenState switchAction noopAction = do
+  screen <- readIORef screenState
+  platformLog ("Animated screen: " <> Text.pack (show screen))
+  let animChild = case screen of
+        ScreenA -> Animated animConfig
+          (Text TextConfig
+            { tcLabel = "ANIM_TEXT"
+            , tcFontConfig = Nothing
+            })
+        ScreenB -> Animated animConfig
+          (Button ButtonConfig
+            { bcLabel = "ANIM_BUTTON"
+            , bcAction = noopAction
+            , bcFontConfig = Nothing
+            })
+  pure $ Column
+    [ Button ButtonConfig
+        { bcLabel = "Switch animated"
+        , bcAction = switchAction
+        , bcFontConfig = Nothing
+        }
+    , animChild
+    ]

--- a/test/android/animated-type-change.sh
+++ b/test/android/animated-type-change.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Android animated-type-change test: widget type change inside Animated wrapper.
+#
+# Tests that when an Animated wrapper's child changes type (Text→Button),
+# the new native node is correctly created and the old one is destroyed.
+#
+# State0: Animated(Text "ANIM_TEXT")
+# State1: Animated(Button "ANIM_BUTTON")
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, ANIMATED_TYPE_CHANGE_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$ANIMATED_TYPE_CHANGE_APK" "animated-type-change"
+wait_for_render "animated-type-change"
+sleep 5
+collect_logcat "atc-initial"
+
+assert_logcat "$LOGCAT_FILE" "Animated screen: ScreenA" "Initial screen is ScreenA"
+
+# Verify ANIM_TEXT visible
+DUMP_A="$WORK_DIR/atc_a.xml"
+dump_ok=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP_A" 2>/dev/null
+        dump_ok=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok -eq 1 ]; then
+    if grep -q 'ANIM_TEXT' "$DUMP_A" 2>/dev/null; then
+        echo "PASS: ANIM_TEXT visible on ScreenA"
+    else
+        echo "FAIL: ANIM_TEXT not visible on ScreenA"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (ScreenA)"
+    EXIT_CODE=1
+fi
+
+# === Switch to ScreenB ===
+echo "=== Tapping Switch animated ==="
+tap_button "Switch animated" || "$ADB" -s "$EMULATOR_SERIAL" shell input tap 540 100
+sleep 5
+collect_logcat "atc-after"
+
+assert_logcat "$LOGCAT_FILE" "Animated screen: ScreenB" "Switched to ScreenB"
+
+DUMP_B="$WORK_DIR/atc_b.xml"
+dump_ok_b=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$DUMP_B" 2>/dev/null
+        dump_ok_b=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $dump_ok_b -eq 1 ]; then
+    echo "=== Post-switch hierarchy ==="
+    cat "$DUMP_B"
+    echo ""
+
+    # ANIM_BUTTON must be visible
+    if grep -q 'ANIM_BUTTON' "$DUMP_B" 2>/dev/null; then
+        echo "PASS: ANIM_BUTTON visible on ScreenB"
+    else
+        echo "FAIL: ANIM_BUTTON not visible on ScreenB"
+        EXIT_CODE=1
+    fi
+
+    # ANIM_TEXT must be gone
+    if grep -q 'ANIM_TEXT' "$DUMP_B" 2>/dev/null; then
+        echo "FAIL: ANIM_TEXT still visible after switch (orphaned view)"
+        EXIT_CODE=1
+    else
+        echo "PASS: ANIM_TEXT removed after switch"
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (ScreenB)"
+    EXIT_CODE=1
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/animated-type-change.sh
+++ b/test/ios/animated-type-change.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# iOS animated-type-change test: widget type change inside Animated wrapper.
+#
+# Tests that when an Animated wrapper's child changes type (Text→Button),
+# the new native node is correctly created and the old one is destroyed.
+#
+# State0: Animated(Text "ANIM_TEXT")
+# State1: Animated(Button "ANIM_BUTTON")
+#
+# --autotest fires callbackId=0 (the Switch animated button) after 3s.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, ANIMATED_TYPE_CHANGE_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$ANIMATED_TYPE_CHANGE_APP" "animated-type-change" --autotest
+wait_for_render "animated-type-change" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for ScreenB
+wait_for_log "$STREAM_LOG" "Animated screen: ScreenB" 30 || true
+sleep 5
+
+collect_logs "animated-type-change"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "Animated screen: ScreenA" "Initial screen is ScreenA"
+assert_log "$FULL_LOG" "Animated screen: ScreenB" "Switched to ScreenB"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/animated-type-change.sh
+++ b/test/watchos/animated-type-change.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# watchOS animated-type-change test: widget type change inside Animated wrapper.
+#
+# Tests that when an Animated wrapper's child changes type (Text→Button),
+# the new native node is correctly created and the old one is destroyed.
+#
+# State0: Animated(Text "ANIM_TEXT")
+# State1: Animated(Button "ANIM_BUTTON")
+#
+# --autotest fires callbackId=0 (the Switch animated button) after 3s.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, LOG_SUBSYSTEM, ANIMATED_TYPE_CHANGE_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$ANIMATED_TYPE_CHANGE_APP" "animated-type-change" --autotest
+wait_for_render "animated-type-change" --autotest
+
+# --autotest fires onUIEvent(0) at +3s — wait for ScreenB
+wait_for_log "$STREAM_LOG" "Animated screen: ScreenB" 30 || true
+sleep 5
+
+collect_logs "animated-type-change"
+
+assert_log "$FULL_LOG" "setRoot" "setRoot called"
+assert_log "$FULL_LOG" "Animated screen: ScreenA" "Initial screen is ScreenA"
+assert_log "$FULL_LOG" "Animated screen: ScreenB" "Switched to ScreenB"
+
+cleanup_app
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Adds Phase 18 emulator test: widget type change inside an Animated wrapper
- Switches between `Animated(Text "ANIM_TEXT")` and `Animated(Button "ANIM_BUTTON")`
- Verifies the new widget renders and the old one is removed

## What this tests

In `Render.hs:328-343`, the Animated diff path:
```haskell
if sameNodeType oldChildWidget newChild
  then do ... -- keep node, register tween
  else do
    destroyRenderedSubtree oldChildNode
    newChildNode <- createRenderedNode animState newChild
    pure (RenderedAnimated (Animated newConfig newChild) newChildNode)
```

When the child type differs, the old node is destroyed and a new one created. This test verifies the lifecycle works correctly end-to-end on the native platform.

## Test plan

- [ ] Phase 18 on Android emulator — verify ANIM_BUTTON visible after switch, ANIM_TEXT gone
- [ ] All other phases remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)