### PR TITLE
ci: remove GitHub Actions nix store cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,12 +27,6 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
-    - name: Nix store cache
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-build-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
-        restore-prefixes-first-match: nix-build-
-        gc-max-store-size-linux: 8G
     - name: Build all nix targets (excludes emulator/simulator runners)
       run: nix-build nix/ci.nix -A all-builds
     - name: Cancel workflow on failure
@@ -57,12 +51,6 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
-    - name: Nix store cache
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-android-aarch64-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
-        restore-prefixes-first-match: nix-android-aarch64-
-        gc-max-store-size-linux: 8G
     - name: Run combined emulator test (lifecycle + UI + buttons + scroll)
       run: nix-build nix/ci.nix -A emulator-all -o result-emulator-all && ./result-emulator-all/bin/test-all
     - name: Cancel workflow on failure
@@ -88,12 +76,6 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
-    - name: Nix store cache
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-android-armv7a-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
-        restore-prefixes-first-match: nix-android-armv7a-
-        gc-max-store-size-linux: 8G
     - name: Run armv7a emulator test
       run: nix-build nix/ci.nix -A emulator-armv7a -o result-emulator-armv7a && ./result-emulator-armv7a/bin/test-all
     - name: Cancel workflow on failure
@@ -114,12 +96,6 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
-    - name: Nix store cache
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-ios-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
-        restore-prefixes-first-match: nix-ios-
-        gc-max-store-size-macos: 8G
     - run: nix-build nix/ci.nix -A simulator-all -A ios-lib
     - name: Run combined simulator test (lifecycle + UI + buttons + scroll)
       run: nix-build nix/ci.nix -A simulator-all -o result-simulator-all && ./result-simulator-all/bin/test-all-ios
@@ -140,14 +116,6 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
-    - name: Nix store cache
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-watchos-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
-        restore-prefixes-first-match: |
-          nix-watchos-
-          nix-ios-
-        gc-max-store-size-macos: 8G
     - run: nix-build nix/ci.nix -A watchos-simulator-all -A watchos-lib
     - name: Run combined watchOS simulator test
       run: nix-build nix/ci.nix -A watchos-simulator-all -o result-watchos && ./result-watchos/bin/test-all-watchos


### PR DESCRIPTION
## Summary

- Remove `nix-community/cache-nix-action@v7` from all 5 CI jobs

The GitHub Actions nix store cache was counterproductive:
- The nix store grows to ~27 GB per job, but `gc-max-store-size` is 8 GB
- GC deletes critical derivations before every cache save
- Cache keys change on every commit, so prefix-match restores an incomplete store
- Result: cache miss on every single run — all 344 store paths are re-downloaded from `nix-cache.jappie.me` regardless

Removing the cache eliminates ~2 min of wasted cache restore/save/GC overhead per job. Builds will rely solely on the binary cache at `nix-cache.jappie.me`, which was already serving all paths anyway.

## Test plan

- [ ] Verify all 5 CI jobs still pass (they download everything from the binary cache as before)
- [ ] Confirm no regression in total CI wall time

🤖 Generated with [Claude Code](https://claude.com/claude-code)