### PR TITLE
Merge ScrollView into Column/Row via LayoutSettings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,7 @@ main = do
     { maContext     = loggingMobileContext
     , maView        = \_userState -> do
         n <- readIORef counter
-        pure $ Column
+        pure $ column
           [ text $ "Count: " <> Text.pack (show n)
           , button "+" increment
           ]

--- a/cbits/ui_bridge_android.c
+++ b/cbits/ui_bridge_android.c
@@ -61,6 +61,7 @@ static jclass   g_class_Button;
 static jclass   g_class_EditText;
 static jclass   g_class_LinearLayout;
 static jclass   g_class_ScrollView;
+static jclass   g_class_HorizontalScrollView;
 static jclass   g_class_ImageView;
 static jclass   g_class_WebView;
 static jclass   g_class_FrameLayout;
@@ -75,6 +76,7 @@ static jmethodID g_ctor_Button;
 static jmethodID g_ctor_EditText;
 static jmethodID g_ctor_LinearLayout;
 static jmethodID g_ctor_ScrollView;
+static jmethodID g_ctor_HorizontalScrollView;
 static jmethodID g_ctor_ImageView;
 static jmethodID g_ctor_WebView;
 static jmethodID g_ctor_FrameLayout;
@@ -171,6 +173,10 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     if (!cls) return -1;
     g_class_ScrollView = (*env)->NewGlobalRef(env, cls);
 
+    cls = (*env)->FindClass(env, "android/widget/HorizontalScrollView");
+    if (!cls) return -1;
+    g_class_HorizontalScrollView = (*env)->NewGlobalRef(env, cls);
+
     cls = (*env)->FindClass(env, "android/widget/ImageView");
     if (!cls) return -1;
     g_class_ImageView = (*env)->NewGlobalRef(env, cls);
@@ -213,6 +219,8 @@ static int resolve_jni_ids(JNIEnv *env, jobject activity)
     g_ctor_LinearLayout = (*env)->GetMethodID(env, g_class_LinearLayout,
         "<init>", "(Landroid/content/Context;)V");
     g_ctor_ScrollView = (*env)->GetMethodID(env, g_class_ScrollView,
+        "<init>", "(Landroid/content/Context;)V");
+    g_ctor_HorizontalScrollView = (*env)->GetMethodID(env, g_class_HorizontalScrollView,
         "<init>", "(Landroid/content/Context;)V");
     g_ctor_ImageView = (*env)->GetMethodID(env, g_class_ImageView,
         "<init>", "(Landroid/content/Context;)V");
@@ -518,6 +526,20 @@ static int32_t android_create_node(int32_t nodeType)
         /* Stack: children overlap in z-order (first at bottom, last on top).
          * FrameLayout is already cached from MapView placeholder. */
         view = (*env)->NewObject(env, g_class_FrameLayout, g_ctor_FrameLayout, g_activity);
+        break;
+    }
+    case UI_NODE_HORIZONTAL_SCROLL_VIEW: {
+        view = (*env)->NewObject(env, g_class_HorizontalScrollView,
+            g_ctor_HorizontalScrollView, g_activity);
+        /* HorizontalScrollView only accepts one direct child.
+         * Create an inner horizontal LinearLayout so that multiple
+         * Haskell children can be added via addChild(). */
+        jobject innerLayout = (*env)->NewObject(env, g_class_LinearLayout,
+            g_ctor_LinearLayout, g_activity);
+        (*env)->CallVoidMethod(env, innerLayout, g_method_setOrientation,
+            ORIENTATION_HORIZONTAL);
+        (*env)->CallVoidMethod(env, view, g_method_addView, innerLayout);
+        (*env)->DeleteLocalRef(env, innerLayout);
         break;
     }
     default:
@@ -893,10 +915,11 @@ static void android_add_child(int32_t parentId, int32_t childId)
     jobject child  = get_node(childId);
     if (!parent || !child) return;
 
-    /* Android ScrollView only accepts one direct child.
-     * Redirect to the inner LinearLayout wrapper (child 0)
+    /* Android ScrollView / HorizontalScrollView only accept one direct
+     * child.  Redirect to the inner LinearLayout wrapper (child 0)
      * that was created in android_create_node. */
-    if ((*env)->IsInstanceOf(env, parent, g_class_ScrollView)) {
+    if ((*env)->IsInstanceOf(env, parent, g_class_ScrollView) ||
+        (*env)->IsInstanceOf(env, parent, g_class_HorizontalScrollView)) {
         jobject innerLayout = (*env)->CallObjectMethod(env, parent,
             g_method_getChildAt, (jint)0);
         if (innerLayout) {
@@ -916,8 +939,9 @@ static void android_remove_child(int32_t parentId, int32_t childId)
     jobject child  = get_node(childId);
     if (!parent || !child) return;
 
-    /* ScrollView: redirect to inner LinearLayout wrapper. */
-    if ((*env)->IsInstanceOf(env, parent, g_class_ScrollView)) {
+    /* ScrollView / HorizontalScrollView: redirect to inner LinearLayout wrapper. */
+    if ((*env)->IsInstanceOf(env, parent, g_class_ScrollView) ||
+        (*env)->IsInstanceOf(env, parent, g_class_HorizontalScrollView)) {
         jobject innerLayout = (*env)->CallObjectMethod(env, parent,
             g_method_getChildAt, (jint)0);
         if (innerLayout) {

--- a/hatter.cabal
+++ b/hatter.cabal
@@ -169,6 +169,16 @@ executable stack-demo
       hatter,
       text
 
+executable horizontal-scroll-demo
+  import: common-options
+  main-is: HorizontalScrollDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
 test-suite unit
   import: common-options
   type: exitcode-stdio-1.0

--- a/include/UIBridge.h
+++ b/include/UIBridge.h
@@ -14,6 +14,7 @@
 #define UI_NODE_MAP_VIEW    7
 #define UI_NODE_WEBVIEW     8
 #define UI_NODE_STACK       9
+#define UI_NODE_HORIZONTAL_SCROLL_VIEW 10
 
 /* Property IDs for string properties */
 #define UI_PROP_TEXT            0

--- a/ios/Hatter/UIBridgeIOS.m
+++ b/ios/Hatter/UIBridgeIOS.m
@@ -359,6 +359,31 @@ static int32_t ios_create_node(int32_t nodeType)
         LOGI("createNode(type=%d) -> %d", nodeType, nodeId);
         return nodeId;
     }
+    case UI_NODE_HORIZONTAL_SCROLL_VIEW: {
+        UIScrollView *scrollView = [[UIScrollView alloc] init];
+        scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+        /* Inner horizontal content stack */
+        UIStackView *contentStack = [[UIStackView alloc] init];
+        contentStack.axis = UILayoutConstraintAxisHorizontal;
+        contentStack.alignment = UIStackViewAlignmentFill;
+        contentStack.spacing = 0;
+        contentStack.translatesAutoresizingMaskIntoConstraints = NO;
+        [scrollView addSubview:contentStack];
+        UILayoutGuide *contentGuide = scrollView.contentLayoutGuide;
+        UILayoutGuide *frameGuide   = scrollView.frameLayoutGuide;
+        [NSLayoutConstraint activateConstraints:@[
+            [contentStack.topAnchor     constraintEqualToAnchor:contentGuide.topAnchor],
+            [contentStack.leadingAnchor constraintEqualToAnchor:contentGuide.leadingAnchor],
+            [contentStack.trailingAnchor constraintEqualToAnchor:contentGuide.trailingAnchor],
+            [contentStack.bottomAnchor  constraintEqualToAnchor:contentGuide.bottomAnchor],
+            [contentStack.heightAnchor  constraintEqualToAnchor:frameGuide.heightAnchor],
+        ]];
+        int32_t nodeId = g_next_node_id++;
+        g_nodes[nodeId]        = scrollView;
+        g_content_views[nodeId] = contentStack;
+        LOGI("createNode(type=%d) -> %d", nodeType, nodeId);
+        return nodeId;
+    }
     default:
         LOGE("Unknown node type: %d", nodeType);
         return 0;

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -306,6 +306,17 @@ let
     name = "hatter-styled-type-change-apk";
   };
 
+  horizontalScrollAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/HorizontalScrollDemoMain.hs;
+  };
+  horizontalScrollApk = lib.mkApk {
+    sharedLibs = [{ lib = horizontalScrollAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-horizontal-scroll.apk";
+    name = "hatter-horizontal-scroll-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -369,6 +380,7 @@ TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
 STYLED_TYPE_CHANGE_APK="${styledTypeChangeApk}/hatter-styled-type-change.apk"
+HORIZONTAL_SCROLL_APK="${horizontalScrollApk}/hatter-horizontal-scroll.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -402,7 +414,8 @@ for so_path in \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
     "${stackAndroid}/lib/${abiDir}/libhatter.so" \
-    "${styledTypeChangeAndroid}/lib/${abiDir}/libhatter.so"; do
+    "${styledTypeChangeAndroid}/lib/${abiDir}/libhatter.so" \
+    "${horizontalScrollAndroid}/lib/${abiDir}/libhatter.so"; do
     SO_BYTES=$(stat -c %s "$so_path")
     SO_MB=$((SO_BYTES / 1048576))
     SO_LABEL=$(echo "$so_path" | grep -oP '[^/]+(?=/lib/)')
@@ -473,6 +486,7 @@ PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
 PHASE18_OK=0
+PHASE19_OK=0
 
 cleanup() {
     echo ""
@@ -589,7 +603,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -609,6 +623,7 @@ PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
 PHASE18_EXIT=0
+PHASE19_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -699,6 +714,8 @@ echo "--- scrollview-switch ---"
 run_with_retry "scrollview-switch" bash "$TEST_SCRIPTS/android/scrollview-switch.sh" || PHASE17_EXIT=1
 echo "--- styled-type-change ---"
 run_with_retry "styled-type-change" bash "$TEST_SCRIPTS/android/styled-type-change.sh" || PHASE18_EXIT=1
+echo "--- horizontal-scroll ---"
+run_with_retry "horizontal-scroll" bash "$TEST_SCRIPTS/android/horizontal-scroll.sh" || PHASE19_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -879,6 +896,16 @@ else
     echo "PHASE 18 FAILED"
 fi
 
+if [ $PHASE19_EXIT -eq 0 ]; then
+    PHASE19_OK=1
+    echo ""
+    echo "PHASE 19 PASSED"
+else
+    PHASE19_OK=0
+    echo ""
+    echo "PHASE 19 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1012,6 +1039,13 @@ if [ $PHASE18_OK -eq 1 ]; then
     echo "PASS  Phase 18 — Styled + child type change (same style)"
 else
     echo "FAIL  Phase 18 — Styled + child type change (same style)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE19_OK -eq 1 ]; then
+    echo "PASS  Phase 19 — Horizontal scroll demo app"
+else
+    echo "FAIL  Phase 19 — Horizontal scroll demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -274,6 +274,17 @@ let
     name = "hatter-styled-type-change-simulator-app";
   };
 
+  horizontalScrollIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/HorizontalScrollDemoMain.hs;
+    simulator = true;
+  };
+  horizontalScrollSimApp = lib.mkSimulatorApp {
+    iosLib = horizontalScrollIos;
+    iosSrc = ../ios;
+    name = "hatter-horizontal-scroll-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -317,6 +328,7 @@ FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 STACK_SHARE_DIR="${stackSimApp}/share/ios"
 STYLED_TYPE_CHANGE_SHARE_DIR="${styledTypeChangeSimApp}/share/ios"
+HORIZONTAL_SCROLL_SHARE_DIR="${horizontalScrollSimApp}/share/ios"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -341,6 +353,7 @@ PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
 PHASE17_OK=0
+PHASE18_OK=0
 
 cleanup() {
     echo ""
@@ -384,7 +397,8 @@ for share_dir in \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
     "$STACK_SHARE_DIR" \
-    "$STYLED_TYPE_CHANGE_SHARE_DIR"; do
+    "$STYLED_TYPE_CHANGE_SHARE_DIR" \
+    "$HORIZONTAL_SCROLL_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1425,6 +1439,30 @@ if [ -z "$STYLED_TYPE_CHANGE_APP" ]; then
 fi
 echo "Styled Type Change app: $STYLED_TYPE_CHANGE_APP"
 
+echo "=== Building Horizontal Scroll app ==="
+cp -r "$HORIZONTAL_SCROLL_SHARE_DIR" "$WORK_DIR/horizontal-scroll-proj"
+chmod -R u+w "$WORK_DIR/horizontal-scroll-proj"
+cd "$WORK_DIR/horizontal-scroll-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/horizontal-scroll-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+HORIZONTAL_SCROLL_APP=$(find "$WORK_DIR/horizontal-scroll-build" -name "*.app" -type d | head -1)
+if [ -z "$HORIZONTAL_SCROLL_APP" ]; then
+    echo "ERROR: Could not find horizontal-scroll .app bundle"
+    exit 1
+fi
+echo "Horizontal Scroll app: $HORIZONTAL_SCROLL_APP"
+
 # --- Discover latest iOS runtime ---
 echo "=== Discovering iOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1486,7 +1524,7 @@ sleep 5
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP STYLED_TYPE_CHANGE_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP STYLED_TYPE_CHANGE_APP HORIZONTAL_SCROLL_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1505,6 +1543,7 @@ PHASE14_EXIT=0
 PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
+PHASE18_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1591,6 +1630,8 @@ echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/ios/stack.sh" || PHASE16_EXIT=1
 echo "--- styled-type-change ---"
 run_with_retry "styled-type-change" bash "$TEST_SCRIPTS/ios/styled-type-change.sh" || PHASE17_EXIT=1
+echo "--- horizontal-scroll ---"
+run_with_retry "horizontal-scroll" bash "$TEST_SCRIPTS/ios/horizontal-scroll.sh" || PHASE18_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1761,6 +1802,16 @@ else
     echo "PHASE 17 FAILED"
 fi
 
+if [ $PHASE18_EXIT -eq 0 ]; then
+    PHASE18_OK=1
+    echo ""
+    echo "PHASE 18 PASSED"
+else
+    PHASE18_OK=0
+    echo ""
+    echo "PHASE 18 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1887,6 +1938,13 @@ if [ $PHASE17_OK -eq 1 ]; then
     echo "PASS  Phase 17 — Styled type change reproducer"
 else
     echo "FAIL  Phase 17 — Styled type change reproducer"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE18_OK -eq 1 ]; then
+    echo "PASS  Phase 18 — Horizontal scroll demo app"
+else
+    echo "FAIL  Phase 18 — Horizontal scroll demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -253,6 +253,17 @@ let
     name = "hatter-watchos-styled-type-change-simulator-app";
   };
 
+  horizontalScrollWatchos = import ./watchos.nix {
+    inherit sources;
+    mainModule = ../test/HorizontalScrollDemoMain.hs;
+    simulator = true;
+  };
+  horizontalScrollSimApp = lib.mkWatchOSSimulatorApp {
+    watchosLib = horizontalScrollWatchos;
+    watchosSrc = ../watchos;
+    name = "hatter-watchos-horizontal-scroll-simulator-app";
+  };
+
   xcodegen = pkgs.xcodegen;
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
@@ -294,6 +305,7 @@ FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/watchos"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/watchos"
 STACK_SHARE_DIR="${stackSimApp}/share/watchos"
 STYLED_TYPE_CHANGE_SHARE_DIR="${styledTypeChangeSimApp}/share/watchos"
+HORIZONTAL_SCROLL_SHARE_DIR="${horizontalScrollSimApp}/share/watchos"
 TEST_SCRIPTS="${testScripts}"
 
 # --- Temp working directory ---
@@ -317,6 +329,7 @@ PHASE14_OK=0
 PHASE15_OK=0
 PHASE16_OK=0
 PHASE18_OK=0
+PHASE19_OK=0
 
 cleanup() {
     echo ""
@@ -358,7 +371,8 @@ for share_dir in \
     "$MAPVIEW_SHARE_DIR" \
     "$TEXTINPUT_RERENDER_SHARE_DIR" \
     "$STACK_SHARE_DIR" \
-    "$STYLED_TYPE_CHANGE_SHARE_DIR"; do
+    "$STYLED_TYPE_CHANGE_SHARE_DIR" \
+    "$HORIZONTAL_SCROLL_SHARE_DIR"; do
     a_path="$share_dir/lib/libHatter.a"
     A_BYTES=$(stat -f %z "$a_path" 2>/dev/null || stat -c %s "$a_path" 2>/dev/null || echo 0)
     A_MB=$((A_BYTES / 1048576))
@@ -1288,6 +1302,30 @@ if [ -z "$STYLED_TYPE_CHANGE_APP" ]; then
 fi
 echo "Styled Type Change app: $STYLED_TYPE_CHANGE_APP"
 
+echo "=== Building Horizontal Scroll app ==="
+cp -r "$HORIZONTAL_SCROLL_SHARE_DIR" "$WORK_DIR/horizontal-scroll-proj"
+chmod -R u+w "$WORK_DIR/horizontal-scroll-proj"
+cd "$WORK_DIR/horizontal-scroll-proj"
+${xcodegen}/bin/xcodegen generate
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk watchsimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/horizontal-scroll-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+HORIZONTAL_SCROLL_APP=$(find "$WORK_DIR/horizontal-scroll-build" -name "*.app" -type d | head -1)
+if [ -z "$HORIZONTAL_SCROLL_APP" ]; then
+    echo "ERROR: Could not find horizontal-scroll .app bundle"
+    exit 1
+fi
+echo "Horizontal Scroll app: $HORIZONTAL_SCROLL_APP"
+
 # --- Discover latest watchOS runtime ---
 echo "=== Discovering watchOS runtime ==="
 RUNTIME=$(xcrun simctl list runtimes -j \
@@ -1351,7 +1389,7 @@ sleep 5
 # ===========================================================================
 # Log subsystem differs from bundle ID for watchOS (bundle ID has .watchkitapp suffix)
 LOG_SUBSYSTEM="me.jappie.hatter"
-export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP STYLED_TYPE_CHANGE_APP WORK_DIR
+export SIM_UDID BUNDLE_ID LOG_SUBSYSTEM COUNTER_APP SCROLL_APP TEXTINPUT_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP STYLED_TYPE_CHANGE_APP HORIZONTAL_SCROLL_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1371,6 +1409,7 @@ PHASE15_EXIT=0
 PHASE16_EXIT=0
 PHASE17_EXIT=0
 PHASE18_EXIT=0
+PHASE19_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1446,6 +1485,8 @@ echo "--- stack ---"
 run_with_retry "stack" bash "$TEST_SCRIPTS/watchos/stack.sh" || PHASE17_EXIT=1
 echo "--- styled-type-change ---"
 run_with_retry "styled-type-change" bash "$TEST_SCRIPTS/watchos/styled-type-change.sh" || PHASE18_EXIT=1
+echo "--- horizontal-scroll ---"
+run_with_retry "horizontal-scroll" bash "$TEST_SCRIPTS/watchos/horizontal-scroll.sh" || PHASE19_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1626,6 +1667,16 @@ else
     echo "PHASE 18 FAILED"
 fi
 
+if [ $PHASE19_EXIT -eq 0 ]; then
+    PHASE19_OK=1
+    echo ""
+    echo "PHASE 19 PASSED"
+else
+    PHASE19_OK=0
+    echo ""
+    echo "PHASE 19 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1759,6 +1810,13 @@ if [ $PHASE18_OK -eq 1 ]; then
     echo "PASS  Phase 18 — Styled type change reproducer"
 else
     echo "FAIL  Phase 18 — Styled type change reproducer"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE19_OK -eq 1 ]; then
+    echo "PASS  Phase 19 — Horizontal scroll demo app"
+else
+    echo "FAIL  Phase 19 — Horizontal scroll demo app"
     FINAL_EXIT=1
 fi
 

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -60,6 +60,7 @@ module Hatter
   , FontConfig(..)
   , TextInputConfig(..)
   , InputType(..)
+  , LayoutSettings(..)
   , ImageConfig(..)
   , ImageSource(..)
   , ResourceName(..)
@@ -72,6 +73,8 @@ module Hatter
   , colorToHex
     -- ** Smart constructors
   , button
+  , column
+  , row
   , text
     -- * Actions
   , Action(..)
@@ -159,6 +162,7 @@ import Hatter.Widget
   , ImageConfig(..)
   , ImageSource(..)
   , InputType(..)
+  , LayoutSettings(..)
   , MapViewConfig(..)
   , ResourceName(..)
   , ScaleType(..)
@@ -171,7 +175,9 @@ import Hatter.Widget
   , button
   , colorFromText
   , colorToHex
+  , column
   , defaultStyle
+  , row
   , text
   )
 
@@ -245,7 +251,7 @@ renderView ctxPtr = do
 -- The dismiss button uses a pre-registered 'Action' handle whose
 -- closure is populated by the exception handler.
 errorWidget :: Action -> SomeException -> Widget
-errorWidget dismissAction exc = Column
+errorWidget dismissAction exc = column
   [ Text TextConfig
       { tcLabel      = "An error occurred"
       , tcFontConfig = Just (FontConfig 20.0)

--- a/src/Hatter/Render.hs
+++ b/src/Hatter/Render.hs
@@ -26,7 +26,7 @@ import Data.Int (Int32)
 import Data.Text (Text, pack)
 import Hatter.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
 import Hatter.Animation (AnimationState, registerTween)
-import Hatter.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex, normalizeAnimated)
+import Hatter.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), LayoutSettings(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex, normalizeAnimated)
 import Hatter.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
 
@@ -41,7 +41,7 @@ data RenderedNode
       Widget         -- ^ Widget value for equality comparison.
       Int32          -- ^ Native node ID from the platform bridge.
   | RenderedContainer
-      Widget         -- ^ Widget value (Column/Row/ScrollView with children).
+      Widget         -- ^ Widget value (Column/Row/Stack with children).
       Int32          -- ^ Native node ID.
       [RenderedNode] -- ^ Rendered children.
   | RenderedStyled
@@ -176,29 +176,27 @@ createRenderedNode _animState widget@(TextInput config) = do
   when (tiAutoFocus config) $
     Bridge.setNumProp nodeId Bridge.PropAutoFocus 1.0
   pure (RenderedLeaf widget nodeId)
-createRenderedNode animState widget@(Column children) = do
-  nodeId <- Bridge.createNode Bridge.NodeColumn
+createRenderedNode animState widget@(Column settings) = do
+  let nodeType = if lsScrollable settings
+        then Bridge.NodeScrollView
+        else Bridge.NodeColumn
+  nodeId <- Bridge.createNode nodeType
   childNodes <- mapM (\child -> do
     childNode <- createRenderedNode animState child
     Bridge.addChild nodeId (renderedNodeId childNode)
     pure childNode
-    ) children
+    ) (lsWidgets settings)
   pure (RenderedContainer widget nodeId childNodes)
-createRenderedNode animState widget@(Row children) = do
-  nodeId <- Bridge.createNode Bridge.NodeRow
+createRenderedNode animState widget@(Row settings) = do
+  let nodeType = if lsScrollable settings
+        then Bridge.NodeHorizontalScrollView
+        else Bridge.NodeRow
+  nodeId <- Bridge.createNode nodeType
   childNodes <- mapM (\child -> do
     childNode <- createRenderedNode animState child
     Bridge.addChild nodeId (renderedNodeId childNode)
     pure childNode
-    ) children
-  pure (RenderedContainer widget nodeId childNodes)
-createRenderedNode animState widget@(ScrollView children) = do
-  nodeId <- Bridge.createNode Bridge.NodeScrollView
-  childNodes <- mapM (\child -> do
-    childNode <- createRenderedNode animState child
-    Bridge.addChild nodeId (renderedNodeId childNode)
-    pure childNode
-    ) children
+    ) (lsWidgets settings)
   pure (RenderedContainer widget nodeId childNodes)
 createRenderedNode animState widget@(Stack children) = do
   nodeId <- Bridge.createNode Bridge.NodeStack
@@ -246,7 +244,6 @@ createRenderedNode animState (Animated config child) = do
     -- (each child is now individually wrapped in Animated).
     Column _     -> createRenderedNode animState normalized
     Row _        -> createRenderedNode animState normalized
-    ScrollView _ -> createRenderedNode animState normalized
     Stack _      -> createRenderedNode animState normalized
     -- Everything else (Styled, leaves): wrap in RenderedAnimated for tween interpolation.
     _            -> do
@@ -280,9 +277,8 @@ sameNodeType :: Widget -> Widget -> Bool
 sameNodeType (Text _)        (Text _)        = True
 sameNodeType (Button _)      (Button _)      = True
 sameNodeType (TextInput _)   (TextInput _)   = True
-sameNodeType (Column _)      (Column _)      = True
-sameNodeType (Row _)         (Row _)         = True
-sameNodeType (ScrollView _)  (ScrollView _)  = True
+sameNodeType (Column a)      (Column b)      = lsScrollable a == lsScrollable b
+sameNodeType (Row a)         (Row b)         = lsScrollable a == lsScrollable b
 sameNodeType (Stack _)       (Stack _)       = True
 sameNodeType (Image _)       (Image _)       = True
 sameNodeType (WebView _)     (WebView _)     = True
@@ -315,8 +311,6 @@ diffRenderNode _animState (Just oldNode) newWidget
 diffRenderNode animState maybeOld (Animated config child@(Column _)) =
   diffRenderNode animState maybeOld (normalizeAnimated config child)
 diffRenderNode animState maybeOld (Animated config child@(Row _)) =
-  diffRenderNode animState maybeOld (normalizeAnimated config child)
-diffRenderNode animState maybeOld (Animated config child@(ScrollView _)) =
   diffRenderNode animState maybeOld (normalizeAnimated config child)
 diffRenderNode animState maybeOld (Animated config child@(Stack _)) =
   diffRenderNode animState maybeOld (normalizeAnimated config child)
@@ -355,9 +349,8 @@ diffRenderNode animState (Just (RenderedStyled _ oldStyle oldChild)) (Styled new
 diffRenderNode animState (Just oldNode@(RenderedContainer _ containerNodeId oldChildren)) newWidget
   | sameNodeType (renderedWidget oldNode) newWidget =
     case newWidget of
-      Column newChildren     -> diffContainer animState containerNodeId oldChildren newChildren newWidget
-      Row newChildren        -> diffContainer animState containerNodeId oldChildren newChildren newWidget
-      ScrollView newChildren -> diffContainer animState containerNodeId oldChildren newChildren newWidget
+      Column settings        -> diffContainer animState containerNodeId oldChildren (lsWidgets settings) newWidget
+      Row settings           -> diffContainer animState containerNodeId oldChildren (lsWidgets settings) newWidget
       Stack newChildren      -> diffContainer animState containerNodeId oldChildren newChildren newWidget
       -- Non-container but same type at container level shouldn't happen,
       -- but fall through to destroy+create for safety.

--- a/src/Hatter/UIBridge.hs
+++ b/src/Hatter/UIBridge.hs
@@ -44,6 +44,7 @@ data NodeType
   | NodeMapView
   | NodeWebView
   | NodeStack
+  | NodeHorizontalScrollView
   deriving (Show, Eq, Enum, Bounded)
 
 -- | Map a 'NodeType' to its C integer code.
@@ -58,6 +59,7 @@ nodeTypeToInt NodeImage      = 6
 nodeTypeToInt NodeMapView    = 7
 nodeTypeToInt NodeWebView    = 8
 nodeTypeToInt NodeStack      = 9
+nodeTypeToInt NodeHorizontalScrollView = 10
 
 -- | Property identifiers for 'setStrProp' and 'setNumProp'.
 data PropId

--- a/src/Hatter/Widget.hs
+++ b/src/Hatter/Widget.hs
@@ -13,6 +13,7 @@ module Hatter.Widget
   (
     Widget(..)
   -- ** configs
+  , LayoutSettings(..)
   , WidgetStyle(..)
   , defaultStyle
   , ButtonConfig(..)
@@ -39,6 +40,8 @@ module Hatter.Widget
   , lerpWord8
   -- ** smart constructors
   , button
+  , column
+  , row
   , text
   )
 where
@@ -195,8 +198,8 @@ data Easing
 
 -- | Configuration for an 'Animated' widget wrapper.
 --
--- When 'Animated' wraps a container ('Column', 'Row', 'ScrollView'), the
--- config is distributed to each child:
+-- When 'Animated' wraps a container ('Column', 'Row'), the config is
+-- distributed to each child:
 --
 -- @
 -- Animated cfg (Column [a, b, c])  =  Column [Animated cfg a, Animated cfg b, Animated cfg c]
@@ -240,8 +243,7 @@ interpolateColor (Color r1 g1 b1 a1) (Color r2 g2 b2 a2) progress = Color
 
 -- | Normalize an 'Animated' wrapper before rendering.
 --
--- * Distributes 'Animated' over container children ('Column', 'Row',
---   'ScrollView').
+-- * Distributes 'Animated' over container children ('Column', 'Row').
 -- * Collapses nested 'Animated' — inner config wins.
 -- * All other widgets ('Styled', leaves) are returned unchanged;
 --   the render engine wraps them in @RenderedAnimated@ for tween
@@ -251,12 +253,10 @@ normalizeAnimated :: AnimatedConfig -> Widget -> Widget
 normalizeAnimated _outerConfig (Animated innerConfig child) =
   Animated innerConfig (normalizeAnimated innerConfig child)
 -- Distribute over containers.
-normalizeAnimated config (Column children) =
-  Column (map (Animated config) children)
-normalizeAnimated config (Row children) =
-  Row (map (Animated config) children)
-normalizeAnimated config (ScrollView children) =
-  ScrollView (map (Animated config) children)
+normalizeAnimated config (Column settings) =
+  Column settings { lsWidgets = map (Animated config) (lsWidgets settings) }
+normalizeAnimated config (Row settings) =
+  Row settings { lsWidgets = map (Animated config) (lsWidgets settings) }
 normalizeAnimated config (Stack children) =
   Stack (map (Animated config) children)
 -- Everything else (Styled, leaves): return unchanged.
@@ -317,11 +317,30 @@ data MapViewConfig = MapViewConfig
     -- Receives @\"lat,lon,zoom\"@ text encoding the new center and zoom.
   } deriving (Show, Eq)
 
+-- | Layout settings for container widgets ('Column', 'Row').
+--
+-- When 'lsScrollable' is 'True', the container renders as a native
+-- scroll view (vertical for 'Column', horizontal for 'Row').
+data LayoutSettings = LayoutSettings
+  { lsWidgets    :: [Widget]
+    -- ^ Child widgets inside the container.
+  , lsScrollable :: Bool
+    -- ^ Whether the container should be scrollable.
+  } deriving (Show, Eq)
+
 text :: Text -> Widget
 text txt = Text $ TextConfig { tcLabel =  txt, tcFontConfig = Nothing }
 
 button :: Text -> Action -> Widget
 button txt action = Button $ ButtonConfig { bcLabel = txt, bcAction = action, bcFontConfig = Nothing }
+
+-- | Build a non-scrollable vertical container.
+column :: [Widget] -> Widget
+column widgets = Column LayoutSettings { lsWidgets = widgets, lsScrollable = False }
+
+-- | Build a non-scrollable horizontal container.
+row :: [Widget] -> Widget
+row widgets = Row LayoutSettings { lsWidgets = widgets, lsScrollable = False }
 
 -- | A declarative description of a UI element.
 --
@@ -338,12 +357,12 @@ data Widget
     -- ^ A tappable button with a label and click handler.
   | TextInput TextInputConfig
     -- ^ A text input field.
-  | Column [Widget]
+  | Column LayoutSettings
     -- ^ A vertical container laying out children top-to-bottom.
-  | Row [Widget]
+    -- When @'lsScrollable' = 'True'@, renders as a vertically scrollable container.
+  | Row LayoutSettings
     -- ^ A horizontal container laying out children left-to-right.
-  | ScrollView [Widget]
-    -- ^ A vertically scrollable container.
+    -- When @'lsScrollable' = 'True'@, renders as a horizontally scrollable container.
   | Stack [Widget]
     -- ^ A z-order container: children overlap, first at bottom, last on top.
     -- Maps to FrameLayout (Android), plain UIView (iOS), ZStack (watchOS).
@@ -357,8 +376,7 @@ data Widget
     -- ^ Apply visual style overrides to a child widget.
   | Animated AnimatedConfig Widget
     -- ^ Animate property changes on the child widget over a duration.
-    -- When wrapping a container ('Column', 'Row', 'ScrollView'), the
-    -- animation is distributed to each child.  Nested 'Animated'
-    -- wrappers collapse: the innermost config wins.
-    -- See 'AnimatedConfig' for details.
+    -- When wrapping a container ('Column', 'Row'), the animation is
+    -- distributed to each child.  Nested 'Animated' wrappers collapse:
+    -- the innermost config wins.  See 'AnimatedConfig' for details.
   deriving (Show, Eq)

--- a/test/AnimationDemoMain.hs
+++ b/test/AnimationDemoMain.hs
@@ -29,6 +29,7 @@ import Hatter.Widget
   , ButtonConfig(..)
   , WidgetStyle(..)
   , defaultStyle
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -43,7 +44,7 @@ main = do
   let viewFn :: UserState -> IO Widget
       viewFn _userState = do
         currentPadding <- readIORef paddingRef
-        pure $ Column
+        pure $ column
           [ Animated (AnimatedConfig 500 EaseInOut) $
               Styled (defaultStyle { wsPadding = Just currentPadding }) $
                 Text TextConfig

--- a/test/AuthSessionDemoMain.hs
+++ b/test/AuthSessionDemoMain.hs
@@ -23,6 +23,7 @@ import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
   , Widget(..)
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -55,7 +56,7 @@ main = do
 
 -- | Builds a Column with a label and a "Start Login" button.
 authSessionDemoView :: Action -> IO Widget
-authSessionDemoView onStartLogin = pure $ Column
+authSessionDemoView onStartLogin = pure $ column
   [ Text TextConfig { tcLabel = "AuthSession Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel      = "Start Login"

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -24,7 +24,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Ble (BleState(..), checkBleAdapter, startBleScan, stopBleScan)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -56,7 +56,7 @@ main = do
 
 -- | Builds a Column with a label, adapter check button, and scan buttons.
 bleDemoView :: Action -> Action -> Action -> IO Widget
-bleDemoView onCheckAdapter onStartScan onStopScan = pure $ Column
+bleDemoView onCheckAdapter onStartScan onStopScan = pure $ column
   [ Text TextConfig { tcLabel = "BLE Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel = "Check Adapter", bcAction = onCheckAdapter, bcFontConfig = Nothing }

--- a/test/BottomSheetDemoMain.hs
+++ b/test/BottomSheetDemoMain.hs
@@ -20,7 +20,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.BottomSheet (BottomSheetConfig(..), BottomSheetState(..), showBottomSheet)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -47,7 +47,7 @@ main = do
 
 -- | Builds a Column with a label and a "Show Actions" button.
 bottomSheetDemoView :: Action -> IO Widget
-bottomSheetDemoView onShowActions = pure $ Column
+bottomSheetDemoView onShowActions = pure $ column
   [ Text TextConfig { tcLabel = "BottomSheet Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel      = "Show Actions"

--- a/test/CameraDemoMain.hs
+++ b/test/CameraDemoMain.hs
@@ -27,6 +27,7 @@ import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
   , Widget(..)
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -62,7 +63,7 @@ main = do
 
 -- | Builds a Column with a label and a "Capture Photo" button.
 cameraDemoView :: Action -> IO Widget
-cameraDemoView onCapturePhoto = pure $ Column
+cameraDemoView onCapturePhoto = pure $ column
   [ Text TextConfig { tcLabel = "Camera Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel      = "Capture Photo"

--- a/test/CounterDemoMain.hs
+++ b/test/CounterDemoMain.hs
@@ -10,7 +10,7 @@ import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
 import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
 import Hatter.AppContext (AppContext)
-import Hatter.Widget (ButtonConfig(..), Color(..), FontConfig(..), TextAlignment(..), TextConfig(..), Widget(..), WidgetStyle(..))
+import Hatter.Widget (ButtonConfig(..), Color(..), FontConfig(..), TextAlignment(..), TextConfig(..), Widget(..), WidgetStyle(..), column, row)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -31,13 +31,13 @@ main = do
 counterView :: IORef Int -> Action -> Action -> IO Widget
 counterView counterState onIncrement onDecrement = do
   n <- readIORef counterState
-  pure $ Column
+  pure $ column
     [ Styled (WidgetStyle (Just 16.0) (Just AlignCenter) (Just (Color 255 0 0 255)) (Just (Color 0 255 0 255)) Nothing Nothing Nothing)
         (Text TextConfig
           { tcLabel      = "Counter: " <> Text.pack (show n)
           , tcFontConfig = Just (FontConfig 24.0)
           })
-    , Row [ Button ButtonConfig
+    , row [ Button ButtonConfig
               { bcLabel = "+", bcAction = onIncrement, bcFontConfig = Nothing }
           , Button ButtonConfig
               { bcLabel = "-", bcAction = onDecrement, bcFontConfig = Nothing }

--- a/test/DialogDemoMain.hs
+++ b/test/DialogDemoMain.hs
@@ -20,7 +20,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Dialog (DialogAction(..), DialogConfig(..), DialogState(..), showDialog)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -65,7 +65,7 @@ main = do
 
 -- | Builds a Column with a label, a "Show Alert" button, and a "Show Confirm" button.
 dialogDemoView :: Action -> Action -> IO Widget
-dialogDemoView onShowAlert onShowConfirm = pure $ Column
+dialogDemoView onShowAlert onShowConfirm = pure $ column
   [ Text TextConfig { tcLabel = "Dialog Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel      = "Show Alert"

--- a/test/FilesDirDemoMain.hs
+++ b/test/FilesDirDemoMain.hs
@@ -20,7 +20,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext)
 import Hatter.FilesDir (getAppFilesDir)
-import Hatter.Widget (TextConfig(..), Widget(..))
+import Hatter.Widget (TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -58,7 +58,7 @@ main = do
 filesDirDemoView :: IO Widget
 filesDirDemoView = do
   filesDir <- getAppFilesDir
-  pure $ Column
+  pure $ column
     [ Text TextConfig { tcLabel = "FilesDir Demo", tcFontConfig = Nothing }
     , Text TextConfig { tcLabel = pack filesDir, tcFontConfig = Nothing }
     ]

--- a/test/HorizontalScrollDemoMain.hs
+++ b/test/HorizontalScrollDemoMain.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Mobile entry point for the horizontal-scroll-demo test app.
+--
+-- Used by the emulator and simulator integration tests.
+-- Displays a scrollable Row containing 20 buttons.
+-- Tapping the last button logs "Click dispatched".
+module Main where
+
+import Data.Text qualified as Text
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (ButtonConfig(..), LayoutSettings(..), Widget(..), button)
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "Horizontal scroll demo app registered"
+  actionState <- newActionState
+  (noopAction, onReachedEnd) <- runActionM actionState $ do
+    noop <- createAction (pure ())
+    reachedEnd <- createAction (pure ())
+    pure (noop, reachedEnd)
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> horizontalScrollDemoView noopAction onReachedEnd
+    , maActionState = actionState
+    }
+
+-- | Builds a scrollable Row containing 20 buttons followed by a "Reached End" button.
+horizontalScrollDemoView :: Action -> Action -> IO Widget
+horizontalScrollDemoView noopAction onReachedEnd = pure $ Row (LayoutSettings
+  ( map (\itemNumber -> button ("Item " <> Text.pack (show (itemNumber :: Int))) noopAction) [1..20]
+  ++ [Button ButtonConfig
+      { bcLabel = "Reached End", bcAction = onReachedEnd, bcFontConfig = Nothing }]
+  ) True)

--- a/test/HttpDemoMain.hs
+++ b/test/HttpDemoMain.hs
@@ -26,6 +26,7 @@ import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
   , Widget(..)
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -64,7 +65,7 @@ main = do
 -- The button fires a GET request to http://localhost:8765/
 httpDemoView :: Action -> IO Widget
 httpDemoView onSendRequest = do
-  pure $ Column
+  pure $ column
     [ Text TextConfig { tcLabel = "HTTP Demo", tcFontConfig = Nothing }
     , Button ButtonConfig
         { bcLabel = "Send Request"

--- a/test/ImageDemoMain.hs
+++ b/test/ImageDemoMain.hs
@@ -9,7 +9,7 @@ import Data.ByteString qualified as BS
 import Foreign.Ptr (Ptr)
 import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
 import Hatter.AppContext (AppContext)
-import Hatter.Widget (ImageConfig(..), ImageSource(..), ResourceName(..), ScaleType(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ImageConfig(..), ImageSource(..), ResourceName(..), ScaleType(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -23,7 +23,7 @@ main = do
 
 -- | Builds a Column with a label and three Image widgets (resource, data, file).
 imageDemoView :: IO Widget
-imageDemoView = pure $ Column
+imageDemoView = pure $ column
   [ Text TextConfig { tcLabel = "Image Demo", tcFontConfig = Nothing }
   , Image ImageConfig
       { icSource    = ImageResource (ResourceName "ic_launcher")

--- a/test/LocationDemoMain.hs
+++ b/test/LocationDemoMain.hs
@@ -25,7 +25,7 @@ import Hatter
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Location (LocationState(..), startLocationUpdates, stopLocationUpdates)
 import Hatter.Location (LocationData(..))
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -57,7 +57,7 @@ main = do
 
 -- | Builds a Column with a label and start/stop location buttons.
 locationDemoView :: Action -> Action -> IO Widget
-locationDemoView onStartLocation onStopLocation = pure $ Column
+locationDemoView onStartLocation onStopLocation = pure $ column
   [ Text TextConfig { tcLabel = "Location Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel = "Start Location", bcAction = onStartLocation, bcFontConfig = Nothing }

--- a/test/MapViewDemoMain.hs
+++ b/test/MapViewDemoMain.hs
@@ -23,6 +23,7 @@ import Hatter.Widget
   ( MapViewConfig(..)
   , TextConfig(..)
   , Widget(..)
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -41,7 +42,7 @@ main = do
 -- | Builds a Column with a label and a MapView centered on Amsterdam.
 mapViewDemoView :: OnChange -> UserState -> IO Widget
 mapViewDemoView onRegionChange _userState =
-  pure $ Column
+  pure $ column
     [ Text TextConfig { tcLabel = "MapView Demo", tcFontConfig = Nothing }
     , MapView MapViewConfig
         { mvLatitude         = 52.3676

--- a/test/NetworkStatusDemoMain.hs
+++ b/test/NetworkStatusDemoMain.hs
@@ -25,7 +25,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.NetworkStatus (NetworkStatusState(..), NetworkStatus(..), NetworkTransport(..), startNetworkMonitoring, stopNetworkMonitoring)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -55,7 +55,7 @@ main = do
 
 -- | Builds a Column with a label and start/stop monitoring buttons.
 networkStatusDemoView :: Action -> Action -> IO Widget
-networkStatusDemoView onStartMonitoring onStopMonitoring = pure $ Column
+networkStatusDemoView onStartMonitoring onStopMonitoring = pure $ column
   [ Text TextConfig { tcLabel = "Network Status Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel = "Start Monitoring", bcAction = onStartMonitoring, bcFontConfig = Nothing }

--- a/test/NodePoolTestMain.hs
+++ b/test/NodePoolTestMain.hs
@@ -11,11 +11,11 @@ import Foreign.Ptr (Ptr)
 import Hatter (MobileApp(..), UserState(..), startMobileApp, newActionState)
 import Hatter.AppContext (AppContext)
 import Hatter.Lifecycle (loggingMobileContext)
-import Hatter.Widget (TextConfig(..), Widget(..))
+import Hatter.Widget (TextConfig(..), Widget(..), column)
 
 -- | Render 300 nodes: 1 Column parent + 299 Text children.
 nodePoolTestView :: UserState -> IO Widget
-nodePoolTestView _userState = pure $ Column $
+nodePoolTestView _userState = pure $ column $
   map (\itemNumber -> Text TextConfig
     { tcLabel = "Item " <> pack (show (itemNumber :: Int))
     , tcFontConfig = Nothing

--- a/test/PermissionDemoMain.hs
+++ b/test/PermissionDemoMain.hs
@@ -20,7 +20,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Permission (Permission(..), PermissionState(..), requestPermission)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -43,7 +43,7 @@ main = do
 
 -- | Builds a Column with a label and a "Request Camera" button.
 permissionDemoView :: Action -> IO Widget
-permissionDemoView onRequestCamera = pure $ Column
+permissionDemoView onRequestCamera = pure $ column
   [ Text TextConfig { tcLabel = "Permission Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel      = "Request Camera"

--- a/test/PlatformSignInDemoMain.hs
+++ b/test/PlatformSignInDemoMain.hs
@@ -30,6 +30,7 @@ import Hatter.Widget
   ( ButtonConfig(..)
   , TextConfig(..)
   , Widget(..)
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -72,7 +73,7 @@ main = do
 
 -- | Builds a Column with a label and two sign-in buttons.
 platformSignInDemoView :: Action -> Action -> IO Widget
-platformSignInDemoView onAppleSignIn onGoogleSignIn = pure $ Column
+platformSignInDemoView onAppleSignIn onGoogleSignIn = pure $ column
   [ Text TextConfig { tcLabel = "PlatformSignIn Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel      = "Sign in with Apple"

--- a/test/ScrollDemoMain.hs
+++ b/test/ScrollDemoMain.hs
@@ -9,7 +9,7 @@ import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
 import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
 import Hatter.AppContext (AppContext)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), LayoutSettings(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -23,13 +23,13 @@ main = do
     , maActionState = actionState
     }
 
--- | Builds a ScrollView containing 20 text items followed by a button.
+-- | Builds a scrollable Column containing 20 text items followed by a button.
 scrollDemoView :: Action -> IO Widget
-scrollDemoView onReachedBottom = pure $ ScrollView
-  [ Column
+scrollDemoView onReachedBottom = pure $ Column (LayoutSettings
+  [ column
     ( map (\itemNumber -> Text TextConfig
         { tcLabel = "Item " <> Text.pack (show (itemNumber :: Int)), tcFontConfig = Nothing }) [1..20]
     ++ [Button ButtonConfig
         { bcLabel = "Reached Bottom", bcAction = onReachedBottom, bcFontConfig = Nothing }]
     )
-  ]
+  ] True)

--- a/test/ScrollTextInputDemoMain.hs
+++ b/test/ScrollTextInputDemoMain.hs
@@ -14,8 +14,8 @@ import Hatter
   )
 import Hatter.AppContext (AppContext)
 import Hatter.Widget
-  ( ButtonConfig(..), InputType(..), TextConfig(..)
-  , TextInputConfig(..), Widget(..)
+  ( ButtonConfig(..), InputType(..), LayoutSettings(..), TextConfig(..)
+  , TextInputConfig(..), Widget(..), row
   )
 
 main :: IO (Ptr AppContext)
@@ -34,10 +34,10 @@ main = do
     , maActionState = actionState
     }
 
--- | ScrollView containing TextInput widgets — reproduces the
+-- | Scrollable Column containing TextInput widgets — reproduces the
 -- prrrrrrrrr layout that triggers DeadObjectException.
 scrollTextInputView :: Action -> Action -> OnChange -> OnChange -> IO Widget
-scrollTextInputView save back onWeight onNotes = pure $ ScrollView
+scrollTextInputView save back onWeight onNotes = pure $ Column (LayoutSettings
   [ Text TextConfig { tcLabel = "Enter data", tcFontConfig = Nothing }
   , TextInput TextInputConfig
       { tiInputType  = InputNumber
@@ -55,10 +55,10 @@ scrollTextInputView save back onWeight onNotes = pure $ ScrollView
       , tiFontConfig = Nothing
       , tiAutoFocus  = False
       }
-  , Row
+  , row
     [ Button ButtonConfig
         { bcLabel = "Save", bcAction = save, bcFontConfig = Nothing }
     , Button ButtonConfig
         { bcLabel = "Back", bcAction = back, bcFontConfig = Nothing }
     ]
-  ]
+  ] True)

--- a/test/ScrollViewSwitchDemoMain.hs
+++ b/test/ScrollViewSwitchDemoMain.hs
@@ -15,7 +15,7 @@ import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
 import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
 import Hatter.AppContext (AppContext)
-import Hatter.Widget (ButtonConfig(..), Widget(..), text)
+import Hatter.Widget (ButtonConfig(..), LayoutSettings(..), Widget(..), column, text)
 
 data Screen = ScreenA | ScreenB
   deriving (Show, Eq)
@@ -53,7 +53,7 @@ switchDemoView screenState switchAction noopAction = do
   screen <- readIORef screenState
   platformLog ("Current screen: " <> Text.pack (show screen))
   let inner = case screen of
-        ScreenA -> ScrollView
+        ScreenA -> Column (LayoutSettings
           [ Button ButtonConfig
               { bcLabel = "SCREENA_BTN"
               , bcAction = noopAction
@@ -61,16 +61,16 @@ switchDemoView screenState switchAction noopAction = do
               }
           , text "SCREENA_TXT1"
           , text "SCREENA_TXT2"
-          ]
-        ScreenB -> ScrollView
+          ] True)
+        ScreenB -> Column (LayoutSettings
           [ text "SCREENB_TXT1"
           , Button ButtonConfig
               { bcLabel = "SCREENB_BTN"
               , bcAction = noopAction
               , bcFontConfig = Nothing
               }
-          ]
-  pure $ Column
+          ] True)
+  pure $ column
     [ Button ButtonConfig
         { bcLabel = "Switch screen"
         , bcAction = switchAction

--- a/test/SecureStorageDemoMain.hs
+++ b/test/SecureStorageDemoMain.hs
@@ -20,7 +20,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.SecureStorage (SecureStorageState(..), secureStorageWrite, secureStorageRead)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..))
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -48,7 +48,7 @@ main = do
 
 -- | Builds a Column with a label, a "Store Token" button, and a "Read Token" button.
 secureStorageDemoView :: Action -> Action -> IO Widget
-secureStorageDemoView onStoreToken onReadToken = pure $ Column
+secureStorageDemoView onStoreToken onReadToken = pure $ column
   [ Text TextConfig { tcLabel = "SecureStorage Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel = "Store Token", bcAction = onStoreToken, bcFontConfig = Nothing }

--- a/test/StyledTypeChangeDemoMain.hs
+++ b/test/StyledTypeChangeDemoMain.hs
@@ -19,7 +19,7 @@ import Data.Word (Word8)
 import Foreign.Ptr (Ptr)
 import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createAction, Action)
 import Hatter.AppContext (AppContext)
-import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), WidgetStyle(..), Color(..), defaultStyle)
+import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), WidgetStyle(..), Color(..), column, defaultStyle)
 
 data Screen = ScreenA | ScreenB
   deriving (Show, Eq)
@@ -74,7 +74,7 @@ styledTypeChangeView screenState switchAction noopAction = do
             , bcAction = noopAction
             , bcFontConfig = Nothing
             })
-  pure $ Column
+  pure $ column
     [ Button ButtonConfig
         { bcLabel = "Switch screen"
         , bcAction = switchAction

--- a/test/Test/ActionTests.hs
+++ b/test/Test/ActionTests.hs
@@ -26,6 +26,7 @@ import Hatter.Widget
   , TextInputConfig(..)
   , Widget(..)
   , WidgetStyle(..)
+  , column
   )
 import Hatter.Render
   ( RenderState(..)
@@ -101,9 +102,9 @@ widgetEqTests = testGroup "WidgetEq"
       assertBool "different labels means different widgets" (widgetA /= widgetB)
 
   , testCase "Column equality is structural" $ do
-      let widgetA = Column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
-          widgetB = Column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
-          widgetC = Column [Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }]
+      let widgetA = column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
+          widgetB = column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
+          widgetC = column [Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }]
       widgetA @?= widgetB
       assertBool "different children means different Column" (widgetA /= widgetC)
   ]
@@ -146,7 +147,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
 
       , testCase "single child change updates in-place, preserving node IDs" $ do
           ((), rs) <- withActions (pure ())
-          let widget1 = Column
+          let widget1 = column
                 [ Text TextConfig { tcLabel = "stable", tcFontConfig = Nothing }
                 , Text TextConfig { tcLabel = "will change", tcFontConfig = Nothing }
                 ]
@@ -157,7 +158,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
               [c0, c1] -> pure (nodeIdOf c0, nodeIdOf c1)
               _        -> assertFailure "expected 2 children" >> pure (-1, -1)
             Nothing -> assertFailure "expected rendered tree" >> pure (-1, -1)
-          let widget2 = Column
+          let widget2 = column
                 [ Text TextConfig { tcLabel = "stable", tcFontConfig = Nothing }
                 , Text TextConfig { tcLabel = "changed!", tcFontConfig = Nothing }
                 ]
@@ -228,7 +229,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
 
       , testCase "adding a child to container" $ do
           ((), rs) <- withActions (pure ())
-          let widget1 = Column
+          let widget1 = column
                 [ Text TextConfig { tcLabel = "first", tcFontConfig = Nothing } ]
           renderWidget rs widget1
           tree1 <- readIORef (rsRenderedTree rs)
@@ -237,7 +238,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
               [c0] -> pure (nodeIdOf c0)
               _    -> assertFailure "expected 1 child" >> pure (-1)
             Nothing -> assertFailure "expected rendered tree" >> pure (-1)
-          let widget2 = Column
+          let widget2 = column
                 [ Text TextConfig { tcLabel = "first", tcFontConfig = Nothing }
                 , Text TextConfig { tcLabel = "second", tcFontConfig = Nothing }
                 ]
@@ -256,12 +257,12 @@ incrementalRenderTests = testGroup "Incremental rendering"
 
       , testCase "removing a child from container" $ do
           ((), rs) <- withActions (pure ())
-          let widget1 = Column
+          let widget1 = column
                 [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
                 , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
                 ]
           renderWidget rs widget1
-          let widget2 = Column
+          let widget2 = column
                 [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing } ]
           renderWidget rs widget2
           tree2 <- readIORef (rsRenderedTree rs)
@@ -402,7 +403,7 @@ incrementalRenderTests = testGroup "Incremental rendering"
       , testCase "TextInput inside Column preserves node on value change" $ do
           (changeHandle, rs) <- withActions $
             createOnChange (\_ -> pure ())
-          let mkWidget value = Column
+          let mkWidget value = column
                 [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
                 , TextInput TextInputConfig
                     { tiInputType = InputNumber, tiHint = "% of 1RM", tiValue = value

--- a/test/Test/AnimationTests.hs
+++ b/test/Test/AnimationTests.hs
@@ -27,9 +27,11 @@ import Hatter.Animation
 import Hatter.Render (RenderState(..), RenderedNode(..), newRenderState, renderWidget)
 import Hatter.Widget
   ( Color(..)
+  , LayoutSettings(..)
   , Widget(..)
   , WidgetStyle(..)
   , TextConfig(..)
+  , column
   , defaultStyle
   , interpolateColor
   , lerpWord8
@@ -222,7 +224,7 @@ animatedWidgetRenderTests = testGroup "Animated widget rendering"
       actionState <- newActionState
       rs <- newRenderState actionState animState
       let child1 = Text TextConfig { tcLabel = "text", tcFontConfig = Nothing }
-          child2 = Column []
+          child2 = column []
           widget1 = Animated (AnimatedConfig 300 EaseOut) child1
           widget2 = Animated (AnimatedConfig 300 EaseOut) child2
       renderWidget rs widget1
@@ -261,18 +263,18 @@ normalizeAnimatedTests = testGroup "normalizeAnimated"
       let cfg = AnimatedConfig 300 EaseOut
           childA = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
           childB = Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
-          result = normalizeAnimated cfg (Column [childA, childB])
-      result @?= Column [Animated cfg childA, Animated cfg childB]
+          result = normalizeAnimated cfg (Column (LayoutSettings [childA, childB] False))
+      result @?= Column (LayoutSettings [Animated cfg childA, Animated cfg childB] False)
   , testCase "Distributes over Row children" $ do
       let cfg = AnimatedConfig 300 EaseOut
           childA = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
-          result = normalizeAnimated cfg (Row [childA])
-      result @?= Row [Animated cfg childA]
-  , testCase "Distributes over ScrollView children" $ do
+          result = normalizeAnimated cfg (Row (LayoutSettings [childA] False))
+      result @?= Row (LayoutSettings [Animated cfg childA] False)
+  , testCase "Distributes over scrollable Column children" $ do
       let cfg = AnimatedConfig 300 EaseOut
           childA = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
-          result = normalizeAnimated cfg (ScrollView [childA])
-      result @?= ScrollView [Animated cfg childA]
+          result = normalizeAnimated cfg (Column (LayoutSettings [childA] True))
+      result @?= Column (LayoutSettings [Animated cfg childA] True)
   , testCase "Inner Animated wins over outer" $ do
       let outerCfg = AnimatedConfig 500 EaseOut
           innerCfg = AnimatedConfig 100 EaseIn
@@ -286,11 +288,11 @@ normalizeAnimatedTests = testGroup "normalizeAnimated"
           leaf = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
           explicitChild = Animated innerCfg leaf
           plainChild = Text TextConfig { tcLabel = "y", tcFontConfig = Nothing }
-          result = normalizeAnimated outerCfg (Column [explicitChild, plainChild])
+          result = normalizeAnimated outerCfg (Column (LayoutSettings [explicitChild, plainChild] False))
       -- Distribution wraps each child in outer Animated; the render engine
       -- then collapses the nested Animated (inner wins) during traversal.
-      result @?= Column [ Animated outerCfg (Animated innerCfg leaf)
-                         , Animated outerCfg plainChild ]
+      result @?= Column (LayoutSettings [ Animated outerCfg (Animated innerCfg leaf)
+                                        , Animated outerCfg plainChild ] False)
   , testCase "Styled returned unchanged" $ do
       let cfg = AnimatedConfig 300 EaseOut
           style = defaultStyle { wsPadding = Just 10 }
@@ -313,7 +315,7 @@ normalizeAnimatedTests = testGroup "normalizeAnimated"
                      Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
           childB = Styled (defaultStyle { wsPadding = Just 20 }) $
                      Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
-          widget = Animated cfg (Column [childA, childB])
+          widget = Animated cfg (column [childA, childB])
       renderWidget rs widget
       renderedTree <- readIORef (rsRenderedTree rs)
       case renderedTree of
@@ -337,8 +339,8 @@ normalizeAnimatedTests = testGroup "normalizeAnimated"
           style1 = defaultStyle { wsPadding = Just 10 }
           style2 = defaultStyle { wsPadding = Just 50 }
           child = Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
-          widget1 = Animated cfg (Column [Styled style1 child])
-          widget2 = Animated cfg (Column [Styled style2 child])
+          widget1 = Animated cfg (column [Styled style1 child])
+          widget2 = Animated cfg (column [Styled style2 child])
       renderWidget rs widget1
       Just tree1 <- readIORef (rsRenderedTree rs)
       let nodeId1 = renderedNodeIdSafe tree1

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -31,7 +31,7 @@ import Hatter.Lifecycle
   , loggingMobileContext
   )
 import Hatter.Animation (newAnimationState)
-import Hatter.Widget (TextConfig(..), Widget(..))
+import Hatter.Widget (LayoutSettings(..), TextConfig(..), Widget(..))
 import Hatter.Render (RenderState, newRenderState)
 
 -- | Helper: create an ActionState, register actions via ActionM, and
@@ -115,7 +115,7 @@ viewIsErrorWidget ctxPtr = do
         }
   widget <- viewFn userState
   case widget of
-    Column (Text config : _) -> pure (tcLabel config == "An error occurred")
+    Column (LayoutSettings (Text config : _) _) -> pure (tcLabel config == "An error occurred")
     Column _                 -> pure False
     Text _                   -> pure False
     Button _                 -> pure False
@@ -125,7 +125,6 @@ viewIsErrorWidget ctxPtr = do
     MapView _                -> pure False
     Row _                    -> pure False
     Stack _                  -> pure False
-    ScrollView _             -> pure False
     Styled _ _               -> pure False
     Animated _ _             -> pure False
 

--- a/test/Test/WidgetTests.hs
+++ b/test/Test/WidgetTests.hs
@@ -33,6 +33,7 @@ import Hatter.Widget
   , ImageConfig(..)
   , ImageSource(..)
   , InputType(..)
+  , LayoutSettings(..)
   , MapViewConfig(..)
   , ResourceName(..)
   , ScaleType(..)
@@ -44,9 +45,11 @@ import Hatter.Widget
   , WidgetStyle(..)
   , colorFromText
   , colorToHex
+  , column
   , defaultStyle
+  , row
   )
-import Hatter.Render (renderWidget, dispatchEvent, dispatchTextEvent)
+import Hatter.Render (RenderState(..), RenderedNode(..), renderWidget, dispatchEvent, dispatchTextEvent)
 import Hatter.Permission (newPermissionState)
 import Hatter.SecureStorage (newSecureStorageState)
 import Hatter.Ble (newBleState)
@@ -80,7 +83,7 @@ uiTests = testGroup "UI"
         hA <- createAction (modifyIORef' refA (const True))
         hB <- createAction (modifyIORef' refB (const True))
         pure (hA, hB)
-      let widget = Row
+      let widget = row
             [ Button ButtonConfig
                 { bcLabel = "A", bcAction = handleA, bcFontConfig = Nothing }
             , Button ButtonConfig
@@ -124,12 +127,12 @@ uiTests = testGroup "UI"
         hA <- createAction (pure ())
         hB <- createAction (pure ())
         pure (hA, hB)
-      let widget = Column
+      let widget = column
             [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
-            , Row
+            , row
               [ Button ButtonConfig
                   { bcLabel = "a", bcAction = handleA, bcFontConfig = Nothing }
-              , Column
+              , column
                 [ Text TextConfig { tcLabel = "nested", tcFontConfig = Nothing }
                 , Button ButtonConfig
                     { bcLabel = "b", bcAction = handleB, bcFontConfig = Nothing }
@@ -177,62 +180,84 @@ uiTests = testGroup "UI"
         WebView _       -> assertFailure "expected Text, got WebView"
         MapView _       -> assertFailure "expected Text, got MapView"
         Row _           -> assertFailure "expected Text, got Row"
-        ScrollView _    -> assertFailure "expected Text, got ScrollView"
         Stack _         -> assertFailure "expected Text, got Stack"
         Styled _ _      -> assertFailure "expected Text, got Styled"
         Animated _ _    -> assertFailure "expected Text, got Animated"
   ]
 
--- | Tests for the ScrollView widget binding.
+-- | Tests for scrollable Column (formerly ScrollView).
 -- These exercise the Haskell render path shared by both Android and iOS —
 -- the platform bridge (JNI / UIKit) receives UI_NODE_SCROLL_VIEW (5) and
 -- is responsible for mapping it to a native scroll container.
 scrollViewTests :: TestTree
 scrollViewTests = testGroup "ScrollView"
-  [ testCase "ScrollView renders without error" $ do
+  [ testCase "scrollable Column renders without error" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs (ScrollView
+      renderWidget rs (Column (LayoutSettings
         [ Text TextConfig { tcLabel = "item 1", tcFontConfig = Nothing }
         , Text TextConfig { tcLabel = "item 2", tcFontConfig = Nothing }
-        ])
+        ] True))
 
-  , testCase "button inside ScrollView fires its callback" $ do
+  , testCase "button inside scrollable Column fires its callback" $ do
       ref <- newIORef (0 :: Int)
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (+ 1))
-      renderWidget rs $ ScrollView
+      renderWidget rs $ Column (LayoutSettings
         [ Button ButtonConfig
             { bcLabel = "press me", bcAction = clickHandle, bcFontConfig = Nothing } ]
+        True)
       dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
 
-  , testCase "ScrollView with nested Column renders and dispatches correctly" $ do
+  , testCase "scrollable Column with nested Column renders and dispatches correctly" $ do
       ref <- newIORef False
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (const True))
-      renderWidget rs $ ScrollView
-        [ Column
+      renderWidget rs $ Column (LayoutSettings
+        [ column
           [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
           , Button ButtonConfig
               { bcLabel = "action", bcAction = clickHandle, bcFontConfig = Nothing }
           ]
-        ]
+        ] True)
       dispatchEvent rs (actionId clickHandle)
       fired <- readIORef ref
       fired @?= True
 
-  , testCase "re-render inside ScrollView preserves callbacks" $ do
+  , testCase "re-render inside scrollable Column preserves callbacks" $ do
       ref <- newIORef (0 :: Int)
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (+ 1))
-      renderWidget rs $ ScrollView [Button ButtonConfig
-        { bcLabel = "old", bcAction = clickHandle, bcFontConfig = Nothing }]
-      renderWidget rs $ ScrollView [Button ButtonConfig
-        { bcLabel = "new", bcAction = clickHandle, bcFontConfig = Nothing }]
+      renderWidget rs $ Column (LayoutSettings [Button ButtonConfig
+        { bcLabel = "old", bcAction = clickHandle, bcFontConfig = Nothing }] True)
+      renderWidget rs $ Column (LayoutSettings [Button ButtonConfig
+        { bcLabel = "new", bcAction = clickHandle, bcFontConfig = Nothing }] True)
       dispatchEvent rs (actionId clickHandle)
       count <- readIORef ref
       count @?= 1
+
+  , testCase "scrollable flag change recreates native node" $ do
+      ((), rs) <- withActions (pure ())
+      let nonScrollable = column [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }]
+      renderWidget rs nonScrollable
+      tree1 <- readIORef (rsRenderedTree rs)
+      let nodeId1 = case tree1 of
+            Just (RenderedContainer _ nid _) -> nid
+            Just (RenderedLeaf _ nid)        -> nid
+            Just (RenderedStyled _ _ _)      -> -1
+            Just (RenderedAnimated _ _)      -> -1
+            Nothing                          -> -1
+      let scrollable = Column (LayoutSettings [Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }] True)
+      renderWidget rs scrollable
+      tree2 <- readIORef (rsRenderedTree rs)
+      let nodeId2 = case tree2 of
+            Just (RenderedContainer _ nid _) -> nid
+            Just (RenderedLeaf _ nid)        -> nid
+            Just (RenderedStyled _ _ _)      -> -2
+            Just (RenderedAnimated _ _)      -> -2
+            Nothing                          -> -2
+      assertBool "node ID should change when scrollable changes" (nodeId1 /= nodeId2)
   ]
 
 -- | Tests for the Stack widget (z-order overlay container).
@@ -264,7 +289,7 @@ stackTests = testGroup "Stack"
         createAction (modifyIORef' ref (const True))
       renderWidget rs $ Stack
         [ Text TextConfig { tcLabel = "bg", tcFontConfig = Nothing }
-        , Column
+        , column
           [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
           , Button ButtonConfig
               { bcLabel = "action", bcAction = clickHandle, bcFontConfig = Nothing }
@@ -329,7 +354,7 @@ textInputTests = testGroup "TextInput"
         ch <- createAction (modifyIORef' clickRef (const True))
         th <- createOnChange (\t -> modifyIORef' textRef (const (show t)))
         pure (ch, th)
-      let widget = Column
+      let widget = column
             [ Button ButtonConfig
                 { bcLabel = "ok", bcAction = clickHandle, bcFontConfig = Nothing }
             , TextInput TextInputConfig
@@ -381,7 +406,7 @@ textInputTests = testGroup "TextInput"
         th <- createOnChange (\t -> modifyIORef' textRef (const (show t)))
         nh <- createOnChange (\t -> modifyIORef' numberRef (const (show t)))
         pure (th, nh)
-      let widget = Column
+      let widget = column
             [ TextInput TextInputConfig
                 { tiInputType = InputText, tiHint = "name", tiValue = ""
                 , tiOnChange = textHandle
@@ -421,7 +446,7 @@ imageTests = testGroup "Image"
 
   , testCase "Image inside Column renders" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Column
+      renderWidget rs $ column
         [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
         , Image ImageConfig
             { icSource = ImageResource (ResourceName "logo"), icScaleType = ScaleFit }
@@ -478,7 +503,7 @@ webViewTests = testGroup "WebView"
 
   , testCase "WebView inside Column renders" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Column
+      renderWidget rs $ column
         [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
         , WebView WebViewConfig
             { wvUrl = "https://example.com", wvOnPageLoad = Nothing }
@@ -516,7 +541,7 @@ styledTests = testGroup "Styled"
       (clickHandle, rs) <- withActions $
         createAction (modifyIORef' ref (const True))
       renderWidget rs $ Styled defaultStyle
-        (Column [ Text TextConfig { tcLabel = "info", tcFontConfig = Nothing }
+        (column [ Text TextConfig { tcLabel = "info", tcFontConfig = Nothing }
                 , Button ButtonConfig
                     { bcLabel = "go", bcAction = clickHandle, bcFontConfig = Nothing }
                 ])
@@ -675,7 +700,7 @@ mapViewTests = testGroup "MapView"
 
   , testCase "MapView inside Column renders" $ do
       ((), rs) <- withActions (pure ())
-      renderWidget rs $ Column
+      renderWidget rs $ column
         [ Text TextConfig { tcLabel = "header", tcFontConfig = Nothing }
         , MapView MapViewConfig
             { mvLatitude = 52.3676, mvLongitude = 4.9041

--- a/test/TextInputDemoMain.hs
+++ b/test/TextInputDemoMain.hs
@@ -8,7 +8,7 @@ module Main where
 import Foreign.Ptr (Ptr)
 import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState, runActionM, createOnChange, OnChange)
 import Hatter.AppContext (AppContext)
-import Hatter.Widget (InputType(..), TextConfig(..), TextInputConfig(..), Widget(..))
+import Hatter.Widget (InputType(..), TextConfig(..), TextInputConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
 main = do
@@ -26,7 +26,7 @@ main = do
 
 -- | Builds a Column with a label and two TextInputs of different InputType.
 textInputDemoView :: OnChange -> OnChange -> IO Widget
-textInputDemoView onWeightChange onNameChange = pure $ Column
+textInputDemoView onWeightChange onNameChange = pure $ column
   [ Text TextConfig { tcLabel = "TextInput Demo", tcFontConfig = Nothing }
   , TextInput TextInputConfig
       { tiInputType  = InputNumber

--- a/test/TextInputReRenderDemoMain.hs
+++ b/test/TextInputReRenderDemoMain.hs
@@ -16,7 +16,7 @@ import Hatter
   )
 import Hatter.AppContext (AppContext)
 import Hatter.Widget
-  ( InputType(..), TextConfig(..), TextInputConfig(..), Widget(..)
+  ( InputType(..), TextConfig(..), TextInputConfig(..), Widget(..), column
   )
 
 main :: IO (Ptr AppContext)
@@ -40,7 +40,7 @@ textInputReRenderView typedRef onChange = do
   typed <- readIORef typedRef
   let displayLabel = "Typed: " <> typed
   platformLog ("view rebuilt: " <> displayLabel)
-  pure $ Column
+  pure $ column
     [ TextInput TextInputConfig
         { tiInputType  = InputText
         , tiHint       = "type here"

--- a/test/WebViewDemoMain.hs
+++ b/test/WebViewDemoMain.hs
@@ -25,6 +25,7 @@ import Hatter.Widget
   , TextConfig(..)
   , WebViewConfig(..)
   , Widget(..)
+  , column
   )
 
 main :: IO (Ptr AppContext)
@@ -48,7 +49,7 @@ main = do
 webViewDemoView :: IORef String -> Action -> Action -> UserState -> IO Widget
 webViewDemoView urlRef onPageLoad onLoadExampleOrg _userState = do
   currentUrl <- readIORef urlRef
-  pure $ Column
+  pure $ column
     [ Text TextConfig { tcLabel = "WebView Demo", tcFontConfig = Nothing }
     , WebView WebViewConfig
         { wvUrl = pack currentUrl

--- a/test/android/horizontal-scroll.sh
+++ b/test/android/horizontal-scroll.sh
@@ -41,9 +41,12 @@ else
     EXIT_CODE=1
 fi
 
-# Swipe left to reveal Reached End button
+# Swipe left multiple times to reveal Reached End button (20 items to scroll past)
 echo "=== Swipe left to reveal Reached End ==="
-"$ADB" -s "$EMULATOR_SERIAL" shell input swipe 900 540 100 540
+for swipe_n in 1 2 3 4 5 6 7 8; do
+    "$ADB" -s "$EMULATOR_SERIAL" shell input swipe 900 540 100 540 300
+    sleep 1
+done
 sleep 3
 
 HSCROLL_DUMP2="$WORK_DIR/hscroll_ui2.xml"

--- a/test/android/horizontal-scroll.sh
+++ b/test/android/horizontal-scroll.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Android horizontal scroll test: install horizontal-scroll APK, assert HorizontalScrollView
+# renders, swipe left to reveal "Reached End" button, tap it.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, HORIZONTAL_SCROLL_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$HORIZONTAL_SCROLL_APK" "horizontal-scroll"
+wait_for_render "horizontal-scroll"
+sleep 5
+collect_logcat "horizontal-scroll"
+
+assert_logcat "$LOGCAT_FILE" "createNode.*type=10" "createNode(type=10) horizontal scroll view"
+
+# Verify HorizontalScrollView in view hierarchy
+HSCROLL_DUMP="$WORK_DIR/hscroll_ui.xml"
+hscroll_dump_ok=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$HSCROLL_DUMP" 2>/dev/null
+        hscroll_dump_ok=1
+        break
+    fi
+    echo "  uiautomator dump attempt $attempt failed, retrying in 5s..."
+    sleep 5
+done
+
+if [ $hscroll_dump_ok -eq 1 ]; then
+    if grep -q 'android.widget.HorizontalScrollView' "$HSCROLL_DUMP" 2>/dev/null; then
+        echo "PASS: android.widget.HorizontalScrollView in view hierarchy"
+    else
+        echo "FAIL: android.widget.HorizontalScrollView not in view hierarchy"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump horizontal scroll view hierarchy"
+    EXIT_CODE=1
+fi
+
+# Swipe left to reveal Reached End button
+echo "=== Swipe left to reveal Reached End ==="
+"$ADB" -s "$EMULATOR_SERIAL" shell input swipe 900 540 100 540
+sleep 3
+
+HSCROLL_DUMP2="$WORK_DIR/hscroll_ui2.xml"
+hscroll_dump2_ok=0
+for attempt in 1 2 3; do
+    if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+        "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$HSCROLL_DUMP2" 2>/dev/null
+        hscroll_dump2_ok=1
+        break
+    fi
+    echo "  uiautomator dump attempt $attempt failed, retrying in 5s..."
+    sleep 5
+done
+
+if [ $hscroll_dump2_ok -eq 1 ]; then
+    if grep -q 'Reached End' "$HSCROLL_DUMP2" 2>/dev/null; then
+        echo "PASS: Reached End visible after swipe"
+    else
+        echo "FAIL: Reached End not visible after swipe"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy after swipe"
+    EXIT_CODE=1
+fi
+
+# Tap Reached End button
+echo "=== Tap Reached End ==="
+tap_done=0
+if [ $hscroll_dump2_ok -eq 1 ]; then
+    tap_button "Reached End" && tap_done=1 || true
+fi
+if [ $tap_done -eq 0 ]; then
+    echo "Using fallback tap at (900, 540)"
+    "$ADB" -s "$EMULATOR_SERIAL" shell input tap 900 540
+fi
+sleep 5
+
+collect_logcat "horizontal-scroll"
+assert_logcat "$LOGCAT_FILE" "Click dispatched" "Click dispatched after Reached End tap"
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/horizontal-scroll.sh
+++ b/test/ios/horizontal-scroll.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# iOS horizontal scroll test: install horizontal-scroll app, launch with --autotest,
+# assert horizontal scroll view + click events.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, HORIZONTAL_SCROLL_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$HORIZONTAL_SCROLL_APP" "horizontal-scroll" --autotest
+wait_for_render "horizontal-scroll" --autotest
+
+# Auto-tap fires 3s after render; poll stream log until click appears or 30s timeout
+wait_for_log "$STREAM_LOG" "Click dispatched" 30 || true
+# Extra buffer so the persistent log store catches up before log show
+sleep 5
+
+collect_logs "horizontal-scroll"
+
+assert_log "$FULL_LOG" 'createNode\(type=10\)' "createNode(type=10)"
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+assert_log "$FULL_LOG" "Click dispatched: callbackId=0" "Click dispatched: callbackId=0"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/test/watchos/horizontal-scroll.sh
+++ b/test/watchos/horizontal-scroll.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# watchOS horizontal scroll test: install horizontal-scroll app, launch with --autotest,
+# assert horizontal scroll view + click events.
+#
+# Required env vars (set by watchos-simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, HORIZONTAL_SCROLL_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$HORIZONTAL_SCROLL_APP" "horizontal-scroll" --autotest
+wait_for_render "horizontal-scroll" --autotest
+
+# Auto-tap fires 3s after render; poll stream log until click appears or 30s timeout
+wait_for_log "$STREAM_LOG" "Click dispatched" 30 || true
+# Extra buffer so the persistent log store catches up before log show
+sleep 5
+
+collect_logs "horizontal-scroll"
+
+assert_log "$FULL_LOG" 'createNode\(type=10\)' "createNode(type=10)"
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+assert_log "$FULL_LOG" "Click dispatched: callbackId=0" "Click dispatched: callbackId=0"
+
+cleanup_app
+
+exit $EXIT_CODE

--- a/watchos/Hatter/ContentView.swift
+++ b/watchos/Hatter/ContentView.swift
@@ -75,6 +75,14 @@ struct NodeView: View {
                     NodeView(node: child)
                 }
             }
+        case 10: // UI_NODE_HORIZONTAL_SCROLL_VIEW
+            ScrollView(.horizontal) {
+                HStack {
+                    ForEach(node.children) { child in
+                        NodeView(node: child)
+                    }
+                }
+            }
         default:
             EmptyView()
         }


### PR DESCRIPTION
## Summary
- Replace `ScrollView [Widget]` with a shared `LayoutSettings` record on `Column` and `Row`, controlled by `lsScrollable :: Bool`
- Add `NodeHorizontalScrollView` (type 10) for scrollable `Row` on all native platforms (Android `HorizontalScrollView`, iOS horizontal `UIScrollView`, watchOS `ScrollView(.horizontal)`)
- Add smart constructors `column` and `row` for non-scrollable containers, update all 19 demo apps and test files
- Wire up horizontal-scroll-demo integration tests in nix harness (emulator-all, simulator-all, watchos-simulator-all)

## Test plan
- [x] `cabal build all` passes (no warnings)
- [x] `cabal test` passes (all 257+ tests including new scrollable flag change test)
- [ ] CI: nix-build passes
- [ ] CI: Android emulator integration tests pass (Phase 19 — horizontal scroll)
- [ ] CI: iOS simulator integration tests pass (Phase 18 — horizontal scroll)
- [ ] CI: watchOS simulator integration tests pass (Phase 19 — horizontal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)