### PR TITLE
Fix armv7a OOM when linking async package (issue #163)

### DIFF
--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -11,6 +11,7 @@
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>
+#include <android/log.h>
 #include "HsFFI.h"
 #include "JniBridge.h"
 #include "PermissionBridge.h"
@@ -25,6 +26,45 @@
 #include "NetworkStatusBridge.h"
 #include "AnimationBridge.h"
 #include "PlatformSignInBridge.h"
+
+/* Deduplicate registerForeignExports to prevent OOM on armv7a.
+ *
+ * When --whole-archive pulls in GHC boot libraries, duplicate .init_array
+ * entries can cause registerForeignExports to be called twice with the
+ * same ForeignExportsList struct.  The second call creates a self-referencing
+ * linked list (struct->next = &struct).  processForeignExports then loops
+ * infinitely, calling getStablePtr billions of times and doubling
+ * enlargeStablePtrTable until the 32-bit address space is exhausted.
+ *
+ * Linked via -Wl,--wrap=registerForeignExports (unconditional in lib.nix).
+ *
+ * See: https://github.com/jappeace/hatter/issues/163
+ */
+struct ForeignExportsList {
+    struct ForeignExportsList *next;
+    int n_entries;
+    void *exports[];
+};
+
+extern void __real_registerForeignExports(struct ForeignExportsList *exports);
+
+static struct ForeignExportsList *g_seen_fexports[64];
+static int g_seen_fexports_count = 0;
+
+void __wrap_registerForeignExports(struct ForeignExportsList *exports) {
+    for (int i = 0; i < g_seen_fexports_count; i++) {
+        if (g_seen_fexports[i] == exports) {
+            __android_log_print(ANDROID_LOG_WARN, "HatterInit",
+                "registerForeignExports: duplicate struct %p — skipping",
+                (void*)exports);
+            return;
+        }
+    }
+    if (g_seen_fexports_count < 64) {
+        g_seen_fexports[g_seen_fexports_count++] = exports;
+    }
+    __real_registerForeignExports(exports);
+}
 
 /* Runs the user's Haskell main via RTS API (cbits/run_main.c).
  * Returns the opaque AppContext pointer. */

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -16,6 +16,21 @@ let
     th-test = import ./test-th.nix { inherit sources; };
     readme-example = import ./test-readme-example.nix { inherit sources; };
     th-direct-test = import ./test-th-direct.nix { inherit sources; };
+    # async package cross-compilation regression test (issue #163).
+    # Without --wrap=registerForeignExports dedup, a duplicate .init_array
+    # entry causes infinite getStablePtr loop → OOM during hs_init.
+    async-oom-test = import ./android.nix {
+      inherit sources;
+      mainModule = ../test/AsyncOomDemoMain.hs;
+      consumerCabal2Nix =
+        { mkDerivation, base, lib, async, text }:
+        mkDerivation {
+          pname = "async-oom-test";
+          version = "0.1.0.0";
+          libraryHaskellDepends = [ base async text ];
+          license = lib.licenses.mit;
+        };
+    };
   } // (if isDarwin then {
     ios-lib = import ./ios.nix { inherit sources; };
     watchos-lib = import ./watchos.nix { inherit sources; };

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -317,6 +317,28 @@ let
     name = "hatter-horizontal-scroll-apk";
   };
 
+  # Async OOM regression test (issue #163).
+  # Without the registerForeignExports dedup fix, this app OOM-kills
+  # during hs_init due to a duplicate .init_array entry.
+  asyncOomAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/AsyncOomDemoMain.hs;
+    consumerCabal2Nix =
+      { mkDerivation, base, lib, async, text }:
+      mkDerivation {
+        pname = "async-oom-test";
+        version = "0.1.0.0";
+        libraryHaskellDepends = [ base async text ];
+        license = lib.licenses.mit;
+      };
+  };
+  asyncOomApk = lib.mkApk {
+    sharedLibs = [{ lib = asyncOomAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-async-oom.apk";
+    name = "hatter-async-oom-apk";
+  };
+
   androidComposition = pkgs.androidenv.composeAndroidPackages {
     platformVersions = [ emulatorApiLevel ];
     includeEmulator = true;
@@ -381,6 +403,7 @@ STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
 STYLED_TYPE_CHANGE_APK="${styledTypeChangeApk}/hatter-styled-type-change.apk"
 HORIZONTAL_SCROLL_APK="${horizontalScrollApk}/hatter-horizontal-scroll.apk"
+ASYNC_OOM_APK="${asyncOomApk}/hatter-async-oom.apk"
 PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
@@ -426,6 +449,16 @@ for so_path in \
         echo "OK    $SO_LABEL .so is ''${SO_MB} MB"
     fi
 done
+# Async OOM .so has a higher threshold — it pulls in 'async' and is known to be larger.
+ASYNC_OOM_SO="${asyncOomAndroid}/lib/${abiDir}/libhatter.so"
+ASYNC_OOM_SO_BYTES=$(stat -c %s "$ASYNC_OOM_SO")
+ASYNC_OOM_SO_MB=$((ASYNC_OOM_SO_BYTES / 1048576))
+if [ "$ASYNC_OOM_SO_MB" -gt 200 ]; then
+    echo "FAIL  async-oom-test .so is ''${ASYNC_OOM_SO_MB} MB (limit: 200 MB)"
+    SIZE_FAIL=1
+else
+    echo "OK    async-oom-test .so is ''${ASYNC_OOM_SO_MB} MB (limit: 200 MB)"
+fi
 if [ "$SIZE_FAIL" -eq 1 ]; then
     echo ""
     echo "FATAL: .so size limit exceeded. This usually means boot package .a files"
@@ -487,6 +520,7 @@ PHASE15_OK=0
 PHASE16_OK=0
 PHASE18_OK=0
 PHASE19_OK=0
+PHASE20_OK=0
 
 cleanup() {
     echo ""
@@ -603,7 +637,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -624,6 +658,7 @@ PHASE16_EXIT=0
 PHASE17_EXIT=0
 PHASE18_EXIT=0
 PHASE19_EXIT=0
+PHASE20_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -716,6 +751,8 @@ echo "--- styled-type-change ---"
 run_with_retry "styled-type-change" bash "$TEST_SCRIPTS/android/styled-type-change.sh" || PHASE18_EXIT=1
 echo "--- horizontal-scroll ---"
 run_with_retry "horizontal-scroll" bash "$TEST_SCRIPTS/android/horizontal-scroll.sh" || PHASE19_EXIT=1
+echo "--- async-oom ---"
+run_with_retry "async-oom" bash "$TEST_SCRIPTS/android/async_oom.sh" || PHASE20_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -906,6 +943,16 @@ else
     echo "PHASE 19 FAILED"
 fi
 
+if [ $PHASE20_EXIT -eq 0 ]; then
+    PHASE20_OK=1
+    echo ""
+    echo "PHASE 20 PASSED"
+else
+    PHASE20_OK=0
+    echo ""
+    echo "PHASE 20 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1046,6 +1093,13 @@ if [ $PHASE19_OK -eq 1 ]; then
     echo "PASS  Phase 19 — Horizontal scroll demo app"
 else
     echo "FAIL  Phase 19 — Horizontal scroll demo app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE20_OK -eq 1 ]; then
+    echo "PASS  Phase 20 — Async OOM regression test (issue #163)"
+else
+    echo "FAIL  Phase 20 — Async OOM regression test (issue #163)"
     FINAL_EXIT=1
 fi
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -428,6 +428,7 @@ in {
           -optl-Wl,-u,haskellOnHttpResult \
           -optl-Wl,-u,haskellOnNetworkStatusChange \
           -optl-Wl,-u,haskellLogLocale \
+          -optl-Wl,--wrap=registerForeignExports \
           -optl-Wl,--no-undefined \
           -optl-Wl,--whole-archive \
           -optl$RTS_LIB \

--- a/test/AsyncOomDemoMain.hs
+++ b/test/AsyncOomDemoMain.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Minimal demo app that depends on the @async@ package.
+--
+-- Reproducer for issue #163: adding @async@ as a cross-compilation
+-- dependency causes the Android app to OOM-kill during @.so@ loading
+-- at runtime (~5.3 GB RSS before any Haskell code executes).
+--
+-- The app will never actually reach @main@ on Android — the process
+-- is killed during @dlopen@.  The code is valid so it compiles and
+-- links; the emulator test asserts that the crash happens.
+module Main where
+
+import Control.Concurrent.Async (async, wait)
+import Foreign.Ptr (Ptr)
+import Hatter (startMobileApp, platformLog, loggingMobileContext, MobileApp(..), newActionState)
+import Hatter.AppContext (AppContext)
+import Hatter.Widget (TextConfig(..), Widget(..))
+
+main :: IO (Ptr AppContext)
+main = do
+  -- Trivial use of async to ensure it is linked in.
+  handle <- async (pure "async loaded")
+  result <- wait handle
+  platformLog result
+  actionState <- newActionState
+  startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> pure (Text TextConfig { tcLabel = "Async loaded", tcFontConfig = Nothing })
+    , maActionState = actionState
+    }

--- a/test/android/async_oom.sh
+++ b/test/android/async_oom.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Android async-OOM reproducer (issue #163).
+#
+# The async package causes the .so to balloon during dlopen, OOM-killing
+# the process before any Haskell code executes.  This test installs the
+# APK, launches it, and asserts that the app starts successfully.
+# Expected result: FAIL (the app never starts — proving the bug).
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, ASYNC_OOM_APK, PACKAGE, ACTIVITY, WORK_DIR
+
+# NOTE: we intentionally use set -uo pipefail WITHOUT -e here.
+# With errexit, diagnostic commands that find nothing (grep returns 1)
+# would kill the script before we can report what happened.
+set -uo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+# Enable bionic linker debug output for dlopen diagnostics.
+"$ADB" -s "$EMULATOR_SERIAL" shell "setprop debug.ld.all dlerror" 2>/dev/null || true
+
+start_app "$ASYNC_OOM_APK" "async_oom"
+
+# Start a background memory monitor on the device that polls /proc/PID/status
+# every 0.5s and logs VmSize/VmRSS/VmPeak.
+# shellcheck disable=SC2016  # single quotes intentional — runs on device
+"$ADB" -s "$EMULATOR_SERIAL" shell '
+  while true; do
+    PID=$(pidof me.jappie.hatter 2>/dev/null)
+    if [ -n "$PID" ]; then
+      STAMP=$(date +%s)
+      MEM=$(grep -E "VmSize|VmRSS|VmPeak" /proc/$PID/status 2>/dev/null | tr "\n" " ")
+      echo "$STAMP $MEM"
+    fi
+    sleep 0.5
+  done
+' > "$WORK_DIR/memory_timeline.txt" 2>/dev/null &
+MEMORY_MONITOR_PID=$!
+
+# Wait for the platformLog output that proves Haskell code ran.
+# Expected: this never arrives because the process is OOM-killed during
+# .so loading.
+wait_for_logcat "async loaded" 60
+WAIT_RC=$?
+
+# Stop the background memory monitor.
+kill "$MEMORY_MONITOR_PID" 2>/dev/null || true
+wait "$MEMORY_MONITOR_PID" 2>/dev/null || true
+
+# --- Diagnostics (always run) ---
+echo ""
+echo "=== async_oom: logcat warnings/errors (last 80 lines) ==="
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:W' 2>&1 | tail -80 || true
+echo "=== end async_oom logcat ==="
+
+echo ""
+echo "=== async_oom: process status ==="
+"$ADB" -s "$EMULATOR_SERIAL" shell "ps -A 2>/dev/null | grep -i jappie || echo 'Process not found (likely killed)'" || true
+echo "=== end process status ==="
+
+# Check for OOM/kill indicators
+LOGCAT_OOM="$WORK_DIR/async_oom_logcat.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$LOGCAT_OOM" 2>&1 || true
+echo ""
+echo "=== async_oom: OOM/kill indicators ==="
+grep -iE "oom|out of memory|lowmemory|am_kill|am_proc_died|killing|lmk" "$LOGCAT_OOM" | grep -i "jappie\|hatter\|oom\|kill\|memory" | tail -20 || echo "(none found)"
+echo "=== end OOM indicators ==="
+
+# Check for native crash indicators
+echo ""
+echo "=== async_oom: native crash indicators ==="
+grep -E "UnsatisfiedLinkError|dlopen failed|cannot locate symbol|SIGABRT|SIGSEGV|Fatal signal" "$LOGCAT_OOM" | tail -10 || echo "(none found)"
+echo "=== end native crash indicators ==="
+
+# HatterOOM debug checkpoints (from jni_bridge.c instrumentation)
+echo ""
+echo "=== async_oom: HatterOOM memory checkpoints ==="
+grep "HatterOOM" "$LOGCAT_OOM" | tail -30 || echo "(none found — DEBUG_OOM may not be enabled)"
+echo "=== end HatterOOM checkpoints ==="
+
+# Linker debug output
+echo ""
+echo "=== async_oom: linker debug output ==="
+grep -i "linker\|dlopen\|dlsym" "$LOGCAT_OOM" | tail -20 || echo "(none found)"
+echo "=== end linker debug ==="
+
+# Memory timeline from background monitor
+echo ""
+echo "=== async_oom: memory timeline ==="
+if [ -s "$WORK_DIR/memory_timeline.txt" ]; then
+    cat "$WORK_DIR/memory_timeline.txt"
+else
+    echo "(no data captured — process may have died too quickly)"
+fi
+echo "=== end memory timeline ==="
+
+# Dump /proc/PID/smaps if the process is still alive
+echo ""
+echo "=== async_oom: smaps (top 10 by RSS) ==="
+# shellcheck disable=SC2016  # single quotes intentional — runs on device
+"$ADB" -s "$EMULATOR_SERIAL" shell '
+  PID=$(pidof me.jappie.hatter 2>/dev/null)
+  if [ -n "$PID" ]; then
+    cat /proc/$PID/smaps 2>/dev/null | \
+      awk "/^[0-9a-f]/{region=\$0} /^Rss:/{print \$2, region}" | \
+      sort -rn | head -10
+  else
+    echo "(process not running)"
+  fi
+' 2>/dev/null || echo "(smaps unavailable)"
+echo "=== end smaps ==="
+# --- End diagnostics ---
+
+if [ "$WAIT_RC" -eq 2 ]; then
+    echo ""
+    echo "FATAL: Native library failed to load (expected for async OOM reproducer)"
+    EXIT_CODE=1
+elif [ "$WAIT_RC" -eq 1 ]; then
+    echo ""
+    echo "FAIL: Timed out waiting for 'async loaded' (app likely OOM-killed)"
+    EXIT_CODE=1
+fi
+
+# Collect final logcat
+collect_logcat "async_oom"
+
+# Assert the app actually started (this is the key assertion — it should FAIL)
+assert_logcat "$LOGCAT_FILE" "async loaded" "async package loaded successfully"
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- **Commit 1**: Adds the async package cross-compilation test as a regression guard (Phase 20 in emulator suite). Without the fix, the app OOM-kills during `hs_init`.
- **Commit 2**: Fixes the OOM by deduplicating `registerForeignExports` `.init_array` entries via `-Wl,--wrap=registerForeignExports`.

## Root cause
`--whole-archive` linking creates duplicate `.init_array` constructors for `registerForeignExports`. The second call with the same `ForeignExportsList` pointer creates a self-referencing linked list (`struct->next = &struct`). `processForeignExports` then loops infinitely, calling `getStablePtr` billions of times and doubling `enlargeStablePtrTable` until the 32-bit address space is exhausted (1 GB malloc → OOM).

## Test plan
- [ ] `nix-build` passes (async-oom-test now in `all-builds`)
- [ ] `android-armv7a-emulator` passes Phase 20 (async OOM regression test)
- [ ] All other phases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)