### PR TITLE
Add XCUITest for iOS and watchOS counter app

### DIFF
--- a/ios/HatterUITests/CounterUITests.swift
+++ b/ios/HatterUITests/CounterUITests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+class CounterUITests: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUp() {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testCounterInitialState() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        XCTAssert(app.buttons["+"].exists)
+        XCTAssert(app.buttons["-"].exists)
+    }
+
+    func testTapIncrementsCounter() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        app.buttons["+"].tap()
+        XCTAssert(app.staticTexts["Counter: 1"].waitForExistence(timeout: 10))
+    }
+
+    func testTapDecrementsCounter() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        app.buttons["-"].tap()
+        XCTAssert(app.staticTexts["Counter: -1"].waitForExistence(timeout: 10))
+    }
+
+    func testFullSequence() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        app.buttons["+"].tap()
+        XCTAssert(app.staticTexts["Counter: 1"].waitForExistence(timeout: 10))
+        app.buttons["+"].tap()
+        XCTAssert(app.staticTexts["Counter: 2"].waitForExistence(timeout: 10))
+        app.buttons["-"].tap()
+        XCTAssert(app.staticTexts["Counter: 1"].waitForExistence(timeout: 10))
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -36,7 +36,8 @@ targets:
     type: bundle.ui-testing
     platform: iOS
     sources:
-      - HatterUITests
+      - path: HatterUITests
+        optional: true
     dependencies:
       - target: Hatter
     settings:

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -31,3 +31,14 @@ targets:
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
         OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit", "-framework", "QuartzCore"]
+
+  HatterUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - HatterUITests
+    dependencies:
+      - target: Hatter
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: me.jappie.hatter.uitests

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -789,6 +789,7 @@ open(sys.argv[1], "w").write(yml)
         mkdir -p $out/share/ios/lib $out/share/ios/include
 
         cp -r ${iosSrc}/Hatter $out/share/ios/
+        cp -r ${iosSrc}/HatterUITests $out/share/ios/
         cp ${iosSrc}/project.yml $out/share/ios/project.yml
         chmod u+w $out/share/ios/project.yml
 
@@ -987,6 +988,7 @@ open(sys.argv[1], "w").write(yml)
         mkdir -p $out/share/watchos/lib $out/share/watchos/include
 
         cp -r ${watchosSrc}/Hatter $out/share/watchos/
+        cp -r ${watchosSrc}/HatterUITests $out/share/watchos/
         cp ${watchosSrc}/project.yml $out/share/watchos/project.yml
 
         cp ${watchosLib}/lib/libHatter.a $out/share/watchos/lib/

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -367,6 +367,7 @@ PHASE16_OK=0
 PHASE17_OK=0
 PHASE18_OK=0
 PHASE19_OK=0
+PHASE20_OK=0
 
 cleanup() {
     echo ""
@@ -458,6 +459,7 @@ cp "$COUNTER_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/counter/include
 cp "$COUNTER_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/RedrawBridge.h" "$WORK_DIR/counter/include/"
 cp -r "$COUNTER_SHARE_DIR/Hatter" "$WORK_DIR/counter/"
+cp -r "$COUNTER_SHARE_DIR/HatterUITests" "$WORK_DIR/counter/"
 cp "$COUNTER_SHARE_DIR/project.yml" "$WORK_DIR/counter/"
 chmod -R u+w "$WORK_DIR/counter"
 
@@ -1603,6 +1605,7 @@ PHASE16_EXIT=0
 PHASE17_EXIT=0
 PHASE18_EXIT=0
 PHASE19_EXIT=0
+PHASE20_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1693,6 +1696,16 @@ echo "--- horizontal-scroll ---"
 run_with_retry "horizontal-scroll" bash "$TEST_SCRIPTS/ios/horizontal-scroll.sh" || PHASE18_EXIT=1
 echo "--- redraw ---"
 run_with_retry "redraw" bash "$TEST_SCRIPTS/ios/redraw.sh" || PHASE19_EXIT=1
+
+echo "--- xcuitest-counter ---"
+run_with_retry "xcuitest-counter" xcodebuild test \
+    -project "$WORK_DIR/counter/Hatter.xcodeproj" \
+    -scheme "HatterUITests" \
+    -destination "platform=iOS Simulator,id=$SIM_UDID" \
+    -only-testing "HatterUITests/CounterUITests" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    || PHASE20_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1883,6 +1896,16 @@ else
     echo "PHASE 19 FAILED"
 fi
 
+if [ $PHASE20_EXIT -eq 0 ]; then
+    PHASE20_OK=1
+    echo ""
+    echo "PHASE 20 PASSED"
+else
+    PHASE20_OK=0
+    echo ""
+    echo "PHASE 20 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -2023,6 +2046,13 @@ if [ $PHASE19_OK -eq 1 ]; then
     echo "PASS  Phase 19 — Redraw demo app (background thread re-render)"
 else
     echo "FAIL  Phase 19 — Redraw demo app (background thread re-render)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE20_OK -eq 1 ]; then
+    echo "PASS  Phase 20 — XCUITest counter app"
+else
+    echo "FAIL  Phase 20 — XCUITest counter app"
     FINAL_EXIT=1
 fi
 

--- a/nix/watchos-simulator-all.nix
+++ b/nix/watchos-simulator-all.nix
@@ -343,6 +343,7 @@ PHASE16_OK=0
 PHASE18_OK=0
 PHASE19_OK=0
 PHASE20_OK=0
+PHASE21_OK=0
 
 cleanup() {
     echo ""
@@ -431,6 +432,7 @@ cp "$COUNTER_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/counter/include
 cp "$COUNTER_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/counter/include/"
 cp "$COUNTER_SHARE_DIR/include/RedrawBridge.h" "$WORK_DIR/counter/include/"
 cp -r "$COUNTER_SHARE_DIR/Hatter" "$WORK_DIR/counter/"
+cp -r "$COUNTER_SHARE_DIR/HatterUITests" "$WORK_DIR/counter/"
 cp "$COUNTER_SHARE_DIR/project.yml" "$WORK_DIR/counter/"
 chmod -R u+w "$WORK_DIR/counter"
 
@@ -1467,6 +1469,7 @@ PHASE17_EXIT=0
 PHASE18_EXIT=0
 PHASE19_EXIT=0
 PHASE20_EXIT=0
+PHASE21_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1546,6 +1549,16 @@ echo "--- horizontal-scroll ---"
 run_with_retry "horizontal-scroll" bash "$TEST_SCRIPTS/watchos/horizontal-scroll.sh" || PHASE19_EXIT=1
 echo "--- redraw ---"
 run_with_retry "redraw" bash "$TEST_SCRIPTS/watchos/redraw.sh" || PHASE20_EXIT=1
+
+echo "--- xcuitest-counter ---"
+run_with_retry "xcuitest-counter" xcodebuild test \
+    -project "$WORK_DIR/counter/Hatter.xcodeproj" \
+    -scheme "HatterUITests" \
+    -destination "platform=watchOS Simulator,id=$SIM_UDID" \
+    -only-testing "HatterUITests/CounterUITests" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    || PHASE21_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -1746,6 +1759,16 @@ else
     echo "PHASE 20 FAILED"
 fi
 
+if [ $PHASE21_EXIT -eq 0 ]; then
+    PHASE21_OK=1
+    echo ""
+    echo "PHASE 21 PASSED"
+else
+    PHASE21_OK=0
+    echo ""
+    echo "PHASE 21 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1893,6 +1916,13 @@ if [ $PHASE20_OK -eq 1 ]; then
     echo "PASS  Phase 20 — Redraw demo app (background thread re-render)"
 else
     echo "FAIL  Phase 20 — Redraw demo app (background thread re-render)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE21_OK -eq 1 ]; then
+    echo "PASS  Phase 21 — XCUITest counter app"
+else
+    echo "FAIL  Phase 21 — XCUITest counter app"
     FINAL_EXIT=1
 fi
 

--- a/watchos/HatterUITests/CounterUITests.swift
+++ b/watchos/HatterUITests/CounterUITests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+class CounterUITests: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUp() {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testCounterInitialState() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        XCTAssert(app.buttons["+"].exists)
+        XCTAssert(app.buttons["-"].exists)
+    }
+
+    func testTapIncrementsCounter() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        app.buttons["+"].tap()
+        XCTAssert(app.staticTexts["Counter: 1"].waitForExistence(timeout: 10))
+    }
+
+    func testTapDecrementsCounter() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        app.buttons["-"].tap()
+        XCTAssert(app.staticTexts["Counter: -1"].waitForExistence(timeout: 10))
+    }
+
+    func testFullSequence() {
+        XCTAssert(app.staticTexts["Counter: 0"].waitForExistence(timeout: 15))
+        app.buttons["+"].tap()
+        XCTAssert(app.staticTexts["Counter: 1"].waitForExistence(timeout: 10))
+        app.buttons["+"].tap()
+        XCTAssert(app.staticTexts["Counter: 2"].waitForExistence(timeout: 10))
+        app.buttons["-"].tap()
+        XCTAssert(app.staticTexts["Counter: 1"].waitForExistence(timeout: 10))
+    }
+}

--- a/watchos/project.yml
+++ b/watchos/project.yml
@@ -31,7 +31,8 @@ targets:
     type: bundle.ui-testing
     platform: watchOS
     sources:
-      - HatterUITests
+      - path: HatterUITests
+        optional: true
     dependencies:
       - target: Hatter
     settings:

--- a/watchos/project.yml
+++ b/watchos/project.yml
@@ -26,3 +26,14 @@ targets:
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
         OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AuthenticationServices"]
+
+  HatterUITests:
+    type: bundle.ui-testing
+    platform: watchOS
+    sources:
+      - HatterUITests
+    dependencies:
+      - target: Hatter
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: me.jappie.hatter.watchkitapp.uitests


### PR DESCRIPTION
## Summary
- Adds XCUITest targets (`HatterUITests`) for both iOS and watchOS that verify the counter app's native view hierarchy via the accessibility tree
- 4 tests per platform: initial state, increment, decrement, full sequence — using `app.staticTexts["Counter: 0"]` and `app.buttons["+"]` which work without bridge changes since UILabel/Button titles auto-expose as accessibility labels
- Integrated into the existing simulator CI pipeline as Phase 19 (iOS) and Phase 20 (watchOS), additive to existing bash log tests

## Test plan
- [ ] CI `ios` job: XCUITest phase (Phase 19) should pass
- [ ] CI `watchos` job: XCUITest phase (Phase 20) should pass
- [ ] Existing bash log tests continue to pass alongside XCUITest

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)