### PR TITLE
Add scrollColumn and scrollRow smart constructors

### DIFF
--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -75,6 +75,8 @@ module Hatter
   , button
   , column
   , row
+  , scrollColumn
+  , scrollRow
   , text
     -- * Actions
   , Action(..)
@@ -178,6 +180,8 @@ import Hatter.Widget
   , column
   , defaultStyle
   , row
+  , scrollColumn
+  , scrollRow
   , text
   )
 

--- a/src/Hatter/Widget.hs
+++ b/src/Hatter/Widget.hs
@@ -42,6 +42,8 @@ module Hatter.Widget
   , button
   , column
   , row
+  , scrollColumn
+  , scrollRow
   , text
   )
 where
@@ -341,6 +343,14 @@ column widgets = Column LayoutSettings { lsWidgets = widgets, lsScrollable = Fal
 -- | Build a non-scrollable horizontal container.
 row :: [Widget] -> Widget
 row widgets = Row LayoutSettings { lsWidgets = widgets, lsScrollable = False }
+
+-- | Build a scrollable vertical container (native scroll view).
+scrollColumn :: [Widget] -> Widget
+scrollColumn widgets = Column LayoutSettings { lsWidgets = widgets, lsScrollable = True }
+
+-- | Build a scrollable horizontal container (native horizontal scroll view).
+scrollRow :: [Widget] -> Widget
+scrollRow widgets = Row LayoutSettings { lsWidgets = widgets, lsScrollable = True }
 
 -- | A declarative description of a UI element.
 --

--- a/test/Test/WidgetTests.hs
+++ b/test/Test/WidgetTests.hs
@@ -48,6 +48,8 @@ import Hatter.Widget
   , column
   , defaultStyle
   , row
+  , scrollColumn
+  , scrollRow
   )
 import Hatter.Render (RenderState(..), RenderedNode(..), renderWidget, dispatchEvent, dispatchTextEvent)
 import Hatter.Permission (newPermissionState)
@@ -258,6 +260,38 @@ scrollViewTests = testGroup "ScrollView"
             Just (RenderedAnimated _ _)      -> -2
             Nothing                          -> -2
       assertBool "node ID should change when scrollable changes" (nodeId1 /= nodeId2)
+
+  , testCase "scrollColumn creates a scrollable Column" $ do
+      let widget = scrollColumn
+            [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+            , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+            ]
+      widget @?= Column (LayoutSettings
+        [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+        , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+        ] True)
+
+  , testCase "scrollRow creates a scrollable Row" $ do
+      let widget = scrollRow
+            [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+            , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+            ]
+      widget @?= Row (LayoutSettings
+        [ Text TextConfig { tcLabel = "a", tcFontConfig = Nothing }
+        , Text TextConfig { tcLabel = "b", tcFontConfig = Nothing }
+        ] True)
+
+  , testCase "scrollColumn button dispatches correctly" $ do
+      ref <- newIORef False
+      (clickHandle, rs) <- withActions $
+        createAction (modifyIORef' ref (const True))
+      renderWidget rs $ scrollColumn
+        [ Button ButtonConfig
+            { bcLabel = "click", bcAction = clickHandle, bcFontConfig = Nothing }
+        ]
+      dispatchEvent rs (actionId clickHandle)
+      fired <- readIORef ref
+      fired @?= True
   ]
 
 -- | Tests for the Stack widget (z-order overlay container).


### PR DESCRIPTION
## Summary
- Add `scrollColumn :: [Widget] -> Widget` — creates a scrollable vertical container (native scroll view)
- Add `scrollRow :: [Widget] -> Widget` — creates a scrollable horizontal container (native horizontal scroll view)
- Exported from both `Hatter.Widget` and `Hatter`

These mirror the existing `column`/`row` constructors but set `lsScrollable = True`, avoiding manual `LayoutSettings` construction.

## Test plan
- [x] `scrollColumn` produces `Column (LayoutSettings _ True)` — equality test
- [x] `scrollRow` produces `Row (LayoutSettings _ True)` — equality test
- [x] Button dispatch through `scrollColumn` works correctly
- [x] `cabal test all` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)