### PR TITLE
Fix animated widget toggle-back bug

### DIFF
--- a/src/Hatter/Render.hs
+++ b/src/Hatter/Render.hs
@@ -67,6 +67,21 @@ renderedWidget (RenderedContainer widget _ _) = widget
 renderedWidget (RenderedStyled widget _ _)    = widget
 renderedWidget (RenderedAnimated widget _)    = widget
 
+-- | Update the widget stored in a RenderedNode to reflect an animation target.
+-- The native node ID and children are preserved; only the bookkeeping fields
+-- (widget, style) change so the next diff sees the post-animation state.
+updateRenderedTarget :: Widget -> RenderedNode -> RenderedNode
+updateRenderedTarget target (RenderedLeaf _ nodeId) =
+  RenderedLeaf target nodeId
+updateRenderedTarget target (RenderedContainer _ nodeId children) =
+  RenderedContainer target nodeId children
+updateRenderedTarget (Styled newStyle _) (RenderedStyled _ _ child) =
+  RenderedStyled (Styled newStyle (renderedWidget child)) newStyle child
+updateRenderedTarget target (RenderedStyled _ oldStyle child) =
+  RenderedStyled target oldStyle child
+updateRenderedTarget target (RenderedAnimated _ child) =
+  RenderedAnimated target child
+
 -- ---------------------------------------------------------------------------
 -- Render state
 -- ---------------------------------------------------------------------------
@@ -329,7 +344,8 @@ diffRenderNode animState (Just (RenderedAnimated _ oldChildNode)) (Animated newC
                oldChildWidget newChild (anDuration newConfig) (anEasing newConfig)
         else pure ()
       -- Update the RenderedAnimated to reflect the new target
-      pure (RenderedAnimated (Animated newConfig newChild) oldChildNode)
+      let updatedChildNode = updateRenderedTarget newChild oldChildNode
+      pure (RenderedAnimated (Animated newConfig newChild) updatedChildNode)
     else do
       -- Different child type: can't animate, destroy+create
       destroyRenderedSubtree oldChildNode

--- a/test/Test/AnimationTests.hs
+++ b/test/Test/AnimationTests.hs
@@ -236,6 +236,44 @@ animatedWidgetRenderTests = testGroup "Animated widget rendering"
       -- Different node type means different node ID
       assertBool "Node ID should change for different node types"
         (firstNodeId /= secondNodeId)
+  , testCase "Toggle-back registers tween after animation completes" $ do
+      -- Hypothesis: after animation A→B completes, toggling B→A should
+      -- register a new tween. If oldChildNode is never updated to reflect
+      -- the post-animation state, the diff sees oldChild==newChild and
+      -- skips the tween, leaving the native view stuck at B.
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let styledA = Styled (defaultStyle { wsPadding = Just 10 }) (Text TextConfig { tcLabel = "x", tcFontConfig = Nothing })
+          styledB = Styled (defaultStyle { wsPadding = Just 50 }) (Text TextConfig { tcLabel = "x", tcFontConfig = Nothing })
+          widgetA = Animated (AnimatedConfig 500 Linear) styledA
+          widgetB = Animated (AnimatedConfig 500 Linear) styledB
+
+      -- Render 1: initial state (padding=10)
+      renderWidget rs widgetA
+      tweensAfter1 <- readIORef (ansTweens animState)
+      assertBool "No tween after first render" (IntMap.null tweensAfter1)
+
+      -- Render 2: change to padding=50 — tween should be registered
+      renderWidget rs widgetB
+      tweensAfter2 <- readIORef (ansTweens animState)
+      assertBool "Tween registered after padding change (10→50)" (not (IntMap.null tweensAfter2))
+
+      -- Complete the animation: first dispatch sets startTime, second completes it
+      dispatchAnimationFrame animState 0.0    -- initialises startTime=0
+      dispatchAnimationFrame animState 1000.0 -- elapsed=1000 > duration=500 → done
+      tweensAfterDispatch <- readIORef (ansTweens animState)
+      assertBool "Tween completed after dispatch" (IntMap.null tweensAfterDispatch)
+
+      -- Render 3: toggle back to padding=10 — tween MUST be registered again
+      -- BUG: if oldChildNode still records padding=10 (pre-animation state),
+      -- the diff sees oldChild==newChild and skips the tween.
+      writeIORef (ansLoopActive animState) True
+      renderWidget rs widgetA
+      tweensAfter3 <- readIORef (ansTweens animState)
+      assertBool "Tween registered after toggle-back (50→10)" (not (IntMap.null tweensAfter3))
   ]
 
 -- | Helper: get the native node ID from a RenderedNode, following through


### PR DESCRIPTION
## Summary

- Add `updateRenderedTarget` helper that updates the bookkeeping widget (and style for `RenderedStyled`) in a `RenderedNode` to reflect the animation's target state
- Use it at the tween registration site so the next diff sees the post-animation state, enabling toggle-back tweens

## Problem

After animation A→B completes, toggling back to A does not register a tween. The native view stays stuck at B.

Root cause: `diffRenderNode` returned `oldChildNode` unchanged after registering a tween. After animating padding 10→50, `oldChildNode`'s widget still says padding=10. Toggling back to 10 makes `oldChildWidget == newChild` → no tween → native stuck at 50.

## Test plan

- [x] Failing test added (first commit)
- [x] `cabal build` — typechecks, no new warnings
- [x] `cabal test` — all 262 tests pass, including "Toggle-back registers tween after animation completes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)