### PR TITLE
Add EaseIn translate animation integration test

### DIFF
--- a/install-ease-in-translate-wear.sh
+++ b/install-ease-in-translate-wear.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Install the EaseIn translate animation demo on a Wear OS watch (armeabi-v7a / 32-bit ARM).
+# Connect the watch via ADB (Wi-Fi or USB debugging) before running.
+
+set -euo pipefail
+
+adb uninstall me.jappie.hatter 2>/dev/null || true
+adb install "$(nix-build nix/ease-in-translate-apk.nix --argstr androidArch armv7a)/hatter-ease-in-translate.apk"

--- a/install-ease-in-translate.sh
+++ b/install-ease-in-translate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Install the EaseIn translate animation demo on an Android phone (aarch64).
+# Connect the device via ADB before running.
+
+set -euo pipefail
+
+adb uninstall me.jappie.hatter 2>/dev/null || true
+adb install "$(nix-build nix/ease-in-translate-apk.nix)/hatter-ease-in-translate.apk"

--- a/nix/ease-in-translate-apk.nix
+++ b/nix/ease-in-translate-apk.nix
@@ -1,0 +1,19 @@
+# Standalone APK for the EaseIn translate animation demo.
+# Usage:
+#   nix-build nix/ease-in-translate-apk.nix                    # aarch64 (phone)
+#   nix-build nix/ease-in-translate-apk.nix --argstr androidArch armv7a  # Wear OS
+{ sources ? import ../npins, androidArch ? "aarch64" }:
+let
+  abiDir = { aarch64 = "arm64-v8a"; armv7a = "armeabi-v7a"; }.${androidArch};
+  lib = import ./lib.nix { inherit sources androidArch; };
+  sharedLib = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/EaseInTranslateDemoMain.hs;
+  };
+in
+lib.mkApk {
+  sharedLibs = [{ lib = sharedLib; inherit abiDir; }];
+  androidSrc = ../android;
+  apkName = "hatter-ease-in-translate.apk";
+  name = "hatter-ease-in-translate-apk";
+}

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -251,6 +251,17 @@ let
     name = "hatter-animation-apk";
   };
 
+  easeInTranslateAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/EaseInTranslateDemoMain.hs;
+  };
+  easeInTranslateApk = lib.mkApk {
+    sharedLibs = [{ lib = easeInTranslateAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-ease-in-translate.apk";
+    name = "hatter-ease-in-translate-apk";
+  };
+
   filesDirAndroid = import ./android.nix {
     inherit sources androidArch;
     mainModule = ../test/FilesDirDemoMain.hs;
@@ -408,6 +419,7 @@ HTTP_APK="${httpApk}/hatter-http.apk"
 NETWORK_STATUS_APK="${networkStatusApk}/hatter-networkstatus.apk"
 MAPVIEW_APK="${mapviewApk}/hatter-mapview.apk"
 ANIMATION_APK="${animationApk}/hatter-animation.apk"
+EASE_IN_TRANSLATE_APK="${easeInTranslateApk}/hatter-ease-in-translate.apk"
 FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
@@ -446,6 +458,7 @@ for so_path in \
     "${networkStatusAndroid}/lib/${abiDir}/libhatter.so" \
     "${mapviewAndroid}/lib/${abiDir}/libhatter.so" \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
+    "${easeInTranslateAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
     "${stackAndroid}/lib/${abiDir}/libhatter.so" \
@@ -535,6 +548,7 @@ PHASE18_OK=0
 PHASE19_OK=0
 PHASE20_OK=0
 PHASE21_OK=0
+PHASE22_OK=0
 
 cleanup() {
     echo ""
@@ -651,7 +665,7 @@ sleep 30
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK REDRAW_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK EASE_IN_TRANSLATE_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK REDRAW_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -674,6 +688,7 @@ PHASE18_EXIT=0
 PHASE19_EXIT=0
 PHASE20_EXIT=0
 PHASE21_EXIT=0
+PHASE22_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -770,6 +785,8 @@ echo "--- async-oom ---"
 run_with_retry "async-oom" bash "$TEST_SCRIPTS/android/async_oom.sh" || PHASE20_EXIT=1
 echo "--- redraw ---"
 run_with_retry "redraw" bash "$TEST_SCRIPTS/android/redraw.sh" || PHASE21_EXIT=1
+echo "--- ease-in-translate ---"
+run_with_retry "ease-in-translate" bash "$TEST_SCRIPTS/android/ease-in-translate.sh" || PHASE22_EXIT=1
 
 # --- Phase results ---
 if [ $PHASE1_EXIT -eq 0 ]; then
@@ -980,6 +997,16 @@ else
     echo "PHASE 21 FAILED"
 fi
 
+if [ $PHASE22_EXIT -eq 0 ]; then
+    PHASE22_OK=1
+    echo ""
+    echo "PHASE 22 PASSED"
+else
+    PHASE22_OK=0
+    echo ""
+    echo "PHASE 22 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1134,6 +1161,13 @@ if [ $PHASE21_OK -eq 1 ]; then
     echo "PASS  Phase 21 — Redraw demo app (background thread re-render)"
 else
     echo "FAIL  Phase 21 — Redraw demo app (background thread re-render)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE22_OK -eq 1 ]; then
+    echo "PASS  Phase 22 — EaseIn translate animation"
+else
+    echo "FAIL  Phase 22 — EaseIn translate animation"
     FINAL_EXIT=1
 fi
 

--- a/test/EaseInTranslateDemoMain.hs
+++ b/test/EaseInTranslateDemoMain.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Integration test app: EaseIn translate animation.
+--
+-- A text label starts at position (0, 0).  Tapping "Move Text"
+-- animates it to (120, 80) over 400ms using EaseIn.  Tapping
+-- "Reset" animates it back.  The app logs position changes so
+-- the Android emulator test can assert via logcat.
+module Main where
+
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (pack)
+import Foreign.Ptr (Ptr)
+import Hatter
+  ( MobileApp(..)
+  , UserState(..)
+  , AnimatedConfig(..)
+  , Easing(..)
+  , startMobileApp
+  , newActionState
+  , runActionM
+  , createAction
+  , loggingMobileContext
+  , platformLog
+  )
+import Hatter.AppContext (AppContext(..))
+import Hatter.Widget
+  ( Widget(..)
+  , TextConfig(..)
+  , ButtonConfig(..)
+  , WidgetStyle(..)
+  , defaultStyle
+  , column
+  )
+
+main :: IO (Ptr AppContext)
+main = do
+  actionState <- newActionState
+  -- False = position A (0,0), True = position B (120,80)
+  atPositionB <- newIORef False
+
+  moveAction <- runActionM actionState $ createAction $ do
+    writeIORef atPositionB True
+    platformLog "Moved to position B (translateX=120, translateY=80)"
+
+  resetAction <- runActionM actionState $ createAction $ do
+    writeIORef atPositionB False
+    platformLog "Reset to position A (translateX=0, translateY=0)"
+
+  let viewFn :: UserState -> IO Widget
+      viewFn _userState = do
+        isAtB <- readIORef atPositionB
+        let translateX = if isAtB then 120.0 else 0.0
+            translateY = if isAtB then 80.0 else 0.0
+        pure $ column
+          [ Animated (AnimatedConfig 400 EaseIn) $
+              Styled (defaultStyle { wsTranslateX = Just translateX
+                                   , wsTranslateY = Just translateY
+                                   }) $
+                Text TextConfig
+                  { tcLabel = "EaseIn " <> pack (show translateX) <> "," <> pack (show translateY)
+                  , tcFontConfig = Nothing
+                  }
+          , Button ButtonConfig
+              { bcLabel = "Move Text"
+              , bcAction = moveAction
+              , bcFontConfig = Nothing
+              }
+          , Button ButtonConfig
+              { bcLabel = "Reset"
+              , bcAction = resetAction
+              , bcFontConfig = Nothing
+              }
+          ]
+      app = MobileApp
+        { maContext     = loggingMobileContext
+        , maView        = viewFn
+        , maActionState = actionState
+        }
+  ctxPtr <- startMobileApp app
+  platformLog "EaseInTranslateDemoMain started"
+  pure ctxPtr

--- a/test/android/ease-in-translate.sh
+++ b/test/android/ease-in-translate.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # Android EaseIn translate animation test.
 #
-# Installs the ease-in-translate demo APK, launches it, taps
+# Installs the ease-in-translate demo APK, launches it, dumps the
+# view hierarchy to capture the text widget's initial bounds, taps
 # "Move Text" to trigger an EaseIn animation from (0,0) to (120,80),
-# and verifies via logcat that:
-#   1. The app started
-#   2. The translate position change was logged
-#   3. The bridge received setNumProp calls for translateX/translateY
-#   4. No fatal crash occurred
+# then dumps the hierarchy again and verifies the text has moved to
+# the expected position.
+#
+# Asserts:
+#   1. App started without crash
+#   2. Text widget visible at initial position in screen dump
+#   3. After animation, text widget bounds shifted right by ~120px and down by ~80px
+#   4. Bridge received setNumProp calls with correct final values
 #
 # Required env vars (set by emulator-all.nix harness):
 #   ADB, EMULATOR_SERIAL, EASE_IN_TRANSLATE_APK, PACKAGE, ACTIVITY, WORK_DIR
@@ -16,30 +20,127 @@ source "$(dirname "$0")/helpers.sh"
 
 EXIT_CODE=0
 
+# --- Helper: dump UI hierarchy with retries ---
+dump_ui() {
+    local out_file="$1"
+    local dump_ok=0
+    for attempt in 1 2 3; do
+        if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+            "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$out_file" 2>/dev/null
+            dump_ok=1
+            break
+        fi
+        echo "  uiautomator dump attempt $attempt failed, retrying in 5s..."
+        sleep 5
+    done
+    return $((1 - dump_ok))
+}
+
+# --- Helper: extract left,top from bounds for a text node ---
+# Usage: extract_bounds DUMP_FILE TEXT_PATTERN
+# Prints: LEFT TOP RIGHT BOTTOM
+extract_bounds() {
+    local dump_file="$1"
+    local text_pattern="$2"
+    local match
+    match=$(grep -o "text=\"${text_pattern}[^\"]*\"[^>]*bounds=\"\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]\"" "$dump_file" 2>/dev/null | head -1 || echo "")
+    if [ -z "$match" ]; then
+        echo ""
+        return 1
+    fi
+    local coords
+    coords=$(echo "$match" | grep -o '\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]')
+    local left top right bottom
+    left=$(echo "$coords" | sed 's/^\[//;s/,.*//')
+    top=$(echo "$coords" | sed 's/^\[[0-9]*,//;s/\].*//')
+    right=$(echo "$coords" | sed 's/.*\]\[//;s/,.*//')
+    bottom=$(echo "$coords" | sed 's/.*,//;s/\]//')
+    echo "$left $top $right $bottom"
+}
+
 start_app "$EASE_IN_TRANSLATE_APK" "ease-in-translate"
 wait_for_render "ease-in-translate"
-
 sleep 3
 
-# Tap "Move Text" to trigger the EaseIn animation
+# === BEFORE: dump screen at initial position ===
+DUMP_BEFORE="$WORK_DIR/ease_in_before.xml"
+if dump_ui "$DUMP_BEFORE"; then
+    echo "=== Before-animation view hierarchy ==="
+    cat "$DUMP_BEFORE"
+    echo ""
+    echo "=== End hierarchy ==="
+
+    BEFORE_BOUNDS=$(extract_bounds "$DUMP_BEFORE" "EaseIn")
+    if [ -n "$BEFORE_BOUNDS" ]; then
+        read -r BEFORE_LEFT BEFORE_TOP BEFORE_RIGHT BEFORE_BOTTOM <<< "$BEFORE_BOUNDS"
+        echo "PASS: Text found at initial bounds [$BEFORE_LEFT,$BEFORE_TOP][$BEFORE_RIGHT,$BEFORE_BOTTOM]"
+    else
+        echo "FAIL: Could not find EaseIn text in before-dump"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (before animation)"
+    EXIT_CODE=1
+fi
+
+# === Tap "Move Text" to trigger EaseIn animation ===
 tap_button "Move Text" || { echo "WARNING: could not tap Move Text"; }
 
 # Wait for animation to complete (400ms duration + settle time)
 sleep 3
 
+# === AFTER: dump screen at final position ===
+DUMP_AFTER="$WORK_DIR/ease_in_after.xml"
+if dump_ui "$DUMP_AFTER"; then
+    echo "=== After-animation view hierarchy ==="
+    cat "$DUMP_AFTER"
+    echo ""
+    echo "=== End hierarchy ==="
+
+    AFTER_BOUNDS=$(extract_bounds "$DUMP_AFTER" "EaseIn")
+    if [ -n "$AFTER_BOUNDS" ]; then
+        read -r AFTER_LEFT AFTER_TOP AFTER_RIGHT AFTER_BOTTOM <<< "$AFTER_BOUNDS"
+        echo "PASS: Text found at final bounds [$AFTER_LEFT,$AFTER_TOP][$AFTER_RIGHT,$AFTER_BOTTOM]"
+    else
+        echo "FAIL: Could not find EaseIn text in after-dump"
+        EXIT_CODE=1
+    fi
+else
+    echo "FAIL: Could not dump view hierarchy (after animation)"
+    EXIT_CODE=1
+fi
+
+# === Verify the text moved by the expected offset ===
+# Android density may scale the dp values, but the relative shift should
+# match translateX=120 and translateY=80 in device pixels.  We check that
+# the left edge moved right and the top edge moved down.
+if [ -n "${BEFORE_BOUNDS:-}" ] && [ -n "${AFTER_BOUNDS:-}" ]; then
+    DX=$((AFTER_LEFT - BEFORE_LEFT))
+    DY=$((AFTER_TOP - BEFORE_TOP))
+    echo "Measured delta: dx=$DX dy=$DY"
+
+    if [ "$DX" -gt 0 ]; then
+        echo "PASS: Text moved right (dx=$DX)"
+    else
+        echo "FAIL: Text did not move right (dx=$DX)"
+        EXIT_CODE=1
+    fi
+
+    if [ "$DY" -gt 0 ]; then
+        echo "PASS: Text moved down (dy=$DY)"
+    else
+        echo "FAIL: Text did not move down (dy=$DY)"
+        EXIT_CODE=1
+    fi
+fi
+
+# === Logcat assertions ===
 collect_logcat "ease-in-translate"
 
-# Assert the app started
 assert_logcat "$LOGCAT_FILE" "EaseInTranslateDemoMain started" "Demo app started"
-
-# Assert initial position was set on first render
+assert_logcat "$LOGCAT_FILE" "Moved to position B" "Position B logged"
 assert_logcat "$LOGCAT_FILE" "setNumProp.*translateX=0.0" "initial translateX=0.0"
 assert_logcat "$LOGCAT_FILE" "setNumProp.*translateY=0.0" "initial translateY=0.0"
-
-# Assert position change was logged
-assert_logcat "$LOGCAT_FILE" "Moved to position B" "Position B logged"
-
-# Assert the bridge received translate property updates with correct final position
 assert_logcat "$LOGCAT_FILE" "setNumProp.*translateX=120.0" "translateX reached 120.0"
 assert_logcat "$LOGCAT_FILE" "setNumProp.*translateY=80.0" "translateY reached 80.0"
 

--- a/test/android/ease-in-translate.sh
+++ b/test/android/ease-in-translate.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Android EaseIn translate animation test.
+#
+# Installs the ease-in-translate demo APK, launches it, taps
+# "Move Text" to trigger an EaseIn animation from (0,0) to (120,80),
+# and verifies via logcat that:
+#   1. The app started
+#   2. The translate position change was logged
+#   3. The bridge received setNumProp calls for translateX/translateY
+#   4. No fatal crash occurred
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, EASE_IN_TRANSLATE_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+start_app "$EASE_IN_TRANSLATE_APK" "ease-in-translate"
+wait_for_render "ease-in-translate"
+
+sleep 3
+
+# Tap "Move Text" to trigger the EaseIn animation
+tap_button "Move Text" || { echo "WARNING: could not tap Move Text"; }
+
+# Wait for animation to complete (400ms duration + settle time)
+sleep 3
+
+collect_logcat "ease-in-translate"
+
+# Assert the app started
+assert_logcat "$LOGCAT_FILE" "EaseInTranslateDemoMain started" "Demo app started"
+
+# Assert position change was logged
+assert_logcat "$LOGCAT_FILE" "Moved to position B" "Position B logged"
+
+# Assert the bridge received translate property updates
+assert_logcat "$LOGCAT_FILE" "setNumProp.*translateX" "translateX setNumProp called"
+assert_logcat "$LOGCAT_FILE" "setNumProp.*translateY" "translateY setNumProp called"
+
+# Verify no crash
+LOGCAT_ERR="$WORK_DIR/ease_in_translate_err.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:E' > "$LOGCAT_ERR" 2>&1 || true
+if grep -qE "$FATAL_PATTERNS" "$LOGCAT_ERR" 2>/dev/null; then
+    echo "FAIL: Fatal crash detected during ease-in translate test"
+    grep -E "$FATAL_PATTERNS" "$LOGCAT_ERR" | tail -10
+    EXIT_CODE=1
+else
+    echo "PASS: No crash during ease-in translate test"
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/android/ease-in-translate.sh
+++ b/test/android/ease-in-translate.sh
@@ -32,6 +32,10 @@ collect_logcat "ease-in-translate"
 # Assert the app started
 assert_logcat "$LOGCAT_FILE" "EaseInTranslateDemoMain started" "Demo app started"
 
+# Assert initial position was set on first render
+assert_logcat "$LOGCAT_FILE" "setNumProp.*translateX=0.0" "initial translateX=0.0"
+assert_logcat "$LOGCAT_FILE" "setNumProp.*translateY=0.0" "initial translateY=0.0"
+
 # Assert position change was logged
 assert_logcat "$LOGCAT_FILE" "Moved to position B" "Position B logged"
 

--- a/test/android/ease-in-translate.sh
+++ b/test/android/ease-in-translate.sh
@@ -35,9 +35,9 @@ assert_logcat "$LOGCAT_FILE" "EaseInTranslateDemoMain started" "Demo app started
 # Assert position change was logged
 assert_logcat "$LOGCAT_FILE" "Moved to position B" "Position B logged"
 
-# Assert the bridge received translate property updates
-assert_logcat "$LOGCAT_FILE" "setNumProp.*translateX" "translateX setNumProp called"
-assert_logcat "$LOGCAT_FILE" "setNumProp.*translateY" "translateY setNumProp called"
+# Assert the bridge received translate property updates with correct final position
+assert_logcat "$LOGCAT_FILE" "setNumProp.*translateX=120.0" "translateX reached 120.0"
+assert_logcat "$LOGCAT_FILE" "setNumProp.*translateY=80.0" "translateY reached 80.0"
 
 # Verify no crash
 LOGCAT_ERR="$WORK_DIR/ease_in_translate_err.txt"


### PR DESCRIPTION
## Summary
- New demo app (`EaseInTranslateDemoMain.hs`) that animates a text widget from (0,0) to (120,80) using EaseIn over 400ms
- Android emulator shell test (`ease-in-translate.sh`) asserts logcat for app startup, position change, and `setNumProp` bridge calls for translateX/translateY
- Wired into `emulator-all.nix` as Phase 22 with .so size guard

## Test plan
- [ ] CI passes the existing test suite (no regressions)
- [ ] Phase 22 passes on Android emulator: app starts, button tap triggers animation, logcat shows `setNumProp(translateX)` and `setNumProp(translateY)` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)