### PR TITLE
Fix first-render animation: register tween from zero origin

### DIFF
--- a/src/Hatter/Render.hs
+++ b/src/Hatter/Render.hs
@@ -30,7 +30,7 @@ import Data.IntSet qualified as IntSet
 import Data.Text (Text, pack)
 import Hatter.Action (Action(..), ActionState, OnChange(..), lookupAction, lookupTextAction)
 import Hatter.Animation (AnimationState, registerTween)
-import Hatter.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), LayoutItem(..), LayoutSettings(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex, normalizeAnimated, resolveKeyAtIndex)
+import Hatter.Widget (AnimatedConfig(..), ButtonConfig(..), FontConfig(..), ImageConfig(..), ImageSource(..), InputType(..), LayoutItem(..), LayoutSettings(..), MapViewConfig(..), ResourceName(..), ScaleType(..), TextAlignment(..), TextConfig(..), TextInputConfig(..), WebViewConfig(..), Widget(..), WidgetStyle(..), colorToHex, normalizeAnimated, resolveKeyAtIndex, zeroAnimationOrigin)
 
 import Hatter.UIBridge qualified as Bridge
 import System.IO (hPutStrLn, stderr)
@@ -269,10 +269,22 @@ createRenderedNode animState (Animated config child) = do
     Row _        -> createRenderedNode animState normalized
     Stack _      -> createRenderedNode animState normalized
     -- Everything else (Styled, leaves): wrap in RenderedAnimated for tween interpolation.
+    -- Create the native node at the zero-origin position and register a tween
+    -- from zero to the target, so the first render animates into place.
     _            -> do
       let finalWidget = Animated config normalized
-      childNode <- createRenderedNode animState normalized
-      pure (RenderedAnimated finalWidget childNode)
+          zeroOrigin = zeroAnimationOrigin normalized
+      childNode <- createRenderedNode animState zeroOrigin
+      if zeroOrigin /= normalized
+        then do
+          registerTween animState (renderedNodeId childNode)
+            zeroOrigin normalized (anDuration config) (anEasing config)
+          -- Store the target widget (not zero) so subsequent diffs see
+          -- the correct post-animation state.
+          let targetChildNode = updateRenderedTarget normalized childNode
+          pure (RenderedAnimated finalWidget targetChildNode)
+        else
+          pure (RenderedAnimated finalWidget childNode)
 
 -- ---------------------------------------------------------------------------
 -- Destroying rendered subtrees

--- a/src/Hatter/Widget.hs
+++ b/src/Hatter/Widget.hs
@@ -38,6 +38,7 @@ module Hatter.Widget
   , Easing(..)
   , AnimatedConfig(..)
   , normalizeAnimated
+  , zeroAnimationOrigin
   , interpolateColor
   , lerpWord8
   -- ** key resolution
@@ -276,6 +277,27 @@ normalizeAnimated _config other = other
 -- | Wrap a 'LayoutItem''s widget in 'Animated', preserving the key.
 wrapLayoutItemAnimated :: AnimatedConfig -> LayoutItem -> LayoutItem
 wrapLayoutItemAnimated config li = li { liWidget = Animated config (liWidget li) }
+
+-- | Produce the animation starting point for a first render.
+--
+-- Zeroes numeric style properties (padding, translateX, translateY) so
+-- the first render can animate FROM zero TO the target position.
+-- Non-numeric properties (colors, text-align, touch-passthrough) and
+-- non-'Styled' widgets are returned unchanged — they have no meaningful
+-- numeric zero to animate from.
+zeroAnimationOrigin :: Widget -> Widget
+zeroAnimationOrigin (Styled style child) = Styled (zeroNumericStyle style) child
+zeroAnimationOrigin other = other
+
+-- | Zero the numeric style properties that support interpolation.
+-- Replaces each 'Just' value with @Just 0@; leaves 'Nothing' fields
+-- unchanged so the interpolation engine correctly skips them.
+zeroNumericStyle :: WidgetStyle -> WidgetStyle
+zeroNumericStyle style = style
+  { wsPadding    = fmap (const 0) (wsPadding style)
+  , wsTranslateX = fmap (const 0) (wsTranslateX style)
+  , wsTranslateY = fmap (const 0) (wsTranslateY style)
+  }
 
 -- | How an image should be scaled within its bounds.
 data ScaleType

--- a/test/Test/AnimationTests.hs
+++ b/test/Test/AnimationTests.hs
@@ -27,7 +27,6 @@ import Hatter.Animation
 import Hatter.Render (RenderState(..), RenderedNode(..), newRenderState, renderWidget)
 import Hatter.Widget
   ( Color(..)
-  , LayoutItem(..)
   , LayoutSettings(..)
   , Widget(..)
   , WidgetStyle(..)
@@ -38,6 +37,7 @@ import Hatter.Widget
   , item
   , lerpWord8
   , normalizeAnimated
+  , zeroAnimationOrigin
   )
 
 animationTests :: TestTree
@@ -49,6 +49,8 @@ animationTests = testGroup "Animation"
   , animatedWidgetRenderTests
   , normalizeAnimatedTests
   , translateAnimationTests
+  , zeroAnimationOriginTests
+  , firstRenderAnimationTests
   ]
 
 -- ---------------------------------------------------------------------------
@@ -253,12 +255,12 @@ animatedWidgetRenderTests = testGroup "Animated widget rendering"
           widgetA = Animated (AnimatedConfig 500 Linear) styledA
           widgetB = Animated (AnimatedConfig 500 Linear) styledB
 
-      -- Render 1: initial state (padding=10)
+      -- Render 1: initial state (padding=10) — tween from zero origin (0→10)
       renderWidget rs widgetA
       tweensAfter1 <- readIORef (ansTweens animState)
-      assertBool "No tween after first render" (IntMap.null tweensAfter1)
+      assertBool "Tween registered after first render (0→10)" (not (IntMap.null tweensAfter1))
 
-      -- Render 2: change to padding=50 — tween should be registered
+      -- Render 2: change to padding=50 — tween replaced (10→50)
       renderWidget rs widgetB
       tweensAfter2 <- readIORef (ansTweens animState)
       assertBool "Tween registered after padding change (10→50)" (not (IntMap.null tweensAfter2))
@@ -348,6 +350,7 @@ normalizeAnimatedTests = testGroup "normalizeAnimated"
   , testCase "Animated Column renders as RenderedContainer with RenderedAnimated children" $ do
       animState <- newAnimationState
       writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
       actionState <- newActionState
       rs <- newRenderState actionState animState
       let cfg = AnimatedConfig 300 EaseOut
@@ -425,4 +428,85 @@ translateAnimationTests = testGroup "Translate animation"
       rs <- newRenderState actionState animState
       renderWidget rs $ Styled (defaultStyle { wsTranslateX = Just 10.5, wsTranslateY = Just (-20.0) })
         (Text TextConfig { tcLabel = "offset", tcFontConfig = Nothing })
+  ]
+
+-- ---------------------------------------------------------------------------
+-- zeroAnimationOrigin
+-- ---------------------------------------------------------------------------
+
+zeroAnimationOriginTests :: TestTree
+zeroAnimationOriginTests = testGroup "zeroAnimationOrigin"
+  [ testCase "Zeroes padding in Styled" $ do
+      let style = defaultStyle { wsPadding = Just 42 }
+          child = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          result = zeroAnimationOrigin (Styled style child)
+      result @?= Styled (defaultStyle { wsPadding = Just 0 }) child
+  , testCase "Zeroes translateX and translateY in Styled" $ do
+      let style = defaultStyle { wsTranslateX = Just 100, wsTranslateY = Just 50 }
+          child = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          result = zeroAnimationOrigin (Styled style child)
+      result @?= Styled (defaultStyle { wsTranslateX = Just 0, wsTranslateY = Just 0 }) child
+  , testCase "Preserves Nothing fields" $ do
+      let style = defaultStyle { wsTranslateX = Just 10 }
+          child = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          result = zeroAnimationOrigin (Styled style child)
+          expected = defaultStyle { wsTranslateX = Just 0 }
+      result @?= Styled expected child
+  , testCase "Preserves color fields unchanged" $ do
+      let color = Color 255 0 0 255
+          style = defaultStyle { wsTextColor = Just color, wsTranslateX = Just 50 }
+          child = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          result = zeroAnimationOrigin (Styled style child)
+          expected = defaultStyle { wsTextColor = Just color, wsTranslateX = Just 0 }
+      result @?= Styled expected child
+  , testCase "Non-Styled widget returned unchanged" $ do
+      let leaf = Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing }
+      zeroAnimationOrigin leaf @?= leaf
+  ]
+
+-- ---------------------------------------------------------------------------
+-- First-render animation
+-- ---------------------------------------------------------------------------
+
+firstRenderAnimationTests :: TestTree
+firstRenderAnimationTests = testGroup "First-render animation"
+  [ testCase "Animated Styled with translate registers tween on first render" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let style = defaultStyle { wsTranslateX = Just 120, wsTranslateY = Just 50 }
+          child = Text TextConfig { tcLabel = "*", tcFontConfig = Nothing }
+          widget = Animated (AnimatedConfig 1200 EaseOut) (Styled style child)
+      renderWidget rs widget
+      tweens <- readIORef (ansTweens animState)
+      assertBool "Tween registered on first render for translate" (not (IntMap.null tweens))
+  , testCase "Animated plain Text has no tween on first render" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let widget = Animated (AnimatedConfig 300 EaseOut)
+                     (Text TextConfig { tcLabel = "hello", tcFontConfig = Nothing })
+      renderWidget rs widget
+      tweens <- readIORef (ansTweens animState)
+      assertBool "No tween for plain Text (no animatable properties)" (IntMap.null tweens)
+  , testCase "First-render tween animates from zero to target" $ do
+      animState <- newAnimationState
+      writeIORef (ansContextPtr animState) nullPtr
+      writeIORef (ansLoopActive animState) True
+      actionState <- newActionState
+      rs <- newRenderState actionState animState
+      let style = defaultStyle { wsPadding = Just 20, wsTranslateX = Just 100 }
+          child = Text TextConfig { tcLabel = "x", tcFontConfig = Nothing }
+          widget = Animated (AnimatedConfig 500 Linear) (Styled style child)
+      renderWidget rs widget
+      tweens <- readIORef (ansTweens animState)
+      -- Verify the tween goes from zero to target
+      case IntMap.elems tweens of
+        [tween] -> do
+          atFromWidget tween @?= Styled (defaultStyle { wsPadding = Just 0, wsTranslateX = Just 0 }) child
+          atToWidget tween @?= Styled style child
+        other -> assertFailure ("Expected exactly one tween, got " ++ show (length other))
   ]


### PR DESCRIPTION
## Summary
- Fixes the confetti animation bug reproduced in #191: `Animated` wrapper now registers tweens on first render
- `createRenderedNode` creates native nodes at zero-origin position and tweens to target, instead of placing nodes at final position immediately
- Adds `zeroAnimationOrigin` function that zeroes numeric style properties (padding, translateX, translateY) for animation starting point
- Non-numeric properties (colors, text-align) and non-`Styled` widgets are unaffected — they have no meaningful zero to animate from

## Changed files
- `src/Hatter/Widget.hs` — new `zeroAnimationOrigin` and `zeroNumericStyle` functions
- `src/Hatter/Render.hs` — `createRenderedNode` Animated case now creates at zero, registers tween, stores target via `updateRenderedTarget`
- `test/Test/AnimationTests.hs` — updated toggle-back test assertion, added `zeroAnimationOrigin` and first-render animation test groups (8 new tests)

## Test plan
- [x] `cabal build` — no warnings
- [x] `cabal test` — all 42 animation tests pass (was 34)
- [x] `nix-build nix/ci.nix -A native` — passes
- [ ] Install confetti repro APK and verify particles animate from center

🤖 Generated with [Claude Code](https://claude.com/claude-code)