### PR TITLE
Add -split-sections + --gc-sections for Android .so builds

### DIFF
--- a/hatter.cabal
+++ b/hatter.cabal
@@ -73,7 +73,7 @@ common common-options
       ImportQualifiedPost
 
   ghc-options:
-    -O2 -Wall -Wincomplete-uni-patterns
+    -O2 -Wall -split-sections -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Widentities -Wredundant-constraints
     -Wcpp-undef -fwarn-tabs -Wpartial-fields
     -fdefer-diagnostics -Wunused-packages

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -464,7 +464,7 @@ in {
         # source tree, then add hatterObjs for pre-compiled interfaces and
         # current dir for consumer modules from extraModuleCopy.
         echo "=== Compiling Main.hs (using pre-compiled hatter objects) ==="
-        ${ghcCmd} -c -O2 \
+        ${ghcCmd} -c -O2 -split-sections \
           -I${hatterSrc}/include \
           ${builtins.concatStringsSep " " (map (d: "-I${d}") extraGhcIncludeDirs)} \
           ${if crossDeps != null then "-package-db ${crossDeps}/pkgdb -i${crossDeps}/hi" else ""} \
@@ -484,6 +484,7 @@ in {
           -optl-lffi \
           -optl-llog \
           -optl-Wl,-z,max-page-size=16384 \
+          -optl-Wl,--gc-sections \
           -optl$(pwd)/jni_bridge.o \
           -optl$(pwd)/ui_bridge_android.o \
           -optl$(pwd)/permission_bridge_android.o \
@@ -540,7 +541,7 @@ in {
           ${if crossDeps != null then "$(for a in ${crossDeps}/lib/*.a; do echo -n \"-optl$a \"; done)" else ""} \
           ${if crossDeps != null && builtins.pathExists "${crossDeps}/lib-boot" then "$(for a in ${crossDeps}/lib-boot/*.a; do echo -n \"-optl$a \"; done)" else ""}
         '' else ''
-        ${ghcCmd} -shared -O2 \
+        ${ghcCmd} -shared -O2 -split-sections \
           -o ${soName} \
           -I${hatterSrc}/include \
           ${builtins.concatStringsSep " " (map (d: "-I${d}") extraGhcIncludeDirs)} \
@@ -554,6 +555,7 @@ in {
           -optl-lffi \
           -optl-llog \
           -optl-Wl,-z,max-page-size=16384 \
+          -optl-Wl,--gc-sections \
           -optl$(pwd)/jni_bridge.o \
           -optl$(pwd)/ui_bridge_android.o \
           -optl$(pwd)/permission_bridge_android.o \


### PR DESCRIPTION
## Summary
- Add `-split-sections` to GHC flags in both `hatter.cabal` (library compilation) and `nix/lib.nix` (final link step), emitting each top-level binding into its own ELF section
- Add `--gc-sections` to the Android linker invocation, enabling the linker to trace reachability from the 19 `-u` entry points and discard all unreferenced sections
- Expected ~40-60% reduction in `.so` size (from ~80 MB to ~35-50 MB) as documented in `docs/so-size-reduction.md`

## Test plan
- [ ] CI Android APK builds succeed — install phase prints reduced stripped size
- [ ] All emulator tests pass (no missing symbol errors)
- [ ] CI size guard (120 MB hard fail) passes with increased margin

🤖 Generated with [Claude Code](https://claude.com/claude-code)