### PR TITLE
Add device info platform integration (#80)

### DIFF
--- a/cbits/device_info.c
+++ b/cbits/device_info.c
@@ -1,0 +1,70 @@
+/*
+ * Device information globals.
+ *
+ * Uses a set/get pattern: platform bridges call setDevice*() during
+ * initialization, and Haskell code reads values via getDevice*().
+ *
+ * Android: jni_bridge.c calls setters in JNI_OnLoad after querying
+ *          Build.MODEL, Build.VERSION.RELEASE, and DisplayMetrics.
+ * iOS:     UIBridgeIOS.m calls setters in setup_ios_platform_globals
+ *          after querying utsname, UIDevice, and UIScreen.
+ * Desktop: falls back to sensible defaults ("desktop", "unknown", etc.).
+ */
+
+#include <stddef.h>
+
+static const char *g_device_model = NULL;
+static const char *g_device_os_version = NULL;
+static const char *g_device_screen_density = NULL;
+static const char *g_device_screen_width = NULL;
+static const char *g_device_screen_height = NULL;
+
+void setDeviceModel(const char *value)
+{
+    g_device_model = value;  /* caller owns the memory (static/strdup'd) */
+}
+
+const char* getDeviceModel(void)
+{
+    return g_device_model ? g_device_model : "desktop";
+}
+
+void setDeviceOsVersion(const char *value)
+{
+    g_device_os_version = value;
+}
+
+const char* getDeviceOsVersion(void)
+{
+    return g_device_os_version ? g_device_os_version : "unknown";
+}
+
+void setDeviceScreenDensity(const char *value)
+{
+    g_device_screen_density = value;
+}
+
+const char* getDeviceScreenDensity(void)
+{
+    return g_device_screen_density ? g_device_screen_density : "1.0";
+}
+
+void setDeviceScreenWidth(const char *value)
+{
+    g_device_screen_width = value;
+}
+
+const char* getDeviceScreenWidth(void)
+{
+    return g_device_screen_width ? g_device_screen_width : "0";
+}
+
+void setDeviceScreenHeight(const char *value)
+{
+    g_device_screen_height = value;
+}
+
+const char* getDeviceScreenHeight(void)
+{
+    return g_device_screen_height ? g_device_screen_height : "0";
+}

--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -81,6 +81,16 @@ extern void haskellLogLocale(void);
 /* App files directory (cbits/files_dir.c) */
 extern void setAppFilesDir(const char *path);
 
+/* Device info (cbits/device_info.c) */
+extern void setDeviceModel(const char *value);
+extern void setDeviceOsVersion(const char *value);
+extern void setDeviceScreenDensity(const char *value);
+extern void setDeviceScreenWidth(const char *value);
+extern void setDeviceScreenHeight(const char *value);
+
+/* Log device info from Haskell (Hatter.DeviceInfo) */
+extern void haskellLogDeviceInfo(void);
+
 /* Haskell foreign exports */
 extern void haskellOnLifecycle(void *ctx, int eventType);
 extern void haskellRenderUI(void *ctx);

--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -9,6 +9,7 @@
  */
 
 #include <jni.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <android/log.h>
@@ -214,10 +215,64 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
                 (*env)->ReleaseStringUTFChars(env, jpath, cpath);
             }
         }
+
+        /* Device info: Build.MODEL */
+        {
+            jclass buildClass = (*env)->FindClass(env, "android/os/Build");
+            jfieldID modelField = (*env)->GetStaticFieldID(env, buildClass,
+                "MODEL", "Ljava/lang/String;");
+            jstring jmodel = (*env)->GetStaticObjectField(env, buildClass, modelField);
+            const char *cmodel = (*env)->GetStringUTFChars(env, jmodel, NULL);
+            setDeviceModel(strdup(cmodel));
+            (*env)->ReleaseStringUTFChars(env, jmodel, cmodel);
+        }
+
+        /* Device info: Build.VERSION.RELEASE */
+        {
+            jclass versionClass = (*env)->FindClass(env, "android/os/Build$VERSION");
+            jfieldID releaseField = (*env)->GetStaticFieldID(env, versionClass,
+                "RELEASE", "Ljava/lang/String;");
+            jstring jrelease = (*env)->GetStaticObjectField(env, versionClass, releaseField);
+            const char *crelease = (*env)->GetStringUTFChars(env, jrelease, NULL);
+            setDeviceOsVersion(strdup(crelease));
+            (*env)->ReleaseStringUTFChars(env, jrelease, crelease);
+        }
+
+        /* Device info: DisplayMetrics (density, width, height) */
+        {
+            jclass resourcesClass = (*env)->FindClass(env, "android/content/res/Resources");
+            jmethodID getSystem = (*env)->GetStaticMethodID(env, resourcesClass,
+                "getSystem", "()Landroid/content/res/Resources;");
+            jobject resources = (*env)->CallStaticObjectMethod(env, resourcesClass, getSystem);
+            jmethodID getDisplayMetrics = (*env)->GetMethodID(env, resourcesClass,
+                "getDisplayMetrics", "()Landroid/util/DisplayMetrics;");
+            jobject metrics = (*env)->CallObjectMethod(env, resources, getDisplayMetrics);
+
+            jclass dmClass = (*env)->FindClass(env, "android/util/DisplayMetrics");
+
+            jfieldID densityField = (*env)->GetFieldID(env, dmClass, "density", "F");
+            float density = (*env)->GetFloatField(env, metrics, densityField);
+            char densityBuf[32];
+            snprintf(densityBuf, sizeof(densityBuf), "%.2f", density);
+            setDeviceScreenDensity(strdup(densityBuf));
+
+            jfieldID widthField = (*env)->GetFieldID(env, dmClass, "widthPixels", "I");
+            int width = (*env)->GetIntField(env, metrics, widthField);
+            char widthBuf[32];
+            snprintf(widthBuf, sizeof(widthBuf), "%d", width);
+            setDeviceScreenWidth(strdup(widthBuf));
+
+            jfieldID heightField = (*env)->GetFieldID(env, dmClass, "heightPixels", "I");
+            int height = (*env)->GetIntField(env, metrics, heightField);
+            char heightBuf[32];
+            snprintf(heightBuf, sizeof(heightBuf), "%d", height);
+            setDeviceScreenHeight(strdup(heightBuf));
+        }
     }
 
     g_haskell_ctx = haskellRunMain();
     haskellLogLocale();
+    haskellLogDeviceInfo();
 
     return JNI_VERSION_1_6;
 }

--- a/hatter.cabal
+++ b/hatter.cabal
@@ -111,6 +111,7 @@ library
       Hatter.Http
       Hatter.NetworkStatus
       Hatter.FilesDir
+      Hatter.DeviceInfo
   hs-source-dirs:
       src
   build-depends:
@@ -137,6 +138,7 @@ library
       cbits/animation_bridge.c
       cbits/redraw_bridge.c
       cbits/files_dir.c
+      cbits/device_info.c
   include-dirs:
       include
 
@@ -200,6 +202,16 @@ executable confetti-repro-demo
       hatter,
       text
 
+executable device-info-demo
+  import: common-options
+  main-is: DeviceInfoDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
 test-suite unit
   import: common-options
   type: exitcode-stdio-1.0
@@ -213,6 +225,7 @@ test-suite unit
       Test.ActionTests
       Test.AnimationTests
       Test.FilesDirTests
+      Test.DeviceInfoTests
   ghc-options: -Wno-unused-packages -threaded -rtsopts "-with-rtsopts=-N -M7G -T -Iw10"
   hs-source-dirs:
       test

--- a/include/Hatter.h
+++ b/include/Hatter.h
@@ -67,6 +67,42 @@ void setAppFilesDir(const char *path);
  * or falls back to "." (current directory) on desktop. */
 const char* getAppFilesDir(void);
 
+/* Set the device model string. Called by platform bridges during init,
+ * before haskellRunMain(). The caller owns the memory (must be strdup'd). */
+void setDeviceModel(const char *value);
+
+/* Get the device model string. Returns the value set by setDeviceModel(),
+ * or falls back to "desktop". */
+const char* getDeviceModel(void);
+
+/* Set the OS version string. Called by platform bridges during init. */
+void setDeviceOsVersion(const char *value);
+
+/* Get the OS version string, or "unknown" on desktop. */
+const char* getDeviceOsVersion(void);
+
+/* Set the screen density string. Called by platform bridges during init. */
+void setDeviceScreenDensity(const char *value);
+
+/* Get the screen density string, or "1.0" on desktop. */
+const char* getDeviceScreenDensity(void);
+
+/* Set the screen width (pixels) as a string. */
+void setDeviceScreenWidth(const char *value);
+
+/* Get the screen width string, or "0" on desktop. */
+const char* getDeviceScreenWidth(void);
+
+/* Set the screen height (pixels) as a string. */
+void setDeviceScreenHeight(const char *value);
+
+/* Get the screen height string, or "0" on desktop. */
+const char* getDeviceScreenHeight(void);
+
+/* Log all device info fields via platformLog.
+ * Called from platform bridges after setDevice*() calls. */
+void haskellLogDeviceInfo(void);
+
 /* Dispatch a permission result from native code back to Haskell.
  * requestId: opaque ID from the original permission_request() call.
  * statusCode: PERMISSION_GRANTED (0) or PERMISSION_DENIED (1).

--- a/ios/Hatter/UIBridgeIOS.m
+++ b/ios/Hatter/UIBridgeIOS.m
@@ -13,6 +13,7 @@
 #import <MapKit/MapKit.h>
 #import <os/log.h>
 #import <objc/runtime.h>
+#include <sys/utsname.h>
 #include <stdlib.h>
 #include <string.h>
 #include "UIBridge.h"
@@ -878,6 +879,32 @@ void setup_ios_platform_globals(void)
                 withIntermediateDirectories:YES attributes:nil error:nil];
             setAppFilesDir(strdup([appSupport UTF8String]));
         }
+    }
+
+    /* Device info */
+    {
+        struct utsname systemInfo;
+        uname(&systemInfo);
+        setDeviceModel(strdup(systemInfo.machine));
+
+        NSString *osVer = [[UIDevice currentDevice] systemVersion];
+        setDeviceOsVersion(strdup([osVer UTF8String]));
+
+        CGFloat scale = [[UIScreen mainScreen] scale];
+        CGFloat pixelWidth = [UIScreen mainScreen].bounds.size.width * scale;
+        CGFloat pixelHeight = [UIScreen mainScreen].bounds.size.height * scale;
+
+        char densityBuf[32];
+        snprintf(densityBuf, sizeof(densityBuf), "%.1f", (double)scale);
+        setDeviceScreenDensity(strdup(densityBuf));
+
+        char widthBuf[32];
+        snprintf(widthBuf, sizeof(widthBuf), "%d", (int)pixelWidth);
+        setDeviceScreenWidth(strdup(widthBuf));
+
+        char heightBuf[32];
+        snprintf(heightBuf, sizeof(heightBuf), "%d", (int)pixelHeight);
+        setDeviceScreenHeight(strdup(heightBuf));
     }
 }
 

--- a/ios/Hatter/UIBridgeIOS.m
+++ b/ios/Hatter/UIBridgeIOS.m
@@ -74,6 +74,13 @@ extern void setSystemLocale(const char *locale);
 /* App files directory (cbits/files_dir.c) */
 extern void setAppFilesDir(const char *path);
 
+/* Device info (cbits/device_info.c) */
+extern void setDeviceModel(const char *value);
+extern void setDeviceOsVersion(const char *value);
+extern void setDeviceScreenDensity(const char *value);
+extern void setDeviceScreenWidth(const char *value);
+extern void setDeviceScreenHeight(const char *value);
+
 /* ---- Global state (valid only on the main thread) ---- */
 static UIViewController *g_viewController = nil;
 

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -262,6 +262,17 @@ let
     name = "hatter-filesdir-apk";
   };
 
+  deviceInfoAndroid = import ./android.nix {
+    inherit sources androidArch;
+    mainModule = ../test/DeviceInfoDemoMain.hs;
+  };
+  deviceInfoApk = lib.mkApk {
+    sharedLibs = [{ lib = deviceInfoAndroid; inherit abiDir; }];
+    androidSrc = ../android;
+    apkName = "hatter-deviceinfo.apk";
+    name = "hatter-deviceinfo-apk";
+  };
+
   textinputRerenderAndroid = import ./android.nix {
     inherit sources androidArch;
     mainModule = ../test/TextInputReRenderDemoMain.hs;
@@ -420,6 +431,7 @@ NETWORK_STATUS_APK="${networkStatusApk}/hatter-networkstatus.apk"
 MAPVIEW_APK="${mapviewApk}/hatter-mapview.apk"
 ANIMATION_APK="${animationApk}/hatter-animation.apk"
 FILES_DIR_APK="${filesDirApk}/hatter-filesdir.apk"
+DEVICE_INFO_APK="${deviceInfoApk}/hatter-deviceinfo.apk"
 TEXTINPUT_RERENDER_APK="${textinputRerenderApk}/hatter-textinput-rerender.apk"
 STACK_APK="${stackApk}/hatter-stack.apk"
 SCROLLVIEW_SWITCH_APK="${scrollviewSwitchApk}/hatter-scrollview-switch.apk"
@@ -459,6 +471,7 @@ for so_path in \
     "${mapviewAndroid}/lib/${abiDir}/libhatter.so" \
     "${animationAndroid}/lib/${abiDir}/libhatter.so" \
     "${filesDirAndroid}/lib/${abiDir}/libhatter.so" \
+    "${deviceInfoAndroid}/lib/${abiDir}/libhatter.so" \
     "${textinputRerenderAndroid}/lib/${abiDir}/libhatter.so" \
     "${stackAndroid}/lib/${abiDir}/libhatter.so" \
     "${styledTypeChangeAndroid}/lib/${abiDir}/libhatter.so" \
@@ -674,7 +687,7 @@ done
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK REDRAW_APK CONFETTI_REPRO_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK FILES_DIR_APK DEVICE_INFO_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK REDRAW_APK CONFETTI_REPRO_APK PACKAGE ACTIVITY WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -698,6 +711,7 @@ PHASE19_EXIT=0
 PHASE20_EXIT=0
 PHASE21_EXIT=0
 PHASE23_EXIT=0
+PHASE24_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -778,6 +792,8 @@ echo "--- animation ---"
 run_with_retry "animation" bash "$TEST_SCRIPTS/android/animation.sh" || PHASE13_EXIT=1
 echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/android/filesdir.sh" || PHASE14_EXIT=1
+echo "--- deviceinfo ---"
+run_with_retry "deviceinfo" bash "$TEST_SCRIPTS/android/deviceinfo.sh" || PHASE24_EXIT=1
 echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/android/textinput_rerender.sh" || PHASE15_EXIT=1
 echo "--- stack ---"
@@ -1014,6 +1030,16 @@ else
     echo "PHASE 23 FAILED"
 fi
 
+if [ $PHASE24_EXIT -eq 0 ]; then
+    PHASE24_OK=1
+    echo ""
+    echo "PHASE 24 PASSED"
+else
+    PHASE24_OK=0
+    echo ""
+    echo "PHASE 24 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -1175,6 +1201,13 @@ if [ $PHASE23_OK -eq 1 ]; then
     echo "PASS  Phase 23 — Confetti animation reproducer (first-render no-tween bug)"
 else
     echo "FAIL  Phase 23 — Confetti animation reproducer (first-render no-tween bug)"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE24_OK -eq 1 ]; then
+    echo "PASS  Phase 24 — DeviceInfo demo app"
+else
+    echo "FAIL  Phase 24 — DeviceInfo demo app"
     FINAL_EXIT=1
 fi
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -594,6 +594,7 @@ in {
         cp ${hatterSrc}/src/Hatter/AppContext.hs Hatter/
         cp ${hatterSrc}/src/Hatter/Animation.hs Hatter/
         cp ${hatterSrc}/src/Hatter/FilesDir.hs Hatter/
+        cp ${hatterSrc}/src/Hatter/DeviceInfo.hs Hatter/
         cp ${hatterSrc}/src/Hatter.hs .
 
         # Extra module copies
@@ -621,6 +622,7 @@ in {
         cp ${hatterSrc}/cbits/animation_bridge.c cbits/
         cp ${hatterSrc}/cbits/redraw_bridge.c cbits/
         cp ${hatterSrc}/cbits/files_dir.c cbits/
+        cp ${hatterSrc}/cbits/device_info.c cbits/
 
         ghc -staticlib \
           -O2 \
@@ -646,6 +648,7 @@ in {
           -optl-Wl,-u,_haskellOnHttpResult \
           -optl-Wl,-u,_haskellOnNetworkStatusChange \
           -optl-Wl,-u,_haskellLogLocale \
+          -optl-Wl,-u,_haskellLogDeviceInfo \
           cbits/platform_log.c \
           cbits/ui_bridge.c \
           cbits/run_main.c \
@@ -664,6 +667,7 @@ in {
           cbits/animation_bridge.c \
           cbits/redraw_bridge.c \
           cbits/files_dir.c \
+          cbits/device_info.c \
           Main.hs \
           Hatter.hs
       '';
@@ -817,6 +821,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${hatterSrc}/src/Hatter/AppContext.hs Hatter/
         cp ${hatterSrc}/src/Hatter/Animation.hs Hatter/
         cp ${hatterSrc}/src/Hatter/FilesDir.hs Hatter/
+        cp ${hatterSrc}/src/Hatter/DeviceInfo.hs Hatter/
         cp ${hatterSrc}/src/Hatter.hs .
 
         # Extra module copies
@@ -844,6 +849,7 @@ open(sys.argv[1], "w").write(yml)
         cp ${hatterSrc}/cbits/animation_bridge.c cbits/
         cp ${hatterSrc}/cbits/redraw_bridge.c cbits/
         cp ${hatterSrc}/cbits/files_dir.c cbits/
+        cp ${hatterSrc}/cbits/device_info.c cbits/
 
         ghc -staticlib \
           -O2 \
@@ -869,6 +875,7 @@ open(sys.argv[1], "w").write(yml)
           -optl-Wl,-u,_haskellOnHttpResult \
           -optl-Wl,-u,_haskellOnNetworkStatusChange \
           -optl-Wl,-u,_haskellLogLocale \
+          -optl-Wl,-u,_haskellLogDeviceInfo \
           cbits/platform_log.c \
           cbits/ui_bridge.c \
           cbits/run_main.c \
@@ -887,6 +894,7 @@ open(sys.argv[1], "w").write(yml)
           cbits/animation_bridge.c \
           cbits/redraw_bridge.c \
           cbits/files_dir.c \
+          cbits/device_info.c \
           Main.hs \
           Hatter.hs
       '';

--- a/nix/simulator-all.nix
+++ b/nix/simulator-all.nix
@@ -241,6 +241,17 @@ let
     name = "hatter-filesdir-simulator-app";
   };
 
+  deviceInfoIos = import ./ios.nix {
+    inherit sources;
+    mainModule = ../test/DeviceInfoDemoMain.hs;
+    simulator = true;
+  };
+  deviceInfoSimApp = lib.mkSimulatorApp {
+    iosLib = deviceInfoIos;
+    iosSrc = ../ios;
+    name = "hatter-deviceinfo-simulator-app";
+  };
+
   textinputRerenderIos = import ./ios.nix {
     inherit sources;
     mainModule = ../test/TextInputReRenderDemoMain.hs;
@@ -336,6 +347,7 @@ NETWORK_STATUS_SHARE_DIR="${networkStatusSimApp}/share/ios"
 MAPVIEW_SHARE_DIR="${mapviewSimApp}/share/ios"
 ANIMATION_SHARE_DIR="${animationSimApp}/share/ios"
 FILES_DIR_SHARE_DIR="${filesDirSimApp}/share/ios"
+DEVICE_INFO_SHARE_DIR="${deviceInfoSimApp}/share/ios"
 TEXTINPUT_RERENDER_SHARE_DIR="${textinputRerenderSimApp}/share/ios"
 STACK_SHARE_DIR="${stackSimApp}/share/ios"
 STYLED_TYPE_CHANGE_SHARE_DIR="${styledTypeChangeSimApp}/share/ios"
@@ -368,6 +380,7 @@ PHASE17_OK=0
 PHASE18_OK=0
 PHASE19_OK=0
 PHASE20_OK=0
+PHASE21_OK=0
 
 cleanup() {
     echo ""
@@ -1380,6 +1393,53 @@ if [ -z "$FILES_DIR_APP" ]; then
 fi
 echo "FilesDir app: $FILES_DIR_APP"
 
+# --- Stage and build deviceinfo demo app ---
+echo "=== Staging deviceinfo demo app ==="
+mkdir -p "$WORK_DIR/deviceinfo/lib" "$WORK_DIR/deviceinfo/include"
+cp "$DEVICE_INFO_SHARE_DIR/lib/libHatter.a" "$WORK_DIR/deviceinfo/lib/"
+cp "$DEVICE_INFO_SHARE_DIR/include/Hatter.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/UIBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/PermissionBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/SecureStorageBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/BleBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/DialogBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/LocationBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/AuthSessionBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/PlatformSignInBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/CameraBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/BottomSheetBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/HttpBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/NetworkStatusBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/AnimationBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp "$DEVICE_INFO_SHARE_DIR/include/RedrawBridge.h" "$WORK_DIR/deviceinfo/include/"
+cp -r "$DEVICE_INFO_SHARE_DIR/Hatter" "$WORK_DIR/deviceinfo/"
+cp "$DEVICE_INFO_SHARE_DIR/project.yml" "$WORK_DIR/deviceinfo/"
+chmod -R u+w "$WORK_DIR/deviceinfo"
+
+echo "=== Generating deviceinfo Xcode project ==="
+cd "$WORK_DIR/deviceinfo"
+${xcodegen}/bin/xcodegen generate
+
+echo "=== Building deviceinfo demo app for simulator ==="
+xcodebuild build \
+    -project Hatter.xcodeproj \
+    -scheme "$SCHEME" \
+    -sdk iphonesimulator \
+    -configuration Release \
+    -derivedDataPath "$WORK_DIR/deviceinfo-build" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    | tail -20
+
+DEVICE_INFO_APP=$(find "$WORK_DIR/deviceinfo-build" -name "*.app" -type d | head -1)
+if [ -z "$DEVICE_INFO_APP" ]; then
+    echo "ERROR: Could not find deviceinfo .app bundle"
+    exit 1
+fi
+echo "DeviceInfo app: $DEVICE_INFO_APP"
+
 # --- Stage and build textinput-rerender demo app ---
 echo "=== Staging textinput-rerender demo app ==="
 mkdir -p "$WORK_DIR/textinput-rerender/lib" "$WORK_DIR/textinput-rerender/include"
@@ -1584,7 +1644,7 @@ sleep 2
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP TEXTINPUT_RERENDER_APP STACK_APP STYLED_TYPE_CHANGE_APP HORIZONTAL_SCROLL_APP REDRAW_APP WORK_DIR
+export SIM_UDID BUNDLE_ID COUNTER_APP SCROLL_APP TEXTINPUT_APP PERMISSION_APP SECURE_STORAGE_APP IMAGE_APP NODEPOOL_APP BLE_APP DIALOG_APP LOCATION_APP WEBVIEW_APP AUTH_SESSION_APP PLATFORM_SIGN_IN_APP CAMERA_APP BOTTOM_SHEET_APP HTTP_APP NETWORK_STATUS_APP MAPVIEW_APP ANIMATION_APP FILES_DIR_APP DEVICE_INFO_APP TEXTINPUT_RERENDER_APP STACK_APP STYLED_TYPE_CHANGE_APP HORIZONTAL_SCROLL_APP REDRAW_APP WORK_DIR
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0
@@ -1606,6 +1666,7 @@ PHASE17_EXIT=0
 PHASE18_EXIT=0
 PHASE19_EXIT=0
 PHASE20_EXIT=0
+PHASE21_EXIT=0
 
 # run_with_retry LABEL COMMAND [ARGS...]
 # Runs the command up to 10 times. Succeeds on first pass, fails only if all 10 fail.
@@ -1685,6 +1746,8 @@ echo "--- animation ---"
 run_with_retry "animation" bash "$TEST_SCRIPTS/ios/animation.sh" || PHASE13_EXIT=1
 echo "--- filesdir ---"
 run_with_retry "filesdir" bash "$TEST_SCRIPTS/ios/filesdir.sh" || PHASE14_EXIT=1
+echo "--- deviceinfo ---"
+run_with_retry "deviceinfo" bash "$TEST_SCRIPTS/ios/deviceinfo.sh" || PHASE21_EXIT=1
 echo "--- textinput_rerender ---"
 run_with_retry "textinput_rerender" bash "$TEST_SCRIPTS/ios/textinput_rerender.sh" || PHASE15_EXIT=1
 echo "--- stack ---"
@@ -1905,6 +1968,16 @@ else
     echo "PHASE 20 FAILED"
 fi
 
+if [ $PHASE21_EXIT -eq 0 ]; then
+    PHASE21_OK=1
+    echo ""
+    echo "PHASE 21 PASSED"
+else
+    PHASE21_OK=0
+    echo ""
+    echo "PHASE 21 FAILED"
+fi
+
 # ===========================================================================
 # Final report
 # ===========================================================================
@@ -2052,6 +2125,13 @@ if [ $PHASE20_OK -eq 1 ]; then
     echo "PASS  Phase 20 — XCUITest counter app"
 else
     echo "FAIL  Phase 20 — XCUITest counter app"
+    FINAL_EXIT=1
+fi
+
+if [ $PHASE21_OK -eq 1 ]; then
+    echo "PASS  Phase 21 — DeviceInfo demo app"
+else
+    echo "FAIL  Phase 21 — DeviceInfo demo app"
     FINAL_EXIT=1
 fi
 

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -153,6 +153,7 @@ import Hatter.Lifecycle
   , lifecycleFromInt
   )
 import Hatter.Locale ()  -- for foreign export ccall haskellLogLocale
+import Hatter.DeviceInfo ()  -- for foreign export ccall haskellLogDeviceInfo
 import Hatter.Location (dispatchLocationUpdate)
 import Hatter.NetworkStatus (dispatchNetworkStatusChange)
 import Hatter.Permission (dispatchPermissionResult)

--- a/src/Hatter/DeviceInfo.hs
+++ b/src/Hatter/DeviceInfo.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Hatter.DeviceInfo
+  ( DeviceInfo(..)
+  , getDeviceInfo
+  , haskellLogDeviceInfo
+  ) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Foreign.C.String (CString, peekCString)
+import Hatter.Lifecycle (platformLog)
+
+-- | Device information collected from the host platform.
+--
+-- All fields are 'Text' — numeric values (density, dimensions) are
+-- stored as string representations so the consumer can parse as needed.
+data DeviceInfo = DeviceInfo
+  { diModel         :: Text  -- ^ Device model name (e.g. @\"Pixel 7\"@, @\"iPhone15,2\"@)
+  , diOsVersion     :: Text  -- ^ OS version string (e.g. @\"14\"@, @\"17.0\"@)
+  , diScreenDensity :: Text  -- ^ Screen density / scale factor (e.g. @\"2.75\"@, @\"3.0\"@)
+  , diScreenWidth   :: Text  -- ^ Screen width in physical pixels (e.g. @\"1080\"@)
+  , diScreenHeight  :: Text  -- ^ Screen height in physical pixels (e.g. @\"2400\"@)
+  } deriving (Show, Eq)
+
+foreign import ccall "getDeviceModel" c_getDeviceModel :: IO CString
+foreign import ccall "getDeviceOsVersion" c_getDeviceOsVersion :: IO CString
+foreign import ccall "getDeviceScreenDensity" c_getDeviceScreenDensity :: IO CString
+foreign import ccall "getDeviceScreenWidth" c_getDeviceScreenWidth :: IO CString
+foreign import ccall "getDeviceScreenHeight" c_getDeviceScreenHeight :: IO CString
+
+-- | Query all device information from the host platform.
+--
+-- * Android: values set from @Build.MODEL@, @Build.VERSION.RELEASE@, @DisplayMetrics@
+-- * iOS: values set from @utsname@, @UIDevice@, @UIScreen@
+-- * Desktop: returns fallback values (@\"desktop\"@, @\"unknown\"@, @\"1.0\"@, @\"0\"@, @\"0\"@)
+getDeviceInfo :: IO DeviceInfo
+getDeviceInfo = do
+  model         <- peekText =<< c_getDeviceModel
+  osVersion     <- peekText =<< c_getDeviceOsVersion
+  screenDensity <- peekText =<< c_getDeviceScreenDensity
+  screenWidth   <- peekText =<< c_getDeviceScreenWidth
+  screenHeight  <- peekText =<< c_getDeviceScreenHeight
+  pure DeviceInfo
+    { diModel         = model
+    , diOsVersion     = osVersion
+    , diScreenDensity = screenDensity
+    , diScreenWidth   = screenWidth
+    , diScreenHeight  = screenHeight
+    }
+
+-- | Log all device info fields via 'platformLog'.
+-- Called from platform bridges after device info setters are invoked.
+haskellLogDeviceInfo :: IO ()
+haskellLogDeviceInfo = do
+  info <- getDeviceInfo
+  platformLog ("DeviceInfo model: " <> diModel info)
+  platformLog ("DeviceInfo osVersion: " <> diOsVersion info)
+  platformLog ("DeviceInfo screenDensity: " <> diScreenDensity info)
+  platformLog ("DeviceInfo screenWidth: " <> diScreenWidth info)
+  platformLog ("DeviceInfo screenHeight: " <> diScreenHeight info)
+
+foreign export ccall haskellLogDeviceInfo :: IO ()
+
+-- | Peek a CString into Text.
+peekText :: CString -> IO Text
+peekText cstr = Text.pack <$> peekCString cstr

--- a/src/Hatter/DeviceInfo.hs
+++ b/src/Hatter/DeviceInfo.hs
@@ -10,17 +10,15 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Foreign.C.String (CString, peekCString)
 import Hatter.Lifecycle (platformLog)
+import Text.Read (readMaybe)
 
 -- | Device information collected from the host platform.
---
--- All fields are 'Text' — numeric values (density, dimensions) are
--- stored as string representations so the consumer can parse as needed.
 data DeviceInfo = DeviceInfo
-  { diModel         :: Text  -- ^ Device model name (e.g. @\"Pixel 7\"@, @\"iPhone15,2\"@)
-  , diOsVersion     :: Text  -- ^ OS version string (e.g. @\"14\"@, @\"17.0\"@)
-  , diScreenDensity :: Text  -- ^ Screen density / scale factor (e.g. @\"2.75\"@, @\"3.0\"@)
-  , diScreenWidth   :: Text  -- ^ Screen width in physical pixels (e.g. @\"1080\"@)
-  , diScreenHeight  :: Text  -- ^ Screen height in physical pixels (e.g. @\"2400\"@)
+  { diModel         :: Text    -- ^ Device model name (e.g. @\"Pixel 7\"@, @\"iPhone15,2\"@)
+  , diOsVersion     :: Text    -- ^ OS version string (e.g. @\"14\"@, @\"17.0\"@)
+  , diScreenDensity :: Double  -- ^ Screen density / scale factor (e.g. @2.75@, @3.0@)
+  , diScreenWidth   :: Int     -- ^ Screen width in physical pixels (e.g. @1080@)
+  , diScreenHeight  :: Int     -- ^ Screen height in physical pixels (e.g. @2400@)
   } deriving (Show, Eq)
 
 foreign import ccall "getDeviceModel" c_getDeviceModel :: IO CString
@@ -33,20 +31,20 @@ foreign import ccall "getDeviceScreenHeight" c_getDeviceScreenHeight :: IO CStri
 --
 -- * Android: values set from @Build.MODEL@, @Build.VERSION.RELEASE@, @DisplayMetrics@
 -- * iOS: values set from @utsname@, @UIDevice@, @UIScreen@
--- * Desktop: returns fallback values (@\"desktop\"@, @\"unknown\"@, @\"1.0\"@, @\"0\"@, @\"0\"@)
+-- * Desktop: returns fallback values (@\"desktop\"@, @\"unknown\"@, @1.0@, @0@, @0@)
 getDeviceInfo :: IO DeviceInfo
 getDeviceInfo = do
   model         <- peekText =<< c_getDeviceModel
   osVersion     <- peekText =<< c_getDeviceOsVersion
-  screenDensity <- peekText =<< c_getDeviceScreenDensity
-  screenWidth   <- peekText =<< c_getDeviceScreenWidth
-  screenHeight  <- peekText =<< c_getDeviceScreenHeight
+  densityStr    <- peekString =<< c_getDeviceScreenDensity
+  widthStr      <- peekString =<< c_getDeviceScreenWidth
+  heightStr     <- peekString =<< c_getDeviceScreenHeight
   pure DeviceInfo
     { diModel         = model
     , diOsVersion     = osVersion
-    , diScreenDensity = screenDensity
-    , diScreenWidth   = screenWidth
-    , diScreenHeight  = screenHeight
+    , diScreenDensity = parseDouble densityStr
+    , diScreenWidth   = parseInt widthStr
+    , diScreenHeight  = parseInt heightStr
     }
 
 -- | Log all device info fields via 'platformLog'.
@@ -56,12 +54,28 @@ haskellLogDeviceInfo = do
   info <- getDeviceInfo
   platformLog ("DeviceInfo model: " <> diModel info)
   platformLog ("DeviceInfo osVersion: " <> diOsVersion info)
-  platformLog ("DeviceInfo screenDensity: " <> diScreenDensity info)
-  platformLog ("DeviceInfo screenWidth: " <> diScreenWidth info)
-  platformLog ("DeviceInfo screenHeight: " <> diScreenHeight info)
+  platformLog ("DeviceInfo screenDensity: " <> Text.pack (show (diScreenDensity info)))
+  platformLog ("DeviceInfo screenWidth: " <> Text.pack (show (diScreenWidth info)))
+  platformLog ("DeviceInfo screenHeight: " <> Text.pack (show (diScreenHeight info)))
 
 foreign export ccall haskellLogDeviceInfo :: IO ()
 
 -- | Peek a CString into Text.
 peekText :: CString -> IO Text
 peekText cstr = Text.pack <$> peekCString cstr
+
+-- | Peek a CString into String.
+peekString :: CString -> IO String
+peekString = peekCString
+
+-- | Parse a Double from a string, defaulting to 0.0.
+parseDouble :: String -> Double
+parseDouble str = case readMaybe str of
+  Just value -> value
+  Nothing    -> 0.0
+
+-- | Parse an Int from a string, defaulting to 0.
+parseInt :: String -> Int
+parseInt str = case readMaybe str of
+  Just value -> value
+  Nothing    -> 0

--- a/test/DeviceInfoDemoMain.hs
+++ b/test/DeviceInfoDemoMain.hs
@@ -7,6 +7,7 @@
 module Main where
 
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
@@ -33,9 +34,9 @@ main = do
   info <- getDeviceInfo
   platformLog ("DeviceInfo model: " <> diModel info)
   platformLog ("DeviceInfo osVersion: " <> diOsVersion info)
-  platformLog ("DeviceInfo screenDensity: " <> diScreenDensity info)
-  platformLog ("DeviceInfo screenWidth: " <> diScreenWidth info)
-  platformLog ("DeviceInfo screenHeight: " <> diScreenHeight info)
+  platformLog ("DeviceInfo screenDensity: " <> Text.pack (show (diScreenDensity info)))
+  platformLog ("DeviceInfo screenWidth: " <> Text.pack (show (diScreenWidth info)))
+  platformLog ("DeviceInfo screenHeight: " <> Text.pack (show (diScreenHeight info)))
 
   pure ctxPtr
 
@@ -46,9 +47,9 @@ deviceInfoDemoView = do
   pure $ column
     [ infoRow "Model" (diModel info)
     , infoRow "OS Version" (diOsVersion info)
-    , infoRow "Density" (diScreenDensity info)
-    , infoRow "Width" (diScreenWidth info)
-    , infoRow "Height" (diScreenHeight info)
+    , infoRow "Density" (Text.pack (show (diScreenDensity info)))
+    , infoRow "Width" (Text.pack (show (diScreenWidth info)))
+    , infoRow "Height" (Text.pack (show (diScreenHeight info)))
     ]
 
 -- | A text widget showing a label-value pair.

--- a/test/DeviceInfoDemoMain.hs
+++ b/test/DeviceInfoDemoMain.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Mobile entry point for the device-info-demo test app.
+--
+-- Used by the emulator and simulator device info integration tests.
+-- After the platform bridge is initialised (via startMobileApp), retrieves
+-- the device information and logs each field.
+module Main where
+
+import Data.Text (Text)
+import Foreign.Ptr (Ptr)
+import Hatter
+  ( MobileApp(..)
+  , startMobileApp
+  , platformLog
+  , loggingMobileContext
+  , newActionState
+  )
+import Hatter.AppContext (AppContext)
+import Hatter.DeviceInfo (DeviceInfo(..), getDeviceInfo)
+import Hatter.Widget (TextConfig(..), Widget(..), column)
+
+main :: IO (Ptr AppContext)
+main = do
+  actionState <- newActionState
+
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \_userState -> deviceInfoDemoView
+    , maActionState = actionState
+    }
+  platformLog "DeviceInfo demo app registered"
+
+  info <- getDeviceInfo
+  platformLog ("DeviceInfo model: " <> diModel info)
+  platformLog ("DeviceInfo osVersion: " <> diOsVersion info)
+  platformLog ("DeviceInfo screenDensity: " <> diScreenDensity info)
+  platformLog ("DeviceInfo screenWidth: " <> diScreenWidth info)
+  platformLog ("DeviceInfo screenHeight: " <> diScreenHeight info)
+
+  pure ctxPtr
+
+-- | Displays device info fields in a column.
+deviceInfoDemoView :: IO Widget
+deviceInfoDemoView = do
+  info <- getDeviceInfo
+  pure $ column
+    [ infoRow "Model" (diModel info)
+    , infoRow "OS Version" (diOsVersion info)
+    , infoRow "Density" (diScreenDensity info)
+    , infoRow "Width" (diScreenWidth info)
+    , infoRow "Height" (diScreenHeight info)
+    ]
+
+-- | A text widget showing a label-value pair.
+infoRow :: Text -> Text -> Widget
+infoRow label value =
+  Text TextConfig { tcLabel = label <> ": " <> value, tcFontConfig = Nothing }

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -19,6 +19,7 @@ import Test.AppContextTests (registrationTests, appContextTests, exceptionHandle
 import Test.ActionTests (actionTests, widgetEqTests, incrementalRenderTests)
 import Test.AnimationTests (animationTests)
 import Test.FilesDirTests (filesDirTests)
+import Test.DeviceInfoTests (deviceInfoTests)
 
 main :: IO ()
 main = do
@@ -73,4 +74,5 @@ tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiP
     , incrementalRenderTests
     , animationTests
     , filesDirTests
+    , deviceInfoTests
     ]

--- a/test/Test/DeviceInfoTests.hs
+++ b/test/Test/DeviceInfoTests.hs
@@ -8,7 +8,6 @@ module Test.DeviceInfoTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.Text qualified as Text
 import Foreign.C.String (CString, newCString)
 import Hatter.DeviceInfo (DeviceInfo(..), getDeviceInfo)
 
@@ -25,9 +24,9 @@ deviceInfoTests = sequentialTestGroup "DeviceInfo" AllFinish
       info <- getDeviceInfo
       diModel info @?= "desktop"
       diOsVersion info @?= "unknown"
-      diScreenDensity info @?= "1.0"
-      diScreenWidth info @?= "0"
-      diScreenHeight info @?= "0"
+      diScreenDensity info @?= 1.0
+      diScreenWidth info @?= 0
+      diScreenHeight info @?= 0
   , testCase "setDevice* / getDeviceInfo roundtrip" $ do
       cmodel   <- newCString "Pixel 7"
       cosver   <- newCString "14"
@@ -42,14 +41,12 @@ deviceInfoTests = sequentialTestGroup "DeviceInfo" AllFinish
       info <- getDeviceInfo
       diModel info @?= "Pixel 7"
       diOsVersion info @?= "14"
-      diScreenDensity info @?= "2.75"
-      diScreenWidth info @?= "1080"
-      diScreenHeight info @?= "2400"
-  , testCase "all fields are non-empty after setting" $ do
+      diScreenDensity info @?= 2.75
+      diScreenWidth info @?= 1080
+      diScreenHeight info @?= 2400
+  , testCase "numeric fields are parsed after setting" $ do
       info <- getDeviceInfo
-      assertBool "model should not be empty" (not (Text.null (diModel info)))
-      assertBool "osVersion should not be empty" (not (Text.null (diOsVersion info)))
-      assertBool "screenDensity should not be empty" (not (Text.null (diScreenDensity info)))
-      assertBool "screenWidth should not be empty" (not (Text.null (diScreenWidth info)))
-      assertBool "screenHeight should not be empty" (not (Text.null (diScreenHeight info)))
+      assertBool "screenDensity should be positive" (diScreenDensity info > 0)
+      assertBool "screenWidth should be positive" (diScreenWidth info > 0)
+      assertBool "screenHeight should be positive" (diScreenHeight info > 0)
   ]

--- a/test/Test/DeviceInfoTests.hs
+++ b/test/Test/DeviceInfoTests.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Unit tests for the device info bridge.
+module Test.DeviceInfoTests
+  ( deviceInfoTests
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Text qualified as Text
+import Foreign.C.String (CString, newCString)
+import Hatter.DeviceInfo (DeviceInfo(..), getDeviceInfo)
+
+foreign import ccall "setDeviceModel" c_setDeviceModel :: CString -> IO ()
+foreign import ccall "setDeviceOsVersion" c_setDeviceOsVersion :: CString -> IO ()
+foreign import ccall "setDeviceScreenDensity" c_setDeviceScreenDensity :: CString -> IO ()
+foreign import ccall "setDeviceScreenWidth" c_setDeviceScreenWidth :: CString -> IO ()
+foreign import ccall "setDeviceScreenHeight" c_setDeviceScreenHeight :: CString -> IO ()
+
+-- | Tests run sequentially because they mutate process-wide C globals.
+deviceInfoTests :: TestTree
+deviceInfoTests = sequentialTestGroup "DeviceInfo" AllFinish
+  [ testCase "getDeviceInfo returns desktop fallbacks by default" $ do
+      info <- getDeviceInfo
+      diModel info @?= "desktop"
+      diOsVersion info @?= "unknown"
+      diScreenDensity info @?= "1.0"
+      diScreenWidth info @?= "0"
+      diScreenHeight info @?= "0"
+  , testCase "setDevice* / getDeviceInfo roundtrip" $ do
+      cmodel   <- newCString "Pixel 7"
+      cosver   <- newCString "14"
+      cdensity <- newCString "2.75"
+      cwidth   <- newCString "1080"
+      cheight  <- newCString "2400"
+      c_setDeviceModel cmodel
+      c_setDeviceOsVersion cosver
+      c_setDeviceScreenDensity cdensity
+      c_setDeviceScreenWidth cwidth
+      c_setDeviceScreenHeight cheight
+      info <- getDeviceInfo
+      diModel info @?= "Pixel 7"
+      diOsVersion info @?= "14"
+      diScreenDensity info @?= "2.75"
+      diScreenWidth info @?= "1080"
+      diScreenHeight info @?= "2400"
+  , testCase "all fields are non-empty after setting" $ do
+      info <- getDeviceInfo
+      assertBool "model should not be empty" (not (Text.null (diModel info)))
+      assertBool "osVersion should not be empty" (not (Text.null (diOsVersion info)))
+      assertBool "screenDensity should not be empty" (not (Text.null (diScreenDensity info)))
+      assertBool "screenWidth should not be empty" (not (Text.null (diScreenWidth info)))
+      assertBool "screenHeight should not be empty" (not (Text.null (diScreenHeight info)))
+  ]

--- a/test/android/deviceinfo.sh
+++ b/test/android/deviceinfo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Android device info test: install device-info APK, launch app,
+# verify device information is retrieved and logged.
+#
+# Required env vars (set by emulator-all.nix harness):
+#   ADB, EMULATOR_SERIAL, DEVICE_INFO_APK, PACKAGE, ACTIVITY, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+install_apk "$DEVICE_INFO_APK" || { echo "FAIL: install_apk"; exit 1; }
+
+"$ADB" -s "$EMULATOR_SERIAL" logcat -c
+"$ADB" -s "$EMULATOR_SERIAL" shell am start -n "$PACKAGE/$ACTIVITY"
+
+wait_for_logcat "setRoot" 120 || true
+wait_for_logcat "DeviceInfo model:" 30 || true
+
+LOGCAT_FILE="$WORK_DIR/deviceinfo_logcat.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_FILE" 2>&1 || true
+assert_logcat "$LOGCAT_FILE" "DeviceInfo model:" "DeviceInfo model retrieved"
+assert_logcat "$LOGCAT_FILE" "DeviceInfo osVersion:" "DeviceInfo osVersion retrieved"
+assert_logcat "$LOGCAT_FILE" "DeviceInfo screenDensity:" "DeviceInfo screenDensity retrieved"
+assert_logcat "$LOGCAT_FILE" "DeviceInfo screenWidth:" "DeviceInfo screenWidth retrieved"
+assert_logcat "$LOGCAT_FILE" "DeviceInfo screenHeight:" "DeviceInfo screenHeight retrieved"
+
+# Verify no crash
+LOGCAT_ERR="$WORK_DIR/deviceinfo_logcat_err.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:E' > "$LOGCAT_ERR" 2>&1 || true
+if grep -qE "$FATAL_PATTERNS" "$LOGCAT_ERR" 2>/dev/null; then
+    echo "FAIL: Fatal crash detected during device info test"
+    grep -E "$FATAL_PATTERNS" "$LOGCAT_ERR" | tail -10
+    EXIT_CODE=1
+else
+    echo "PASS: No crash during device info test"
+fi
+
+"$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/test/ios/deviceinfo.sh
+++ b/test/ios/deviceinfo.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# iOS device info test: install device-info app, launch with
+# --autotest, verify device information is retrieved and logged.
+#
+# Required env vars (set by simulator-all.nix harness):
+#   SIM_UDID, BUNDLE_ID, DEVICE_INFO_APP, WORK_DIR
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+EXIT_CODE=0
+
+xcrun simctl install "$SIM_UDID" "$DEVICE_INFO_APP"
+echo "DeviceInfo app installed."
+
+DI_START=$(date "+%Y-%m-%d %H:%M:%S")
+
+STREAM_LOG="$WORK_DIR/deviceinfo_stream.txt"
+true > "$STREAM_LOG"
+xcrun simctl spawn "$SIM_UDID" log stream \
+    --level info \
+    --predicate "subsystem == \"$BUNDLE_ID\"" \
+    --style compact \
+    > "$STREAM_LOG" 2>&1 &
+LOG_STREAM_PID=$!
+sleep 1
+
+xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest
+
+render_done=0
+wait_for_log "$STREAM_LOG" "setRoot" 60 && render_done=1 || true
+
+if [ $render_done -eq 0 ]; then
+    echo "WARNING: setRoot not found — retrying with relaunch"
+    xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+    sleep 1
+    true > "$STREAM_LOG"
+    xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" --autotest
+    wait_for_log "$STREAM_LOG" "setRoot" 60 || true
+fi
+
+wait_for_log "$STREAM_LOG" "DeviceInfo model:" 30 || true
+
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+sleep 1
+
+FULL_LOG="$WORK_DIR/deviceinfo_full.txt"
+get_full_log "$DI_START" "$FULL_LOG"
+
+if ! grep -q "setRoot" "$FULL_LOG" 2>/dev/null; then
+    echo "  'log show' empty/incomplete, using stream log"
+    FULL_LOG="$STREAM_LOG"
+fi
+
+assert_log "$FULL_LOG" "DeviceInfo demo app registered" "DeviceInfo demo app started"
+assert_log "$FULL_LOG" "DeviceInfo model:" "DeviceInfo model retrieved"
+assert_log "$FULL_LOG" "DeviceInfo osVersion:" "DeviceInfo osVersion retrieved"
+assert_log "$FULL_LOG" "DeviceInfo screenDensity:" "DeviceInfo screenDensity retrieved"
+assert_log "$FULL_LOG" "DeviceInfo screenWidth:" "DeviceInfo screenWidth retrieved"
+assert_log "$FULL_LOG" "DeviceInfo screenHeight:" "DeviceInfo screenHeight retrieved"
+assert_log "$FULL_LOG" "setRoot" "setRoot"
+
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" 2>/dev/null || true
+
+exit $EXIT_CODE

--- a/watchos/Hatter/HaskellBridge.swift
+++ b/watchos/Hatter/HaskellBridge.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WatchKit
 import os.log
 
 /// Swift wrapper around the Haskell FFI functions exposed via C.
@@ -20,8 +21,20 @@ class HaskellBridge {
     static func initialize() {
         hs_init(nil, nil)
         setSystemLocale("en")  // watchOS default locale, before Haskell main
+
+        // Device info — WKInterfaceDevice for watchOS
+        let device = WKInterfaceDevice.current()
+        setDeviceModel(strdup(device.model))
+        setDeviceOsVersion(strdup(device.systemVersion))
+        let scale = device.screenScale
+        setDeviceScreenDensity(strdup(String(format: "%.1f", scale)))
+        let bounds = device.screenBounds
+        setDeviceScreenWidth(strdup(String(Int(bounds.width * scale))))
+        setDeviceScreenHeight(strdup(String(Int(bounds.height * scale))))
+
         context = haskellRunMain()
         haskellLogLocale()
+        haskellLogDeviceInfo()
         setup_watchos_redraw_bridge(context)
     }
 


### PR DESCRIPTION
## Summary
- Expose device model, OS version, screen density, and screen dimensions to Haskell via C set/get globals (matching the locale/filesdir pattern)
- Platform bridges (Android JNI, iOS ObjC, watchOS Swift) call setters during init before `haskellRunMain()`
- Desktop returns sensible fallbacks ("desktop", "unknown", "1.0", "0", "0")
- No unique device ID — modern platforms restrict access, not worth the complexity

## Changes
- `cbits/device_info.c` — static globals with setter/getter pairs
- `src/Hatter/DeviceInfo.hs` — FFI module with `DeviceInfo` record, `getDeviceInfo`, `haskellLogDeviceInfo`
- `include/Hatter.h` — C declarations for all setters/getters
- `cbits/jni_bridge.c` — Android: Build.MODEL, Build.VERSION.RELEASE, DisplayMetrics
- `ios/Hatter/UIBridgeIOS.m` — iOS: utsname, UIDevice, UIScreen
- `watchos/Hatter/HaskellBridge.swift` — watchOS: WKInterfaceDevice
- Integration test demo app + Android/iOS test scripts + Nix wiring (Phase 24/21)
- Unit tests for set/get roundtrip and desktop fallback values (3 new tests, 275 total)

## Test plan
- [x] `cabal build` passes
- [x] `cabal test` passes (275 tests)
- [x] `nix-build nix/ci.nix` evaluates correctly (deviceinfo APK derivation created)
- [ ] Android emulator integration test verifies logcat contains DeviceInfo fields
- [ ] iOS simulator integration test verifies log contains DeviceInfo fields

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)