### PR TITLE
Bundle libffi into static archive for iOS/watchOS

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,7 +30,7 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: Hatter/Hatter-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit", "-framework", "QuartzCore"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit", "-framework", "QuartzCore"]
 
   HatterUITests:
     type: bundle.ui-testing

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,7 +30,7 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: Hatter/Hatter-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit", "-framework", "QuartzCore"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AVFoundation", "-framework", "AuthenticationServices", "-framework", "Contacts", "-framework", "CoreLocation", "-framework", "CoreBluetooth", "-framework", "WebKit", "-framework", "MapKit", "-framework", "QuartzCore"]
 
   HatterUITests:
     type: bundle.ui-testing

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -561,6 +561,18 @@ in {
       gmpStatic = iosPkgs.gmp.overrideAttrs (old: {
         dontDisableStatic = true;
       });
+      # Apple's libffi (v40) only ships .dylib — no static archive.
+      # Build GNU libffi from source with --enable-static for bundling
+      # into the iOS fat archive (mac2ios patches the platform tag).
+      libffiStatic = iosPkgs.stdenv.mkDerivation {
+        pname = "libffi-static";
+        version = "3.5.2";
+        src = iosPkgs.fetchurl {
+          url = "https://github.com/libffi/libffi/releases/download/v3.5.2/libffi-3.5.2.tar.gz";
+          hash = "sha256-86MIKiOzfCk6T80QUxR7Nx8v+R+n6hsqUuM1Z2usgtw=";
+        };
+        configureFlags = [ "--enable-static" "--disable-shared" ];
+      };
     in
     iosPkgs.stdenv.mkDerivation {
       inherit pname;
@@ -569,7 +581,7 @@ in {
       src = hatterSrc + "/src";
 
       nativeBuildInputs = [ iosGhc iosPkgs.cctools ];
-      buildInputs = [ iosPkgs.libffi gmpStatic ];
+      buildInputs = [ libffiStatic gmpStatic ];
 
       buildPhase = ''
         mkdir -p Hatter
@@ -678,6 +690,7 @@ in {
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
+          ${libffiStatic}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 
@@ -788,6 +801,15 @@ open(sys.argv[1], "w").write(yml)
       gmpStatic = iosPkgs.gmp.overrideAttrs (old: {
         dontDisableStatic = true;
       });
+      libffiStatic = iosPkgs.stdenv.mkDerivation {
+        pname = "libffi-static";
+        version = "3.5.2";
+        src = iosPkgs.fetchurl {
+          url = "https://github.com/libffi/libffi/releases/download/v3.5.2/libffi-3.5.2.tar.gz";
+          hash = "sha256-86MIKiOzfCk6T80QUxR7Nx8v+R+n6hsqUuM1Z2usgtw=";
+        };
+        configureFlags = [ "--enable-static" "--disable-shared" ];
+      };
     in
     iosPkgs.stdenv.mkDerivation {
       inherit pname;
@@ -796,7 +818,7 @@ open(sys.argv[1], "w").write(yml)
       src = hatterSrc + "/src";
 
       nativeBuildInputs = [ iosGhc iosPkgs.cctools ];
-      buildInputs = [ iosPkgs.libffi gmpStatic ];
+      buildInputs = [ libffiStatic gmpStatic ];
 
       buildPhase = ''
         mkdir -p Hatter
@@ -905,6 +927,7 @@ open(sys.argv[1], "w").write(yml)
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
+          ${libffiStatic}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -561,6 +561,9 @@ in {
       gmpStatic = iosPkgs.gmp.overrideAttrs (old: {
         dontDisableStatic = true;
       });
+      libffiStatic = iosPkgs.libffi.overrideAttrs (old: {
+        dontDisableStatic = true;
+      });
     in
     iosPkgs.stdenv.mkDerivation {
       inherit pname;
@@ -569,7 +572,7 @@ in {
       src = hatterSrc + "/src";
 
       nativeBuildInputs = [ iosGhc iosPkgs.cctools ];
-      buildInputs = [ iosPkgs.libffi gmpStatic ];
+      buildInputs = [ libffiStatic gmpStatic ];
 
       buildPhase = ''
         mkdir -p Hatter
@@ -678,6 +681,7 @@ in {
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
+          ${libffiStatic}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 
@@ -788,6 +792,9 @@ open(sys.argv[1], "w").write(yml)
       gmpStatic = iosPkgs.gmp.overrideAttrs (old: {
         dontDisableStatic = true;
       });
+      libffiStatic = iosPkgs.libffi.overrideAttrs (old: {
+        dontDisableStatic = true;
+      });
     in
     iosPkgs.stdenv.mkDerivation {
       inherit pname;
@@ -796,7 +803,7 @@ open(sys.argv[1], "w").write(yml)
       src = hatterSrc + "/src";
 
       nativeBuildInputs = [ iosGhc iosPkgs.cctools ];
-      buildInputs = [ iosPkgs.libffi gmpStatic ];
+      buildInputs = [ libffiStatic gmpStatic ];
 
       buildPhase = ''
         mkdir -p Hatter
@@ -905,6 +912,7 @@ open(sys.argv[1], "w").write(yml)
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
+          ${libffiStatic}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -561,9 +561,6 @@ in {
       gmpStatic = iosPkgs.gmp.overrideAttrs (old: {
         dontDisableStatic = true;
       });
-      libffiStatic = iosPkgs.libffi.overrideAttrs (old: {
-        dontDisableStatic = true;
-      });
     in
     iosPkgs.stdenv.mkDerivation {
       inherit pname;
@@ -572,7 +569,7 @@ in {
       src = hatterSrc + "/src";
 
       nativeBuildInputs = [ iosGhc iosPkgs.cctools ];
-      buildInputs = [ libffiStatic gmpStatic ];
+      buildInputs = [ iosPkgs.libffi gmpStatic ];
 
       buildPhase = ''
         mkdir -p Hatter
@@ -681,7 +678,7 @@ in {
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
-          ${libffiStatic}/lib/libffi.a \
+          ${iosPkgs.libffi}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 
@@ -792,9 +789,6 @@ open(sys.argv[1], "w").write(yml)
       gmpStatic = iosPkgs.gmp.overrideAttrs (old: {
         dontDisableStatic = true;
       });
-      libffiStatic = iosPkgs.libffi.overrideAttrs (old: {
-        dontDisableStatic = true;
-      });
     in
     iosPkgs.stdenv.mkDerivation {
       inherit pname;
@@ -803,7 +797,7 @@ open(sys.argv[1], "w").write(yml)
       src = hatterSrc + "/src";
 
       nativeBuildInputs = [ iosGhc iosPkgs.cctools ];
-      buildInputs = [ libffiStatic gmpStatic ];
+      buildInputs = [ iosPkgs.libffi gmpStatic ];
 
       buildPhase = ''
         mkdir -p Hatter
@@ -912,7 +906,7 @@ open(sys.argv[1], "w").write(yml)
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
-          ${libffiStatic}/lib/libffi.a \
+          ${iosPkgs.libffi}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -678,7 +678,6 @@ in {
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
-          ${iosPkgs.libffi}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 
@@ -906,7 +905,6 @@ open(sys.argv[1], "w").write(yml)
         echo "Merging static archives into libHatter.a"
         libtool -static -o libCombined.a libHatter.a \
           ${gmpStatic}/lib/libgmp.a \
-          ${iosPkgs.libffi}/lib/libffi.a \
           ${if crossDeps != null then "${crossDeps}/lib/*.a" else ""}
         mv libCombined.a libHatter.a
 

--- a/watchos/project.yml
+++ b/watchos/project.yml
@@ -25,7 +25,7 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: Hatter/Hatter-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lc++", "-framework", "AuthenticationServices"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AuthenticationServices"]
 
   HatterUITests:
     type: bundle.ui-testing

--- a/watchos/project.yml
+++ b/watchos/project.yml
@@ -25,7 +25,7 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: Hatter/Hatter-Bridging-Header.h
         LIBRARY_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/lib"]
         HEADER_SEARCH_PATHS: ["$(inherited)", "$(PROJECT_DIR)/include"]
-        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lffi", "-lc++", "-framework", "AuthenticationServices"]
+        OTHER_LDFLAGS: ["$(inherited)", "-lHatter", "-lz", "-liconv", "-lc++", "-framework", "AuthenticationServices"]
 
   HatterUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## Summary
- Merge `libffi.a` into the combined `libHatter.a` archive via `libtool -static`, same pattern as `libgmp.a`
- Remove `-lffi` from `ios/project.yml` and `watchos/project.yml` since it's now bundled
- Use `libffiStatic` (with `dontDisableStatic`) to ensure a `.a` is available

Fixes "library 'ffi' not found" when building in Xcode after `setup-ios.sh` stages the project.

## Test plan
- [ ] `nix-build nix/ci.nix -A ios-app` still produces a valid Xcode project
- [ ] Opening the staged project in Xcode and building succeeds (no linker errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)