### PR TITLE
Reduce complexity for AI comprehension

### DIFF
--- a/src/Hatter/Animation.hs
+++ b/src/Hatter/Animation.hs
@@ -33,7 +33,8 @@ import Data.Time.Clock (NominalDiffTime)
 import Foreign.Ptr (Ptr)
 import Unwitch.Convert.Int32 qualified as Int32
 import Hatter.Widget
-  ( Keyframe(..)
+  ( Color
+  , Keyframe(..)
   , WidgetStyle(..)
   , colorToHex
   , interpolateColor
@@ -201,60 +202,47 @@ interpolateKeyframeAndApply nodeId keyframes progress = do
   interpolateStyle nodeId fromStyle toStyle segmentProgress
 
 -- | Interpolate 'WidgetStyle' properties and apply them to a native node.
+--
+-- For each style field, the behaviour depends on the (from, to) pair:
+--
+--   * @(Just, Just)@: interpolate between the two values.
+--   * @(Nothing, Just)@: snap to the target immediately (no 'from' to lerp from).
+--   * @(Just, Nothing)@ or @(Nothing, Nothing)@: do nothing — leave native value as-is.
 interpolateStyle :: Int32 -> WidgetStyle -> WidgetStyle -> Double -> IO ()
 interpolateStyle nodeId fromStyle toStyle progress = do
-  -- Padding
-  case (wsPadding fromStyle, wsPadding toStyle) of
-    (Just fromPad, Just toPad) ->
-      Bridge.setNumProp nodeId Bridge.PropPadding
-        (interpolateDouble fromPad toPad progress)
-    (Nothing, Just toPad) ->
-      Bridge.setNumProp nodeId Bridge.PropPadding toPad
-    (Just _fromPad, Nothing) -> pure ()
-    (Nothing, Nothing) -> pure ()
-  -- Text color
-  case (wsTextColor fromStyle, wsTextColor toStyle) of
-    (Just fromColor, Just toColor) ->
-      Bridge.setStrProp nodeId Bridge.PropColor
-        (colorToHex (interpolateColor fromColor toColor progress))
-    (Nothing, Just toColor) ->
-      Bridge.setStrProp nodeId Bridge.PropColor (colorToHex toColor)
-    (Just _fromColor, Nothing) -> pure ()
-    (Nothing, Nothing) -> pure ()
-  -- Background color
-  case (wsBackgroundColor fromStyle, wsBackgroundColor toStyle) of
-    (Just fromColor, Just toColor) ->
-      Bridge.setStrProp nodeId Bridge.PropBgColor
-        (colorToHex (interpolateColor fromColor toColor progress))
-    (Nothing, Just toColor) ->
-      Bridge.setStrProp nodeId Bridge.PropBgColor (colorToHex toColor)
-    (Just _fromColor, Nothing) -> pure ()
-    (Nothing, Nothing) -> pure ()
-  -- TranslateX
-  case (wsTranslateX fromStyle, wsTranslateX toStyle) of
-    (Just fromTx, Just toTx) ->
-      Bridge.setNumProp nodeId Bridge.PropTranslateX
-        (interpolateDouble fromTx toTx progress)
-    (Nothing, Just toTx) ->
-      Bridge.setNumProp nodeId Bridge.PropTranslateX toTx
-    (Just _fromTx, Nothing) -> pure ()
-    (Nothing, Nothing) -> pure ()
-  -- TranslateY
-  case (wsTranslateY fromStyle, wsTranslateY toStyle) of
-    (Just fromTy, Just toTy) ->
-      Bridge.setNumProp nodeId Bridge.PropTranslateY
-        (interpolateDouble fromTy toTy progress)
-    (Nothing, Just toTy) ->
-      Bridge.setNumProp nodeId Bridge.PropTranslateY toTy
-    (Just _fromTy, Nothing) -> pure ()
-    (Nothing, Nothing) -> pure ()
-  -- TouchPassthrough (boolean — snaps to target, no interpolation)
-  case (wsTouchPassthrough fromStyle, wsTouchPassthrough toStyle) of
-    (_, Just enabled) ->
+  lerpNumProp Bridge.PropPadding
+    (wsPadding fromStyle) (wsPadding toStyle)
+  lerpColorProp Bridge.PropColor
+    (wsTextColor fromStyle) (wsTextColor toStyle)
+  lerpColorProp Bridge.PropBgColor
+    (wsBackgroundColor fromStyle) (wsBackgroundColor toStyle)
+  lerpNumProp Bridge.PropTranslateX
+    (wsTranslateX fromStyle) (wsTranslateX toStyle)
+  lerpNumProp Bridge.PropTranslateY
+    (wsTranslateY fromStyle) (wsTranslateY toStyle)
+  -- TouchPassthrough is boolean — snaps to target, no interpolation.
+  case wsTouchPassthrough toStyle of
+    Just enabled ->
       Bridge.setNumProp nodeId Bridge.PropTouchPassthrough
         (if enabled then 1.0 else 0.0)
-    (Just _fromEnabled, Nothing) -> pure ()
-    (Nothing, Nothing) -> pure ()
+    Nothing -> pure ()
+  where
+    -- | Interpolate a numeric property and apply it to the native node.
+    lerpNumProp :: Bridge.PropId -> Maybe Double -> Maybe Double -> IO ()
+    lerpNumProp prop (Just fromVal) (Just toVal) =
+      Bridge.setNumProp nodeId prop (interpolateDouble fromVal toVal progress)
+    lerpNumProp prop Nothing (Just toVal) =
+      Bridge.setNumProp nodeId prop toVal
+    lerpNumProp _prop _ Nothing = pure ()
+
+    -- | Interpolate a color property and apply it as a hex string.
+    lerpColorProp :: Bridge.PropId -> Maybe Color -> Maybe Color -> IO ()
+    lerpColorProp prop (Just fromColor) (Just toColor) =
+      Bridge.setStrProp nodeId prop
+        (colorToHex (interpolateColor fromColor toColor progress))
+    lerpColorProp prop Nothing (Just toColor) =
+      Bridge.setStrProp nodeId prop (colorToHex toColor)
+    lerpColorProp _prop _ Nothing = pure ()
 
 -- | FFI imports for the C animation bridge.
 foreign import ccall "animation_start_loop" c_animationStartLoop :: Ptr () -> IO ()

--- a/src/Hatter/Render.hs
+++ b/src/Hatter/Render.hs
@@ -175,6 +175,21 @@ applyStyle nodeId style = do
 -- Creating rendered nodes from scratch
 -- ---------------------------------------------------------------------------
 
+-- | Create a container native node, recursively rendering each child
+-- and attaching it via the bridge.  Used by Column, Row, and Stack which
+-- share identical child-processing logic.
+createContainerNode :: AnimationState -> Widget -> Bridge.NodeType
+                    -> [LayoutItem] -> IO RenderedNode
+createContainerNode animState widget nodeType layoutItems = do
+  nodeId <- Bridge.createNode nodeType
+  keyedChildren <- mapM (\(index, layoutItem) -> do
+    let keyVal = resolveKeyAtIndex index layoutItem
+    childNode <- createRenderedNode animState (liWidget layoutItem)
+    Bridge.addChild nodeId (renderedNodeId childNode)
+    pure (keyVal, childNode)
+    ) (zip [0..] layoutItems)
+  pure (RenderedContainer widget nodeId keyedChildren)
+
 -- | Create a native node from a 'Widget', returning a 'RenderedNode'
 -- snapshot. Used for fresh creation (no old node to diff against).
 createRenderedNode :: AnimationState -> Widget -> IO RenderedNode
@@ -203,35 +218,14 @@ createRenderedNode animState widget@(Column settings) = do
   let nodeType = if lsScrollable settings
         then Bridge.NodeScrollView
         else Bridge.NodeColumn
-  nodeId <- Bridge.createNode nodeType
-  keyedChildren <- mapM (\(index, layoutItem) -> do
-    let keyVal = resolveKeyAtIndex index layoutItem
-    childNode <- createRenderedNode animState (liWidget layoutItem)
-    Bridge.addChild nodeId (renderedNodeId childNode)
-    pure (keyVal, childNode)
-    ) (zip [0..] (lsWidgets settings))
-  pure (RenderedContainer widget nodeId keyedChildren)
+  createContainerNode animState widget nodeType (lsWidgets settings)
 createRenderedNode animState widget@(Row settings) = do
   let nodeType = if lsScrollable settings
         then Bridge.NodeHorizontalScrollView
         else Bridge.NodeRow
-  nodeId <- Bridge.createNode nodeType
-  keyedChildren <- mapM (\(index, layoutItem) -> do
-    let keyVal = resolveKeyAtIndex index layoutItem
-    childNode <- createRenderedNode animState (liWidget layoutItem)
-    Bridge.addChild nodeId (renderedNodeId childNode)
-    pure (keyVal, childNode)
-    ) (zip [0..] (lsWidgets settings))
-  pure (RenderedContainer widget nodeId keyedChildren)
-createRenderedNode animState widget@(Stack items) = do
-  nodeId <- Bridge.createNode Bridge.NodeStack
-  keyedChildren <- mapM (\(index, layoutItem) -> do
-    let keyVal = resolveKeyAtIndex index layoutItem
-    childNode <- createRenderedNode animState (liWidget layoutItem)
-    Bridge.addChild nodeId (renderedNodeId childNode)
-    pure (keyVal, childNode)
-    ) (zip [0..] items)
-  pure (RenderedContainer widget nodeId keyedChildren)
+  createContainerNode animState widget nodeType (lsWidgets settings)
+createRenderedNode animState widget@(Stack items) =
+  createContainerNode animState widget Bridge.NodeStack items
 createRenderedNode _animState widget@(Image config) = do
   nodeId <- Bridge.createNode Bridge.NodeImage
   case icSource config of

--- a/src/Hatter/SecureStorage.hs
+++ b/src/Hatter/SecureStorage.hs
@@ -121,10 +121,22 @@ secureStorageDelete storageState key callback = do
   withCString (Text.unpack key) $ \cKey ->
     c_secureStorageDelete ctx (Int32.toCInt requestId) cKey
 
+-- | Look up and remove a callback from an 'IORef' 'IntMap'.
+-- Returns 'Just' the callback if found (and removes it), 'Nothing' otherwise.
+popCallback :: IORef (IntMap a) -> Int -> IO (Maybe a)
+popCallback ref reqKey = do
+  callbacks <- readIORef ref
+  case IntMap.lookup reqKey callbacks of
+    Just callback -> do
+      modifyIORef' ref (IntMap.delete reqKey)
+      pure (Just callback)
+    Nothing -> pure Nothing
+
 -- | Dispatch a secure storage result from the platform back to the
 -- registered Haskell callback.  Tries write callbacks first, then read,
--- then delete.  Removes the callback after firing.
--- Unknown request IDs or status codes are silently logged to stderr.
+-- then delete — exactly one map will contain the request ID since each
+-- operation type registers into its own map.
+-- Unknown request IDs or status codes are logged to stderr.
 dispatchSecureStorageResult :: SecureStorageState -> CInt -> CInt -> Maybe Text -> IO ()
 dispatchSecureStorageResult storageState requestId statusCode maybeValue =
   case storageStatusFromInt statusCode of
@@ -132,29 +144,17 @@ dispatchSecureStorageResult storageState requestId statusCode maybeValue =
       "dispatchSecureStorageResult: unknown status code " ++ show statusCode
     Just status -> do
       let reqKey = CInt.toInt requestId
-      -- Try write callbacks
-      writeCallbacks <- readIORef (ssWriteCallbacks storageState)
-      case IntMap.lookup reqKey writeCallbacks of
-        Just callback -> do
-          modifyIORef' (ssWriteCallbacks storageState) (IntMap.delete reqKey)
-          callback status
-          return ()
+      maybeWrite  <- popCallback (ssWriteCallbacks storageState) reqKey
+      case maybeWrite of
+        Just callback -> callback status
         Nothing -> do
-          -- Try read callbacks
-          readCallbacks <- readIORef (ssReadCallbacks storageState)
-          case IntMap.lookup reqKey readCallbacks of
-            Just callback -> do
-              modifyIORef' (ssReadCallbacks storageState) (IntMap.delete reqKey)
-              callback status maybeValue
-              return ()
+          maybeRead <- popCallback (ssReadCallbacks storageState) reqKey
+          case maybeRead of
+            Just callback -> callback status maybeValue
             Nothing -> do
-              -- Try delete callbacks
-              deleteCallbacks <- readIORef (ssDeleteCallbacks storageState)
-              case IntMap.lookup reqKey deleteCallbacks of
-                Just callback -> do
-                  modifyIORef' (ssDeleteCallbacks storageState) (IntMap.delete reqKey)
-                  callback status
-                  return ()
+              maybeDelete <- popCallback (ssDeleteCallbacks storageState) reqKey
+              case maybeDelete of
+                Just callback -> callback status
                 Nothing -> hPutStrLn stderr $
                   "dispatchSecureStorageResult: unknown request ID " ++ show requestId
 


### PR DESCRIPTION
## Summary
- Extract `createContainerNode` helper in Render.hs (Column/Row/Stack shared identical child-processing logic)
- Extract `lerpNumProp`/`lerpColorProp` where-helpers in Animation.hs (replaced 6x repetitive 4-case pattern match with documented helpers)
- Extract `popCallback` helper in SecureStorage.hs (flattened nested readIORef/lookup/modifyIORef cascade)

No behaviour changes — pure readability refactoring verified by sending functions to a haiku-class model before and after.

## Test plan
- [x] `cabal build` passes with no warnings
- [x] `cabal test` passes (all test suites)
- [x] Haiku re-verification confirms previous confusions resolved
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)