### PR TITLE
Add kbeacon-ota-demo: BLE scanning POC

### DIFF
--- a/docs/kbeacon-ota-todo.md
+++ b/docs/kbeacon-ota-todo.md
@@ -1,0 +1,73 @@
+# TODO — items not yet ported from kbeacon-ota-tool
+
+## 1. Beacon configuration (GATT connect + write)
+
+**Original**: `SetAdvPeriodState.kt` — connects to each beacon with
+`beacon.connectEnhanced("0000000000000000", 5000, connPara, delegate)`,
+then calls `beacon.modifyConfig(slotCfg)` to write the advertisement period.
+
+**Blocked on**: hatter has no BLE connect / GATT API yet.
+
+**Hatter issue**: https://github.com/jappeace/hatter/issues/108
+"BLE: connection, GATT, and scan filtering"
+
+When #108 lands, implement this as a new action that:
+1. Connects to the beacon by `bsrDeviceAddress`
+2. Discovers the KBeacon slot config characteristic
+3. Writes the target advertisement period
+4. Disconnects and records the result in the beacon list
+
+---
+
+## 2. HTTP result reporting
+
+**Original**: `ReportAdvPeriodState.kt` — POSTs each `BeaconResult` (name,
+mac, advPeriod, batteryPercent) to a user-supplied URL as JSON.
+
+**Available in hatter**: `Hatter.Http.performRequest` already exists.
+
+**What's needed**: wire up the URL TextInput + a "Report" mode switch, then
+call `performRequest` after each beacon's configuration result is known.
+Depends on item 1 (configuration) to have actual results worth reporting.
+
+---
+
+## 3. Battery percentage per beacon
+
+**Original**: `BeaconResult.batteryPercent` — read from the KBeacon GATT
+connection after `connectEnhanced`.
+
+**Blocked on**: (a) BLE GATT connect (item 1 above), and (b) hatter's
+`BleScanResult` doesn't expose battery level even from advertisement packets.
+
+**Hatter issue**: https://github.com/jappeace/hatter/issues/78
+"Platform integration: Battery status" (device battery — may not cover
+peripheral BLE battery; the advertisement-level battery field is part of
+https://github.com/jappeace/hatter/issues/108 scan-result extensions)
+
+---
+
+## 4. Scan result filtering by service UUID
+
+**Original**: `Scanner.kt` only queues beacons that advertise `KBAdvType.EddyUID`
+— i.e., it filters to KBeacon-specific beacons at the advertisement type level.
+
+**Blocked on**: hatter #108 also covers scan filtering by service UUID.
+
+When available, add a UUID filter to `startBleScan` so the scan returns only
+KBeacon Pro devices instead of all nearby BLE peripherals.
+
+---
+
+## 5. npins setup
+
+`nix/sources/` is currently a placeholder. Before running `nix-build`, pin
+hatter with npins:
+
+```
+cd kbeacon-ota-hatter
+npins init
+npins add github jappeace hatter
+```
+
+This creates `nix/sources/` with the pinned hatter revision.

--- a/hatter.cabal
+++ b/hatter.cabal
@@ -226,6 +226,27 @@ executable keyframe-demo
       text,
       time
 
+executable ble-demo
+  import: common-options
+  main-is: BleDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text
+
+executable kbeacon-ota-demo
+  import: common-options
+  main-is: KBeaconOtaDemoMain.hs
+  ghc-options: -Wno-unused-packages -threaded
+  hs-source-dirs:
+      test
+  build-depends:
+      hatter,
+      text,
+      containers
+
 test-suite unit
   import: common-options
   type: exitcode-stdio-1.0

--- a/test/KBeaconOtaDemoMain.hs
+++ b/test/KBeaconOtaDemoMain.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Data.IORef (newIORef, readIORef, writeIORef, modifyIORef')
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text, pack)
+import Foreign.Ptr (Ptr)
+import Hatter
+  ( MobileApp(..)
+  , Action
+  , OnChange
+  , startMobileApp
+  , platformLog
+  , loggingMobileContext
+  , newActionState
+  , runActionM
+  , createAction
+  , createOnChange
+  )
+import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Ble (BleState, checkBleAdapter, startBleScan, stopBleScan)
+import Hatter.Widget
+  ( ButtonConfig(..)
+  , InputType(..)
+  , TextConfig(..)
+  , TextInputConfig(..)
+  , Widget(..)
+  , column
+  , row
+  , scrollColumn
+  , text
+  , button
+  )
+
+data ScannedBeacon = ScannedBeacon
+  { sbName    :: Text
+  , sbAddress :: Text
+  , sbRssi    :: Int
+  }
+
+-- Beacons closer than this RSSI threshold are ignored (same as original Scanner.kt)
+rssiThreshold :: Int
+rssiThreshold = -50
+
+main :: IO (Ptr AppContext)
+main = do
+  platformLog "kbeacon-ota-hatter starting"
+  actionState  <- newActionState
+  beaconsRef   <- newIORef ([] :: [ScannedBeacon])
+  seenMacsRef  <- newIORef (Set.empty :: Set Text)
+  advPeriodRef <- newIORef ("1000" :: Text)
+  isScanningRef <- newIORef False
+  bleStateRef  <- newIORef (Nothing :: Maybe BleState)
+  redrawRef    <- newIORef (pure () :: IO ())
+
+  (onRequestPerms, onCheckAdapter, onStartScan, onStopScan, onPeriodChange) <-
+    runActionM actionState $ do
+
+      perms <- createAction $ do
+        -- TODO: call Hatter.Permission once BLE permission API is available
+        -- See: https://github.com/jappeace/hatter (check for Permission module)
+        platformLog "permission request not yet wired (no BLE-specific permission hook)"
+
+      checkAdapter <- createAction $ do
+        status <- checkBleAdapter
+        platformLog ("BLE adapter status: " <> pack (show status))
+
+      startScan <- createAction $ do
+        mBleState <- readIORef bleStateRef
+        case mBleState of
+          Nothing -> platformLog "BLE state not ready"
+          Just bleState -> do
+            writeIORef beaconsRef []
+            writeIORef seenMacsRef Set.empty
+            writeIORef isScanningRef True
+            startBleScan bleState $ \result -> do
+              let rssi = bsrRssi result
+                  mac  = bsrDeviceAddress result
+              if rssi < rssiThreshold
+                then platformLog ("ignored " <> mac <> " rssi=" <> pack (show rssi))
+                else do
+                  seen <- readIORef seenMacsRef
+                  if Set.member mac seen
+                    then platformLog ("already seen " <> mac)
+                    else do
+                      modifyIORef' seenMacsRef (Set.insert mac)
+                      modifyIORef' beaconsRef
+                        (ScannedBeacon (bsrDeviceName result) mac rssi :)
+                      redraw <- readIORef redrawRef
+                      redraw
+            platformLog "BLE scan started"
+
+      stopScan <- createAction $ do
+        mBleState <- readIORef bleStateRef
+        case mBleState of
+          Nothing -> pure ()
+          Just bleState -> do
+            stopBleScan bleState
+            writeIORef isScanningRef False
+            platformLog "BLE scan stopped"
+
+      periodChange <- createOnChange $ \newValue ->
+        writeIORef advPeriodRef newValue
+
+      pure (perms, checkAdapter, startScan, stopScan, periodChange)
+
+  ctxPtr <- startMobileApp MobileApp
+    { maContext     = loggingMobileContext
+    , maView        = \userState -> do
+        writeIORef redrawRef (userRequestRedraw userState)
+        beacons    <- readIORef beaconsRef
+        advPeriod  <- readIORef advPeriodRef
+        isScanning <- readIORef isScanningRef
+        pure $ appView
+          beacons advPeriod isScanning
+          onRequestPerms onCheckAdapter onStartScan onStopScan onPeriodChange
+    , maActionState = actionState
+    }
+
+  appCtx <- derefAppContext ctxPtr
+  writeIORef bleStateRef (Just (acBleState appCtx))
+  pure ctxPtr
+
+appView
+  :: [ScannedBeacon]
+  -> Text
+  -> Bool
+  -> Action -> Action -> Action -> Action -> OnChange
+  -> IO Widget
+appView beacons advPeriod isScanning
+        onRequestPerms onCheckAdapter onStartScan onStopScan onPeriodChange =
+  pure $ column
+    [ row
+        [ button "Request Permissions" onRequestPerms
+        , button "Check Adapter"       onCheckAdapter
+        ]
+    , TextInput TextInputConfig
+        { tiInputType  = InputNumber
+        , tiHint       = "Adv interval (ms)"
+        , tiValue      = advPeriod
+        , tiOnChange   = onPeriodChange
+        , tiFontConfig = Nothing
+        , tiAutoFocus  = False
+        }
+    , row
+        [ button "Start Scan" onStartScan
+        , button "Stop Scan"  onStopScan
+        ]
+    , text ("Scanning: " <> if isScanning then "yes" else "no")
+    , text (pack (show (length beacons)) <> " device(s) found")
+    , scrollColumn (map beaconRow (reverse beacons))
+    ]
+
+beaconRow :: ScannedBeacon -> Widget
+beaconRow beacon = row
+  [ text (sbName beacon)
+  , text (" | " <> sbAddress beacon)
+  , text (" | RSSI: " <> pack (show (sbRssi beacon)))
+  ]


### PR DESCRIPTION
## Summary

- Ports the scanning and UI layer of [kbeacon-ota-tool](https://github.com/jappeace/kbeacon-ota-tool) to Haskell as a proof-of-concept that `Hatter.Ble` works for a real-world use case
- Adds `test/KBeaconOtaDemoMain.hs` — BLE scan, RSSI filtering (≥ -50 dBm), MAC dedup, advertisement interval TextInput, scrollable results list
- Also adds the `ble-demo` executable that was in `test/` but missing from `hatter.cabal`

## What is NOT yet ported

See `docs/kbeacon-ota-todo.md` for the full list with issue links. The short version:

| Feature | Blocked on |
|---------|-----------|
| Beacon GATT connect + config write | #108 |
| HTTP result reporting | ready once GATT works |
| Battery percentage | #108 + #78 |
| Service UUID scan filter | #108 |

## Test plan

- [ ] `cabal build exe:kbeacon-ota-demo` passes
- [ ] `nix-build nix/android.nix --argstr mainModule test/KBeaconOtaDemoMain.hs` produces a shared lib
- [ ] Install APK on device → press Start Scan → nearby BLE devices appear filtered to RSSI ≥ -50

🤖 Generated with [Claude Code](https://claude.com/claude-code)