### PR TITLE
BLE: read advertised name from scan record, not getRemoteName

### DIFF
--- a/android/java/me/jappie/hatter/HatterActivity.java
+++ b/android/java/me/jappie/hatter/HatterActivity.java
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
 import android.content.Context;
 import android.content.Intent;
@@ -256,7 +257,15 @@ public class HatterActivity extends Activity implements View.OnClickListener {
             bleScanCallback = new ScanCallback() {
                 @Override
                 public void onScanResult(int callbackType, ScanResult result) {
-                    String name = result.getDevice().getName();
+                    // Read the advertised name from the scan record rather than
+                    // BluetoothDevice.getName(). getName() calls getRemoteName(),
+                    // which requires the BLUETOOTH_CONNECT runtime permission on
+                    // API 31+ and crashes a scan-only app with SecurityException.
+                    // The advertised name is carried in the scan packet itself and
+                    // needs only BLUETOOTH_SCAN; it is null when the device does
+                    // not advertise a name, which the Haskell side maps to "".
+                    ScanRecord record = result.getScanRecord();
+                    String name = record != null ? record.getDeviceName() : null;
                     String address = result.getDevice().getAddress();
                     int rssi = result.getRssi();
                     onBleScanResult(name, address, rssi);


### PR DESCRIPTION
## Problem

`HatterActivity`'s scan callback read the device name via `result.getDevice().getName()`, which calls `getRemoteName()` internally. On API 31+ that requires the **`BLUETOOTH_CONNECT`** runtime permission. A scan-only consumer holds only `BLUETOOTH_SCAN` (the one `Hatter.Permission` exposes for Bluetooth), so the **first scan result crashes**:

```
java.lang.SecurityException: Need android.permission.BLUETOOTH_CONNECT permission
  for AttributionSource { ... }: AdapterService getRemoteName
    at com.android.bluetooth.btservice.AdapterService$AdapterServiceBinder.getRemoteName
```

No connection is actually involved — the name is only ever used as a display label. Android 12 simply reclassified the *remote name lookup* under `BLUETOOTH_CONNECT`, while passive advertisement observation stays under `BLUETOOTH_SCAN`.

## Fix

Read the **advertised name** from the scan record instead:

```java
ScanRecord record = result.getScanRecord();
String name = record != null ? record.getDeviceName() : null;
```

The advertised name is carried in the scan packet and needs only `BLUETOOTH_SCAN`. It is `null` when the device advertises no name — and `dispatchBleScanResult` already maps a null name `CString` to `""`, so behaviour is unchanged for named devices and no longer crashes for connect-less scanning.

This means a BLE-scanning consumer needs **no `BLUETOOTH_CONNECT`** and no extra permission plumbing beyond `Hatter.Permission`'s existing `PermissionBluetooth` (→ `BLUETOOTH_SCAN`).

## Notes

- `getAddress()` is unchanged — it does not require `BLUETOOTH_CONNECT`.
- Java platform glue; not covered by `cabal test`. The Haskell BLE dispatch path (incl. the null-name → `""` mapping) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)