### PR TITLE
fix(android): initialise JNI bridges once, not on every render

### DIFF
--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -298,20 +298,35 @@ JNI_OnUnload(JavaVM *vm, void *reserved)
 JNIEXPORT void JNICALL
 JNI_METHOD(renderUI)(JNIEnv *env, jobject thiz)
 {
-    setup_android_ui_bridge(env, thiz, g_haskell_ctx);
-    setup_android_permission_bridge(env, thiz, g_haskell_ctx);
-    setup_android_secure_storage_bridge(env, thiz, g_haskell_ctx);
-    setup_android_ble_bridge(env, thiz, g_haskell_ctx);
-    setup_android_dialog_bridge(env, thiz, g_haskell_ctx);
-    setup_android_location_bridge(env, thiz, g_haskell_ctx);
-    setup_android_auth_session_bridge(env, thiz, g_haskell_ctx);
-    setup_android_camera_bridge(env, thiz, g_haskell_ctx);
-    setup_android_bottom_sheet_bridge(env, thiz, g_haskell_ctx);
-    setup_android_http_bridge(env, thiz, g_haskell_ctx);
-    setup_android_network_status_bridge(env, thiz, g_haskell_ctx);
-    setup_android_animation_bridge(env, thiz, g_haskell_ctx);
-    setup_android_redraw_bridge(env, thiz, g_haskell_ctx);
-    setup_android_platform_sign_in_bridge(env, thiz, g_haskell_ctx);
+    /* The bridge setups are one-time initialization: they resolve JNI method
+     * IDs, cache the activity, register callbacks, and (in
+     * setup_android_ui_bridge) reset the node pool to g_next_node_id = 1.
+     *
+     * renderUI() is called both for the initial render and for every
+     * subsequent redraw (Activity.requestRedraw -> renderUI). Re-running setup
+     * on each redraw wiped the native node pool while the Haskell render state
+     * kept the old node IDs, so setStrProp/addChild targeted freed nodes and
+     * callback-driven redraws never reached the screen. Initialise the bridges
+     * once, then only render — matching the iOS bridge, which sets up once at
+     * init and whose renderUI just calls haskellRenderUI. */
+    static int g_bridges_initialized = 0;
+    if (!g_bridges_initialized) {
+        setup_android_ui_bridge(env, thiz, g_haskell_ctx);
+        setup_android_permission_bridge(env, thiz, g_haskell_ctx);
+        setup_android_secure_storage_bridge(env, thiz, g_haskell_ctx);
+        setup_android_ble_bridge(env, thiz, g_haskell_ctx);
+        setup_android_dialog_bridge(env, thiz, g_haskell_ctx);
+        setup_android_location_bridge(env, thiz, g_haskell_ctx);
+        setup_android_auth_session_bridge(env, thiz, g_haskell_ctx);
+        setup_android_camera_bridge(env, thiz, g_haskell_ctx);
+        setup_android_bottom_sheet_bridge(env, thiz, g_haskell_ctx);
+        setup_android_http_bridge(env, thiz, g_haskell_ctx);
+        setup_android_network_status_bridge(env, thiz, g_haskell_ctx);
+        setup_android_animation_bridge(env, thiz, g_haskell_ctx);
+        setup_android_redraw_bridge(env, thiz, g_haskell_ctx);
+        setup_android_platform_sign_in_bridge(env, thiz, g_haskell_ctx);
+        g_bridges_initialized = 1;
+    }
     haskellRenderUI(g_haskell_ctx);
 }
 

--- a/test/android/helpers.sh
+++ b/test/android/helpers.sh
@@ -177,6 +177,45 @@ assert_logcat() {
     fi
 }
 
+# assert_ui_text TEXT LABEL
+# Dumps the current uiautomator view hierarchy and asserts an on-screen node
+# with the given visible text exists. Unlike assert_logcat (which only proves
+# the Haskell view function ran), this checks what is actually rendered — so it
+# catches redraws that re-run the view but never reach the native widgets.
+# Sets EXIT_CODE=1 on failure (EXIT_CODE must be declared in caller).
+assert_ui_text() {
+    local text="$1"
+    local label="$2"
+    local dump_file="$WORK_DIR/ui_assert.xml"
+    local dump_ok=0
+
+    for attempt in 1 2 3; do
+        if "$ADB" -s "$EMULATOR_SERIAL" shell uiautomator dump /data/local/tmp/ui.xml 2>&1 | grep -q "dumped"; then
+            "$ADB" -s "$EMULATOR_SERIAL" pull /data/local/tmp/ui.xml "$dump_file" 2>/dev/null
+            dump_ok=1
+            break
+        fi
+        sleep 2
+    done
+
+    if [ $dump_ok -eq 0 ]; then
+        echo "FAIL: $label (could not dump UI hierarchy)"
+        # shellcheck disable=SC2034  # set for caller
+        EXIT_CODE=1
+        return
+    fi
+
+    if grep -qF "text=\"$text\"" "$dump_file" 2>/dev/null; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label (no on-screen node with text=\"$text\")"
+        echo "  --- on-screen text nodes ---"
+        grep -o 'text="[^"]*"' "$dump_file" 2>/dev/null | sort -u | head -20
+        # shellcheck disable=SC2034  # set for caller
+        EXIT_CODE=1
+    fi
+}
+
 # start_app APK_PATH LABEL [EXTRAS...]
 # Installs APK, clears logcat, starts activity with optional intent extras.
 start_app() {

--- a/test/android/redraw.sh
+++ b/test/android/redraw.sh
@@ -21,6 +21,13 @@ assert_logcat "$LOGCAT_FILE" "Background tick: 2" "Background tick 2"
 assert_logcat "$LOGCAT_FILE" "view rebuilt: count=1" "View rebuilt after background tick 1"
 assert_logcat "$LOGCAT_FILE" "view rebuilt: count=2" "View rebuilt after background tick 2"
 
+# The asserts above only prove the Haskell view function re-ran. Assert the
+# screen actually reflects the latest background tick. After 3 ticks the demo's
+# counter is 3, so a correctly rendered screen shows "Count: 3". This is what
+# the logcat-only asserts miss: a redraw can re-run the view yet never update
+# the native widgets, leaving the screen frozen at the initial "Count: 0".
+assert_ui_text "Count: 3" "Screen reflects latest count after background redraws"
+
 # Verify no crash
 LOGCAT_ERR="$WORK_DIR/redraw_logcat_err.txt"
 "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:E' > "$LOGCAT_ERR" 2>&1 || true


### PR DESCRIPTION
## Bug

Any UI redraw not driven by a touch event — e.g. a BLE scan callback calling `userRequestRedraw` — re-runs the Haskell view function but never updates the screen.

`renderUI()` (`cbits/jni_bridge.c`) re-runs **every** `setup_android_*_bridge` on each call, and `setup_android_ui_bridge` resets the node pool (`g_next_node_id = 1`). Because `renderUI()` is invoked for every redraw (`Activity.requestRedraw → renderUI`), each redraw wipes the native node pool while the Haskell render state keeps the old node IDs. `setStrProp`/`addChild` then target freed nodes, so the screen freezes. Button events were unaffected because they render via `haskellOnUIEvent`, not `renderUI()`.

On a real device this shows up as a flood of `... bridge initialized` + `createNode -> 1` on every `request_redraw()`.

## TDD

Two commits, the fix does not touch the test:

1. **`test(android)`** — adds `assert_ui_text` (uiautomator dump + on-screen text check) and asserts the redraw demo's screen shows `Count: 3` after the background ticks. The previous test only checked logcat (`view rebuilt: count=N`), which proves the view *function* ran but not that the screen changed — the exact blind spot. **Fails before the fix** (frozen at `Count: 0`).
2. **`fix(android)`** — guard the bridge setup with a static flag so it runs once; thereafter `renderUI()` only calls `haskellRenderUI`. **Test passes.**

## Why this matches iOS

iOS's `HaskellBridge.swift` already sets bridges up **once** at init, and its `renderUI()` is just `haskellRenderUI(context)`. This change makes Android behave the same way. iOS was never affected — its redraw demo would already pass.

## Known limitation

A permanent static flag means setup is not re-run if the Activity is recreated (e.g. orientation change). That path previously "worked" only by re-wiping the node pool every frame; proper re-init on Activity recreation is left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)