### PR TITLE
DEMO (do not merge): redraw reproducer red — fix reverted

### DIFF
--- a/cbits/jni_bridge.c
+++ b/cbits/jni_bridge.c
@@ -298,35 +298,20 @@ JNI_OnUnload(JavaVM *vm, void *reserved)
 JNIEXPORT void JNICALL
 JNI_METHOD(renderUI)(JNIEnv *env, jobject thiz)
 {
-    /* The bridge setups are one-time initialization: they resolve JNI method
-     * IDs, cache the activity, register callbacks, and (in
-     * setup_android_ui_bridge) reset the node pool to g_next_node_id = 1.
-     *
-     * renderUI() is called both for the initial render and for every
-     * subsequent redraw (Activity.requestRedraw -> renderUI). Re-running setup
-     * on each redraw wiped the native node pool while the Haskell render state
-     * kept the old node IDs, so setStrProp/addChild targeted freed nodes and
-     * callback-driven redraws never reached the screen. Initialise the bridges
-     * once, then only render — matching the iOS bridge, which sets up once at
-     * init and whose renderUI just calls haskellRenderUI. */
-    static int g_bridges_initialized = 0;
-    if (!g_bridges_initialized) {
-        setup_android_ui_bridge(env, thiz, g_haskell_ctx);
-        setup_android_permission_bridge(env, thiz, g_haskell_ctx);
-        setup_android_secure_storage_bridge(env, thiz, g_haskell_ctx);
-        setup_android_ble_bridge(env, thiz, g_haskell_ctx);
-        setup_android_dialog_bridge(env, thiz, g_haskell_ctx);
-        setup_android_location_bridge(env, thiz, g_haskell_ctx);
-        setup_android_auth_session_bridge(env, thiz, g_haskell_ctx);
-        setup_android_camera_bridge(env, thiz, g_haskell_ctx);
-        setup_android_bottom_sheet_bridge(env, thiz, g_haskell_ctx);
-        setup_android_http_bridge(env, thiz, g_haskell_ctx);
-        setup_android_network_status_bridge(env, thiz, g_haskell_ctx);
-        setup_android_animation_bridge(env, thiz, g_haskell_ctx);
-        setup_android_redraw_bridge(env, thiz, g_haskell_ctx);
-        setup_android_platform_sign_in_bridge(env, thiz, g_haskell_ctx);
-        g_bridges_initialized = 1;
-    }
+    setup_android_ui_bridge(env, thiz, g_haskell_ctx);
+    setup_android_permission_bridge(env, thiz, g_haskell_ctx);
+    setup_android_secure_storage_bridge(env, thiz, g_haskell_ctx);
+    setup_android_ble_bridge(env, thiz, g_haskell_ctx);
+    setup_android_dialog_bridge(env, thiz, g_haskell_ctx);
+    setup_android_location_bridge(env, thiz, g_haskell_ctx);
+    setup_android_auth_session_bridge(env, thiz, g_haskell_ctx);
+    setup_android_camera_bridge(env, thiz, g_haskell_ctx);
+    setup_android_bottom_sheet_bridge(env, thiz, g_haskell_ctx);
+    setup_android_http_bridge(env, thiz, g_haskell_ctx);
+    setup_android_network_status_bridge(env, thiz, g_haskell_ctx);
+    setup_android_animation_bridge(env, thiz, g_haskell_ctx);
+    setup_android_redraw_bridge(env, thiz, g_haskell_ctx);
+    setup_android_platform_sign_in_bridge(env, thiz, g_haskell_ctx);
     haskellRenderUI(g_haskell_ctx);
 }
 


### PR DESCRIPTION
**Expected to FAIL CI on purpose. Do not merge.**

Both #225 (the fix) and its test are already on master, so a test-only branch can't go red anymore. To make the reproducer visible as a failure against current master, this branch **reverts only the fix commit** (`fix(android): initialise JNI bridges once, not on every render`) and keeps the test.

So CI here runs the redraw emulator test against the buggy `renderUI()` (re-inits bridges + resets the node pool on every redraw). Expected result: the new `assert_ui_text "Count: 3"` step FAILS — the screen stays frozen at `Count: 0` while the view function re-runs.

Re-applying the fix (i.e. reverting this revert) makes it green again — that's #225, already merged.

Close once you've seen the red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)