### PR TITLE
Filter hatterSrc so platform-file edits don't bust the cross cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,15 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+          # Decision: harden substitution against the self-hosted cache dropping
+          # multi-GB NARs mid-stream ("Stream error in the HTTP/2 framing layer",
+          # seen twice on the android system image). http2=false removes that
+          # curl failure mode, download-attempts covers other transient drops.
+          # Alternative --fallback was rejected: a cache miss on the patched GHC
+          # would rebuild it from source in CI (hours) instead of failing fast.
+          # These two lines are repeated in every job's extra_nix_config below.
+          http2 = false
+          download-attempts = 10
     - name: Build all nix targets (excludes emulator/simulator runners)
       run: nix-build nix/ci.nix -A all-builds
     - name: Cancel workflow on failure
@@ -60,6 +69,8 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+          http2 = false
+          download-attempts = 10
           # apk.nix boots a qemu VM, so its build is __noChroot; relaxed permits
           # that while still sandboxing everything else.
           sandbox = relaxed
@@ -97,6 +108,8 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+          http2 = false
+          download-attempts = 10
     - name: Run combined emulator test (lifecycle + UI + buttons + scroll)
       run: nix-build nix/ci.nix -A emulator-all -o result-emulator-all && ./result-emulator-all/bin/test-all
     - name: Cancel workflow on failure
@@ -122,6 +135,8 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+          http2 = false
+          download-attempts = 10
     - name: Run armv7a emulator test
       run: nix-build nix/ci.nix -A emulator-armv7a -o result-emulator-armv7a && ./result-emulator-armv7a/bin/test-all
     - name: Cancel workflow on failure
@@ -142,6 +157,8 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+          http2 = false
+          download-attempts = 10
     - run: nix-build nix/ci.nix -A simulator-all -A ios-lib
     - name: Run combined simulator test (lifecycle + UI + buttons + scroll)
       run: nix-build nix/ci.nix -A simulator-all -o result-simulator-all && ./result-simulator-all/bin/test-all-ios
@@ -165,6 +182,8 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+          http2 = false
+          download-attempts = 10
     - name: Build watchOS (with diagnostics)
       run: |
         # Background watchdog: every 60s log what nix is building + system load

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ ios/Hatter.xcodeproj/
 # Staging dirs populated from nix build output
 ios/lib/
 ios/include/
+
+# Stray command-output logs
+*.log

--- a/docs/android-emulator-flake-ci-options.md
+++ b/docs/android-emulator-flake-ci-options.md
@@ -1,0 +1,119 @@
+# Android Emulator Flakiness: Free-Tier CI Options
+
+Issue: [#208](https://github.com/jappeace/hatter/issues/208)
+Date: 2026-06-17
+
+Investigation of how to make the android emulator CI job reliable on free
+tiers, given that the app must keep shipping arm (arm64-v8a / armeabi-v7a)
+native code.
+
+## Problem
+
+The android emulator job intermittently fails with `SIGSEGV`. The crash
+backtrace shows the fault is not in hatter: all 101 crashes in one failing run
+are inside `ndk_translation_HandleNoExec` (`libndk_translation.so`), with no
+hatter frame.
+
+```
+#01 libndk_translation.so (ndk_translation_HandleNoExec+208)
+#02 libndk_translation.so (ndk_translation::ExecuteGuest+224)
+```
+
+The CI emulator is **x86_64**, but the app ships **arm64-v8a / armeabi-v7a**
+native code, so every native call runs under the emulator's ARM to x86 binary
+translation layer. That layer intermittently faults (`SEGV_ACCERR`) managing
+its JIT code cache. The identical APK passes on a re-run, so the crash is a
+transient emulator flake, not a hatter bug.
+
+The shipped mitigation (see `test/android/retryable-crash.sh`, wired into
+`run_with_retry` in `nix/emulator-all.nix`) retries the transient crash instead
+of failing the job on first hit. That makes CI resilient but does not remove the
+crash. Removing it means executing arm code on an arm CPU (option 1) or on a
+real device (option 2). hatter is a **public** repo, which is decisive for what
+is free.
+
+## Verdict at a glance
+
+| Path | Free? | Eliminates flake? | Viable? |
+|---|---|---|---|
+| macOS arm64 runner (`macos-latest`, Apple Silicon) | Yes, free and unlimited on public repos | Yes, native arm via Hypervisor.Framework, no translation | Yes, best free option |
+| Firebase Test Lab (Spark free tier) | Yes, 5 physical + 10 virtual runs/day | Yes, on physical (real arm) devices | Quota-limited, needs test restructuring |
+| Linux arm64 runner (`ubuntu-24.04-arm`) | Yes, free | Yes, in principle | No: lacks KVM, so unaccelerated and too slow |
+| AWS Device Farm | No: 1000 free *trial* minutes once, then paid | Yes, real devices | No sustainable free tier |
+
+## Details
+
+### 1. macOS arm64 runner: the strongest free option
+
+`macos-latest` is Apple Silicon (arm64) and is free and unlimited on public
+repositories. hatter already runs the iOS and watchOS jobs on `macos-latest`,
+so the infrastructure and billing are proven for this repo. On Apple Silicon,
+the android emulator runs an `arm64-v8a` system image natively via
+Hypervisor.Framework, so `libndk_translation` is never in the path and the
+`HandleNoExec` fault is structurally impossible. The `android-emulator-runner`
+action supports macOS with Hypervisor.Framework, and `hannesa2/action-android-arm64`
+exists specifically for Apple Silicon arm64 android.
+
+Cost is engineering, not money. The android job is a bespoke nix harness
+(`nix/emulator-all.nix`) tightly coupled to Linux. Two sub-paths:
+
+- **(a) Faithful port:** run the android build and emulator under nix on
+  `aarch64-darwin`. Keeps nix reproducibility, but is uncertain: nixpkgs'
+  android emulator on Darwin is less travelled.
+- **(b) Pragmatic swap:** for the android job only, drop the nix harness and use
+  `reactivecircus/android-emulator-runner` on `macos-latest` with an
+  `arm64-v8a` image. Well-trodden and fast to stand up, but loses nix
+  reproducibility for that one job.
+
+Caveat: `arm64-v8a` system images are limited to fewer API levels (around API
+30 or 31).
+
+### 2. Firebase Test Lab: free, real arm hardware, but quota-bound
+
+The Spark (free) plan gives 5 physical-device plus 10 virtual-device test runs
+per day. Physical devices are real arm hardware, so no translation and no flake.
+No evidence was found of a blanket physical-device shutdown; individual models
+age out of the catalog over time.
+
+Cost is restructuring plus limits. The test would be converted to Firebase Test
+Lab's instrumentation or Robo model (upload APK plus test, not the bespoke
+logcat harness), accept the 5-per-day physical cap, and take on an external
+dependency plus a service-account secret. Fine for an occasionally-pushed repo,
+tight if CI runs often.
+
+### 3. Linux arm64 free runners: no KVM (non-starter)
+
+Free Linux arm64 runners (`ubuntu-22.04-arm`, `ubuntu-24.04-arm`) do not expose
+`/dev/kvm`. GitHub staff, verbatim in community discussion #148648: "nested virt
+is not supported for this sku" (Azure DPDSv6 series), and "as soon as azure
+supports it, we can support it, but just blocked until then." Without KVM the
+emulator runs in software (TCG), which is glacial and would likely re-create the
+original 6h timeout. Dead end while acceleration is required.
+
+### 4. AWS Device Farm: not a sustainable free tier
+
+A one-time 1000-minute free trial, then $0.17 per device-minute. Not suitable
+for recurring CI.
+
+## Recommendation
+
+Move the android emulator job to `macos-latest`. It is the only path that is
+genuinely free for this repo (public, already in use), keeps arm64 as the tested
+target, and eliminates the flake rather than retrying around it. Start with
+sub-path (b) (the `reactivecircus` action on `macos-latest` with an `arm64-v8a`
+image) to prove the flake disappears quickly; if it does, decide whether to
+invest in the faithful nix-on-Darwin port. Keep the retry classifier as a cheap
+safety net regardless.
+
+If macOS runner contention or the `arm64-v8a` API-level limit becomes a problem,
+Firebase Test Lab Spark is the fallback (real arm devices, 5 per day free).
+
+## Sources
+
+- [arm64 hosted runners GA for public repos (GitHub Changelog)](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/)
+- [Linux arm64 runners lack nested virtualization (community discussion #148648)](https://github.com/orgs/community/discussions/148648)
+- [GitHub-hosted runners reference: macOS standard runners free and unlimited on public repos; `macos-latest` is arm64](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+- [android-emulator-runner (macOS Hypervisor.Framework support)](https://github.com/ReactiveCircus/android-emulator-runner)
+- [hannesa2/action-android-arm64 (Apple Silicon arm64 android)](https://github.com/hannesa2/action-android-arm64)
+- [Firebase Test Lab usage, quotas and pricing (Spark: 5 physical, 10 virtual per day)](https://firebase.google.com/docs/test-lab/usage-quotas-pricing)
+- [AWS Device Farm FAQs (1000 free trial minutes, then $0.17 per device-minute)](https://aws.amazon.com/device-farm/faqs/)

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -10,15 +10,14 @@
 }:
 let
   lib = import ./lib.nix { inherit sources androidArch; };
+  hatterSrc = import ./hatter-src.nix { inherit sources; };
   # Hatter is built as a normal cross-compiled Haskell package through
   # haskellPackages.  Nix caches the result by (hatterSrc, androidArch),
   # so all apps sharing the same hatter source reuse the same compilation.
   crossDeps = import ./cross-deps.nix {
-    inherit sources androidArch consumerCabalFile consumerCabal2Nix hpkgs;
-    hatterSrc = ../.;
+    inherit sources androidArch consumerCabalFile consumerCabal2Nix hpkgs hatterSrc;
   };
 in
 lib.mkAndroidLib {
-  hatterSrc = ../.;
-  inherit mainModule crossDeps maxNodes dynamicNodePool;
+  inherit hatterSrc mainModule crossDeps maxNodes dynamicNodePool;
 }

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -10,6 +10,8 @@
 }:
 let
   lib = import ./lib.nix { inherit sources androidArch; };
+  # Filtered source, not ../. , so platform-file edits don't bust the
+  # cross-compile cache (see nix/hatter-src.nix and issue #208).
   hatterSrc = import ./hatter-src.nix { inherit sources; };
   # Hatter is built as a normal cross-compiled Haskell package through
   # haskellPackages.  Nix caches the result by (hatterSrc, androidArch),

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -108,8 +108,18 @@ let
 
   testScripts = builtins.path { path = ../test; name = "test-scripts"; };
 
+  # Pure-bash check (no emulator) for the crash retry classifier that decides
+  # whether an emulator crash is the transient ndk_translation flake (issue
+  # #208, retry) or a deterministic native failure (give up).
+  retryClassificationTest = pkgs.runCommand "retry-classification-test" {} ''
+    bash ${testScripts}/android/retryable-crash-test.sh
+    touch $out
+  '';
+
 in
   buildTargets // testRunners // knownFailing // {
+    inherit retryClassificationTest;
+
     # Meta-target: builds every compilation/link-test target.
     # Excludes emulator/simulator runners (they have dedicated CI jobs).
     # Adding a new attr to buildTargets automatically includes it here.
@@ -119,6 +129,7 @@ in
         builtins.map (name: "ln -s ${buildTargets.${name}} $out/${name}")
           (builtins.attrNames buildTargets)
       )}
+      ln -s ${retryClassificationTest} $out/retry-classification-test
     '';
 
     # Lint all test shell scripts with shellcheck.

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -748,7 +748,8 @@ run_with_retry() {
             # LOAD is deterministic, but a runtime SIGSEGV on the x86_64 emulator
             # is dominated by the ARM->x86 translation flake
             # (ndk_translation_HandleNoExec, issue #208) and passes on a re-run.
-            # retryable-crash.sh decides which case this is.
+            # retryable-crash.sh decides which case this is. $TEST_SCRIPTS is
+            # the test-tree root set near the top of this harness script.
             if bash "$TEST_SCRIPTS/android/retryable-crash.sh" "$output_file"; then
                 echo "[$label] transient crash, likely the ndk_translation ARM-emulation flake, retrying"
             else

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -744,8 +744,17 @@ run_with_retry() {
             return 0
         fi
         if grep -q "^FATAL:" "$output_file" 2>/dev/null; then
-            echo "[$label] FATAL error detected — not retrying"
-            return 1
+            # Not every "FATAL:" is permanent. A native library that fails to
+            # LOAD is deterministic, but a runtime SIGSEGV on the x86_64 emulator
+            # is dominated by the ARM->x86 translation flake
+            # (ndk_translation_HandleNoExec, issue #208) and passes on a re-run.
+            # retryable-crash.sh decides which case this is.
+            if bash "$TEST_SCRIPTS/android/retryable-crash.sh" "$output_file"; then
+                echo "[$label] transient crash, likely the ndk_translation ARM-emulation flake, retrying"
+            else
+                echo "[$label] deterministic native failure, not retrying"
+                return 1
+            fi
         fi
         echo "[$label] attempt $attempt FAILED"
         attempt=$((attempt + 1))

--- a/nix/hatter-src.nix
+++ b/nix/hatter-src.nix
@@ -1,0 +1,36 @@
+# Filtered hatter source tree for the GHC (cross-)builds.
+#
+# Decision: use lib.fileset.toSource to pin the build inputs to only the
+# Haskell-relevant paths. Alternatives considered: passing ../. directly (the
+# whole repo, so any Swift, project.yml, nix/, docs or npins change altered the
+# source hash and rebuilt the expensive GHC cross-compile from scratch instead
+# of pulling it from the community cache, see issue #208), and lib.cleanSource
+# (still drags in ios/, watchos/, android/, docs/, makefile, etc.). Keeping the
+# fileset explicit means editing a platform or tooling file no longer
+# invalidates the cross-compilation cache.
+#
+# What the (cross-)builds actually read from this tree:
+#   src/, include/, cbits/ - library Haskell + C bridge sources (lib.nix)
+#   hatter.cabal           - callCabal2nix in cross-deps.nix
+#   LICENSE                - the cabal declares license-file: LICENSE, so the
+#                            Setup copy phase fails without it; not Haskell, but
+#                            required for the build to succeed.
+# test/ is deliberately excluded: cross-deps.nix strips the executable and
+# test-suite stanzas (they cannot link on the target), and the iOS/watchOS
+# wrappers pass their entry module through mainModule, not this tree.
+{ sources ? import ../npins
+,
+}:
+let
+  pkgs = import ./pkgs.nix { inherit sources; };
+in
+pkgs.lib.fileset.toSource {
+  root = ../.;
+  fileset = pkgs.lib.fileset.unions [
+    ../src
+    ../cbits
+    ../include
+    ../hatter.cabal
+    ../LICENSE
+  ];
+}

--- a/nix/hatter-src.nix
+++ b/nix/hatter-src.nix
@@ -15,6 +15,16 @@
 #   LICENSE                - the cabal declares license-file: LICENSE, so the
 #                            Setup copy phase fails without it; not Haskell, but
 #                            required for the build to succeed.
+#   nix/mac2ios.nix,       - mkIOSLib / mkWatchOSLib import these from hatterSrc
+#   nix/mac2watchos.nix      (lib.nix:560,798) to build the Mach-O platform-tag
+#                            patchers. Included as individual files, NOT the
+#                            whole nix/ dir, so editing lib.nix or any other nix
+#                            file still does not invalidate the cross cache.
+#                            mac2watchos.nix compiles cbits/mac2watchos.c (in
+#                            the cbits/ tree above); mac2ios.nix builds from
+#                            sources.mobile-core-tools. Both are imported with
+#                            sources and pkgs supplied, so their ../npins
+#                            defaults never resolve against this tree.
 # test/ is deliberately excluded: cross-deps.nix strips the executable and
 # test-suite stanzas (they cannot link on the target), and the iOS/watchOS
 # wrappers pass their entry module through mainModule, not this tree.
@@ -32,5 +42,7 @@ pkgs.lib.fileset.toSource {
     ../include
     ../hatter.cabal
     ../LICENSE
+    ../nix/mac2ios.nix
+    ../nix/mac2watchos.nix
   ];
 }

--- a/nix/ios.nix
+++ b/nix/ios.nix
@@ -19,7 +19,7 @@ let
   };
 in
 lib.mkIOSLib {
-  hatterSrc = ../.;
+  hatterSrc = import ./hatter-src.nix { inherit sources; };
   inherit mainModule simulator;
   crossDeps = iosDeps;
 }

--- a/nix/ios.nix
+++ b/nix/ios.nix
@@ -19,6 +19,8 @@ let
   };
 in
 lib.mkIOSLib {
+  # Filtered source, not ../. , so platform-file edits don't bust the
+  # cross-compile cache (see nix/hatter-src.nix and issue #208).
   hatterSrc = import ./hatter-src.nix { inherit sources; };
   inherit mainModule simulator;
   crossDeps = iosDeps;

--- a/nix/watchos.nix
+++ b/nix/watchos.nix
@@ -15,6 +15,8 @@ let
   };
 in
 lib.mkWatchOSLib {
+  # Filtered source, not ../. , so platform-file edits don't bust the
+  # cross-compile cache (see nix/hatter-src.nix and issue #208).
   hatterSrc = import ./hatter-src.nix { inherit sources; };
   inherit mainModule simulator;
   crossDeps = iosDeps;

--- a/nix/watchos.nix
+++ b/nix/watchos.nix
@@ -15,7 +15,7 @@ let
   };
 in
 lib.mkWatchOSLib {
-  hatterSrc = ../.;
+  hatterSrc = import ./hatter-src.nix { inherit sources; };
   inherit mainModule simulator;
   crossDeps = iosDeps;
 }

--- a/test/android/retryable-crash-test.sh
+++ b/test/android/retryable-crash-test.sh
@@ -47,6 +47,16 @@ FATAL: App crashed before rendering, aborting node-pool
 EOF
 expect 1 "SIGABRT is not retryable" "$tmp/abort.log"
 
+# Both a deterministic load failure AND a SIGSEGV present: the deterministic
+# verdict must win (load failures are checked first), so this is not retryable.
+# Pins the grep precedence so a future reordering would fail this test.
+cat > "$tmp/mixed.log" <<'EOF'
+E AndroidRuntime: java.lang.UnsatisfiedLinkError: dlopen failed: library "libhatter.so" not found
+F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR) in tid 100 (e.jappie.hatter)
+FATAL: App crashed, aborting
+EOF
+expect 1 "load failure wins over SIGSEGV" "$tmp/mixed.log"
+
 if [ "$failures" -ne 0 ]; then
     echo "retryable-crash classification test FAILED ($failures case(s))"
     exit 1

--- a/test/android/retryable-crash-test.sh
+++ b/test/android/retryable-crash-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Asserts retryable-crash.sh classifies crashes correctly.
+# Pure log classification: no emulator or device needed, so it runs as a cheap
+# nix check (ci.nix: retry-classification-test) in the normal build job.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+classify="$here/retryable-crash.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+
+# expect EXPECTED_EXIT LABEL FIXTURE_FILE
+expect() {
+    local expected="$1" label="$2" fixture="$3"
+    local rc=0
+    bash "$classify" "$fixture" || rc=$?
+    if [ "$rc" -ne "$expected" ]; then
+        echo "FAIL: $label (expected exit $expected, got $rc)"
+        failures=$((failures + 1))
+    else
+        echo "ok: $label (exit $rc)"
+    fi
+}
+
+# The real ndk_translation SIGSEGV flake (issue #208): must be retryable.
+cat > "$tmp/translation.log" <<'EOF'
+=== FATAL: App crashed ===
+F libc    : Fatal signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr 0x70a481c43c74 in tid 6973 (e.jappie.hatter)
+F DEBUG   :       #01 pc 0000000000208e30  /system/lib64/libndk_translation.so (ndk_translation_HandleNoExec+208)
+FATAL: App crashed before rendering, aborting lifecycle
+EOF
+expect 0 "ndk_translation SIGSEGV is retryable" "$tmp/translation.log"
+
+# A genuine native-library load failure: deterministic, must not retry.
+cat > "$tmp/load.log" <<'EOF'
+E AndroidRuntime: java.lang.UnsatisfiedLinkError: dlopen failed: library "libhatter.so" not found
+FATAL: Native library failed to load, aborting
+EOF
+expect 1 "UnsatisfiedLinkError is not retryable" "$tmp/load.log"
+
+# A deliberate abort (RTS panic / assertion): deterministic, must not retry.
+cat > "$tmp/abort.log" <<'EOF'
+F libc    : Fatal signal 6 (SIGABRT), code -1 in tid 100 (e.jappie.hatter)
+FATAL: App crashed before rendering, aborting node-pool
+EOF
+expect 1 "SIGABRT is not retryable" "$tmp/abort.log"
+
+if [ "$failures" -ne 0 ]; then
+    echo "retryable-crash classification test FAILED ($failures case(s))"
+    exit 1
+fi
+echo "retryable-crash classification test passed"

--- a/test/android/retryable-crash.sh
+++ b/test/android/retryable-crash.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# retryable-crash.sh OUTPUT_FILE
+#
+# Classifies a detected Android app crash so the test harness (run_with_retry in
+# nix/emulator-all.nix) knows whether retrying is worthwhile. It is only called
+# once a "^FATAL:" line has already been seen in OUTPUT_FILE, so a crash did
+# happen; this decides whether that crash is transient or deterministic.
+#
+# Why this exists: the CI emulator is x86_64, but the app ships arm64-v8a /
+# armeabi-v7a native code, so every native call runs under the emulator's
+# ARM->x86 binary-translation layer. That layer intermittently SIGSEGVs in
+# ndk_translation_HandleNoExec (issue #208) while managing its JIT code cache;
+# the identical APK passes on a re-run, so such a crash is a flake worth
+# retrying. A native library that fails to LOAD, or a deliberate abort, fails
+# the same way on every attempt, so retrying it only wastes CI minutes.
+#
+# Exit 0: transient, retry.
+# Exit 1: deterministic, do not retry.
+set -u
+
+output_file="${1:?usage: retryable-crash.sh OUTPUT_FILE}"
+
+# Deterministic failures: a missing/unloadable native library, an unresolved
+# symbol, or a deliberate abort (RTS panic, assertion) recur every attempt.
+if grep -qE "UnsatisfiedLinkError|dlopen failed|cannot locate symbol|SIGABRT" "$output_file" 2>/dev/null; then
+    exit 1
+fi
+
+# A runtime segfault on this translated emulator is dominated by the
+# ndk_translation flake. Treat any SIGSEGV / fatal signal as retryable.
+if grep -qE "SIGSEGV|Fatal signal" "$output_file" 2>/dev/null; then
+    exit 0
+fi
+
+# Any other unrecognised FATAL: be conservative and do not retry.
+exit 1


### PR DESCRIPTION
## Summary

Fixes #208, which reported two CI symptoms and guessed both were nix cache invalidation: a watchOS 6h timeout and an android emulator SIGSEGV. Investigation showed they have **different** root causes, and this PR addresses both.

### 1. Cache invalidation (the watchOS timeout) — source filtering

`hatterSrc = ../.` handed the **entire repo** to the GHC cross builds, so the nix source hash changed on any tracked-file edit. A one-line Swift change in `ios/`/`watchos/` invalidated the GHC cross-compilation derivation, forcing a from-scratch rebuild that missed the community cache. That is what timed out watchOS.

Fix: new `nix/hatter-src.nix`, a `lib.fileset.toSource` view of only the inputs the (cross-)builds read (`src/`, `include/`, `cbits/`, `hatter.cabal`, `LICENSE`, and `nix/mac2ios.nix` + `nix/mac2watchos.nix`, which `mkIOSLib`/`mkWatchOSLib` import from `hatterSrc`). Wired into `watchos.nix`, `ios.nix`, `android.nix` in place of `../.`. Mirrors `haskell-template-project`'s `nix/hpkgs.nix`. Verified: a `watchos/*.swift` edit leaves the source hash unchanged; a `src/*.hs` edit changes it.

### 2. The android SIGSEGV was NOT cache invalidation — an emulator translation flake

The crash backtrace tells a different story: all 101 crashes in the failing run are inside `ndk_translation_HandleNoExec` (`libndk_translation.so`), with no hatter frame. The CI emulator is **x86_64** but the app ships **arm64-v8a/armeabi-v7a** native code, so every native call runs under the emulator's **ARM→x86 binary-translation layer**, which intermittently faults (`SEGV_ACCERR`) managing its JIT code cache. The identical APK passes on a re-run, so it is a transient emulator flake, not a hatter bug.

The harness already retries phases up to 10×, but `run_with_retry` treated any `^FATAL:` output as permanent. The test scripts emit `FATAL:` for a SIGSEGV, so the translation flake was misclassified as fatal and failed the job on first hit (zero effective retries). Fix: classify crashes, genuine native **load** failures (`UnsatisfiedLinkError`, `dlopen failed`, missing symbol) and deliberate aborts (`SIGABRT`) stay non-retryable; a runtime SIGSEGV becomes retryable. Logic lives in one top-level script `test/android/retryable-crash.sh` with a pure-bash test wired into `ci.nix` `all-builds` (runs in the normal build job, no emulator).

The deeper fix, eliminating translation by building an x86_64-android lib for the x86_64 emulator, is a larger toolchain change left for a follow-up.

## Test plan

- [x] Filtered store path contains exactly the intended paths; `watchos/*.swift` edit → unchanged hash, `src/*.hs` edit → changed hash.
- [x] iOS/watchOS/nix-build/android(+armv7a) all green on the latest run (android via re-run, the flake this PR now retries automatically).
- [x] `retryable-crash.sh` classifies the **real** captured ndk_translation tombstone as retryable, and `UnsatisfiedLinkError`/`SIGABRT` as not; test passes locally and runs in CI via `all-builds`.
- [ ] CI green on this commit, with any android translation flake retried instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)