### PR TITLE
ci: keep http2 enabled on macos-apk (HTTP/1.1 stalled the NDK download)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,8 @@ jobs:
           # curl failure mode, download-attempts covers other transient drops.
           # Alternative --fallback was rejected: a cache miss on the patched GHC
           # would rebuild it from source in CI (hours) instead of failing fast.
-          # These two lines are repeated in every job's extra_nix_config below.
+          # These two lines are repeated in every Linux and simulator job below;
+          # macos-apk deliberately omits them (HTTP/1.1 stalled its downloads).
           http2 = false
           download-attempts = 10
     - name: Build all nix targets (excludes emulator/simulator runners)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,10 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
-          http2 = false
-          download-attempts = 10
+          # No http2=false here, unlike every other job: on macos-15-intel the
+          # HTTP/1.1 download of the multi-GB NDK toolchain NARs stalled
+          # silently for 99 minutes and timed out the job (run 28588129668),
+          # while HTTP/2 has only ever failed on the ubuntu runners.
           # apk.nix boots a qemu VM, so its build is __noChroot; relaxed permits
           # that while still sandboxing everything else.
           sandbox = relaxed


### PR DESCRIPTION
## Summary
- #227 merged with the `http2 = false` cache hardening applied to every job, but on macos-15-intel that config stalled the NDK-toolchain NAR download silently for 99 minutes and timed out the job at 2h (run 28588129668). These two commits were pushed to #227's branch minutes after it merged, so they carry the fix to master as a fresh PR.
- Scopes `http2 = false` / `download-attempts = 10` to the jobs where the HTTP/2 framing-layer failures were actually observed (the ubuntu runners, where android has now passed repeatedly with HTTP/1.1) and documents the macos-apk exception in place.
- Note master's own post-#227 run passed with the unscoped config (macos-apk survived HTTP/1.1 that time), so this is about removing a one-in-two observed hang, not a hard breakage.

## Test plan
- [ ] CI passes on all six jobs
- [ ] macos-apk completes in its usual 28-60 min band rather than flirting with the 120 min timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)