### PR TITLE
Simulate BLE traffic in emulator CI and add BLE connect API (first slice of #108)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,25 @@
 # Change log for hatter
 
+## Unreleased
+
+### Added
+
+- `Hatter.Ble` connection API (issue #108, first slice):
+  `connectBleDevice`, `disconnectBleDevice`, and the
+  `BleConnectionEvent` sum type (`BleConnectionEstablished`,
+  `BleConnectionClosed`, `BleConnectionFailed`) with streaming
+  connection-state callbacks.  Implemented on Android
+  (`BluetoothGatt`) and iOS (`CBCentralManager`); the desktop stub
+  fails connections visibly.  GATT service discovery,
+  characteristic read/write/subscribe, and scan filtering remain
+  open in #108.
+- The Android emulator CI job now simulates real BLE traffic: the
+  emulator boots with a netsim virtual radio and a bumble-based
+  virtual peripheral (`test/android/ble_peripheral.py`) advertises
+  into it.  The BLE test asserts hatter's scan callback receives the
+  advertisement and that hatter code can connect to and disconnect
+  from the peripheral.  See docs/ble-emulator-simulation.md.
+
 ## Version 0.3.0 2026.04.19
 
 ### Breaking changes

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,9 @@
   fails connections visibly.  GATT service discovery,
   characteristic read/write/subscribe, and scan filtering remain
   open in #108.
+- `BleDeviceAddress` newtype: `bsrDeviceAddress` and
+  `connectBleDevice` use it instead of a bare `Text` (breaking for
+  existing `BleScanResult` consumers).
 - The Android emulator CI job now simulates real BLE traffic: the
   emulator boots with a netsim virtual radio and a bumble-based
   virtual peripheral (`test/android/ble_peripheral.py`) advertises

--- a/android/java/me/jappie/hatter/HatterActivity.java
+++ b/android/java/me/jappie/hatter/HatterActivity.java
@@ -4,7 +4,11 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothManager;
+import android.bluetooth.BluetoothProfile;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanRecord;
@@ -72,6 +76,7 @@ public class HatterActivity extends Activity implements View.OnClickListener {
     private native void onPermissionResult(int requestCode, int statusCode);
     private native void onSecureStorageResult(int requestId, int statusCode, String value);
     private native void onBleScanResult(String deviceName, String deviceAddress, int rssi);
+    private native void onBleConnectionEvent(int event);
     private native void onDialogResult(int requestId, int actionCode);
     private native void onLocationResult(double lat, double lon, double alt, double acc);
     private native void onAuthSessionResult(int requestId, int statusCode,
@@ -94,6 +99,16 @@ public class HatterActivity extends Activity implements View.OnClickListener {
 
     private BluetoothLeScanner bleScanner;
     private ScanCallback bleScanCallback;
+    private BluetoothGatt bleGatt;
+    /**
+     * Devices seen during the current scan, keyed by address.  Connecting
+     * through the scanned BluetoothDevice preserves the address type
+     * (public vs random): adapter.getRemoteDevice(address) assumes a
+     * public address and fails to connect to peripherals advertising
+     * with a random static address.
+     */
+    private final java.util.HashMap<String, BluetoothDevice> bleScannedDevices =
+        new java.util.HashMap<>();
 
     private LocationManager locationManager;
     private LocationListener locationListener;
@@ -268,6 +283,7 @@ public class HatterActivity extends Activity implements View.OnClickListener {
                     String name = record != null ? record.getDeviceName() : null;
                     String address = result.getDevice().getAddress();
                     int rssi = result.getRssi();
+                    bleScannedDevices.put(address, result.getDevice());
                     onBleScanResult(name, address, rssi);
                 }
             };
@@ -289,6 +305,86 @@ public class HatterActivity extends Activity implements View.OnClickListener {
             }
         } catch (Exception e) {
             android.util.Log.e("BleBridge", "stopBleScan failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Connect to a BLE device by address. Called from native code via JNI.
+     * Connection state changes are delivered via the onBleConnectionEvent
+     * JNI callback: 0 = established, 1 = closed, 2 = failed.
+     * Only one GATT connection is held at a time; connecting again closes
+     * the previous client first.
+     */
+    public void connectBleDevice(String address) {
+        try {
+            if (bleGatt != null) {
+                bleGatt.close();
+                bleGatt = null;
+            }
+            BluetoothManager manager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
+            BluetoothAdapter adapter = manager != null ? manager.getAdapter() : null;
+            if (adapter == null || !adapter.isEnabled()) {
+                android.util.Log.e("BleBridge", "connectBleDevice: adapter unavailable");
+                onBleConnectionEvent(2 /* FAILED */);
+                return;
+            }
+            BluetoothDevice device = bleScannedDevices.get(address);
+            if (device == null) {
+                device = adapter.getRemoteDevice(address);
+            }
+            BluetoothGattCallback gattCallback = new BluetoothGattCallback() {
+                @Override
+                public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
+                    android.util.Log.i("BleBridge",
+                        "onConnectionStateChange status=" + status + " newState=" + newState);
+                    final int event;
+                    if (newState == BluetoothProfile.STATE_CONNECTED) {
+                        event = 0; // ESTABLISHED
+                    } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                        // A disconnect with an error status on a connection
+                        // that was never established is a failed connect.
+                        event = status == BluetoothGatt.GATT_SUCCESS ? 1 /* CLOSED */ : 2 /* FAILED */;
+                        gatt.close();
+                        if (bleGatt == gatt) {
+                            bleGatt = null;
+                        }
+                    } else {
+                        return; // ignore intermediate CONNECTING/DISCONNECTING
+                    }
+                    // GATT callbacks arrive on a binder thread; the JNI env
+                    // cached by the native bridge is only valid on the UI
+                    // thread, so hop over before calling into Haskell.
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            onBleConnectionEvent(event);
+                        }
+                    });
+                }
+            };
+            bleGatt = device.connectGatt(this, false, gattCallback, BluetoothDevice.TRANSPORT_LE);
+            if (bleGatt == null) {
+                android.util.Log.e("BleBridge", "connectBleDevice: connectGatt returned null");
+                onBleConnectionEvent(2 /* FAILED */);
+            }
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge", "connectBleDevice failed: " + e.getMessage());
+            onBleConnectionEvent(2 /* FAILED */);
+        }
+    }
+
+    /**
+     * Disconnect the active BLE connection. Called from native code via JNI.
+     * The CLOSED event is delivered asynchronously through the GATT callback
+     * registered by connectBleDevice.
+     */
+    public void disconnectBleDevice() {
+        try {
+            if (bleGatt != null) {
+                bleGatt.disconnect();
+            }
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge", "disconnectBleDevice failed: " + e.getMessage());
         }
     }
 

--- a/cbits/ble_bridge.c
+++ b/cbits/ble_bridge.c
@@ -1,5 +1,5 @@
 /*
- * Platform-agnostic BLE scanning bridge dispatcher.
+ * Platform-agnostic BLE bridge dispatcher.
  *
  * Stores function pointers filled by the platform (Android/iOS).
  * Each ble_* function delegates to the corresponding pointer.
@@ -8,15 +8,23 @@
  * native code.
  *
  * Unlike the permission bridge, no fabricated devices are delivered
- * on desktop — start_scan is a no-op.
+ * on desktop; start_scan is a no-op.  Connection attempts however
+ * always produce an event: with no registered implementation,
+ * ble_connect dispatches BLE_CONNECTION_FAILED so that callers are
+ * never left waiting on a connection that can not happen.
  */
 
 #include "BleBridge.h"
 #include <stdio.h>
 
+/* Haskell FFI export (dispatches connection events back to Haskell) */
+extern void haskellOnBleConnectionEvent(void *ctx, int32_t event);
+
 static int32_t (*g_check_adapter_impl)(void) = NULL;
 static void (*g_start_scan_impl)(void *) = NULL;
 static void (*g_stop_scan_impl)(void) = NULL;
+static void (*g_connect_impl)(void *, const char *) = NULL;
+static void (*g_disconnect_impl)(void) = NULL;
 
 void ble_register_impl(
     int32_t (*check_adapter)(void),
@@ -26,6 +34,14 @@ void ble_register_impl(
     g_check_adapter_impl = check_adapter;
     g_start_scan_impl = start_scan;
     g_stop_scan_impl = stop_scan;
+}
+
+void ble_register_connect_impl(
+    void (*connect)(void *, const char *),
+    void (*disconnect)(void))
+{
+    g_connect_impl = connect;
+    g_disconnect_impl = disconnect;
 }
 
 int32_t ble_check_adapter(void)
@@ -56,4 +72,36 @@ void ble_stop_scan(void)
     }
     /* Desktop stub: no-op */
     fprintf(stderr, "[BleBridge stub] ble_stop_scan() -> no-op\n");
+}
+
+void ble_connect(void *ctx, const char *address)
+{
+    if (g_connect_impl) {
+        g_connect_impl(ctx, address);
+        return;
+    }
+    /* No implementation (desktop, or a consumer Activity without the
+     * connect JNI methods): fail the connection immediately and loudly
+     * instead of leaving the caller waiting forever. */
+    fprintf(stderr,
+            "[BleBridge stub] ble_connect(\"%s\") -> BLE_CONNECTION_FAILED"
+            " (no platform connect implementation registered)\n",
+            address ? address : "(null)");
+    if (ctx) {
+        haskellOnBleConnectionEvent(ctx, BLE_CONNECTION_FAILED);
+    } else {
+        fprintf(stderr,
+                "[BleBridge stub] ble_connect: null context,"
+                " cannot dispatch failure event\n");
+    }
+}
+
+void ble_disconnect(void)
+{
+    if (g_disconnect_impl) {
+        g_disconnect_impl();
+        return;
+    }
+    /* Desktop stub: no-op (nothing can be connected without an impl) */
+    fprintf(stderr, "[BleBridge stub] ble_disconnect() -> no-op\n");
 }

--- a/cbits/ble_bridge_android.c
+++ b/cbits/ble_bridge_android.c
@@ -1,11 +1,14 @@
 /*
- * Android implementation of the BLE scanning bridge callbacks.
+ * Android implementation of the BLE bridge callbacks.
  *
  * Uses JNI to call Activity.checkBleAdapter(), Activity.startBleScan(),
- * and Activity.stopBleScan(). Compiled by NDK clang, not cabal.
+ * Activity.stopBleScan(), Activity.connectBleDevice() and
+ * Activity.disconnectBleDevice(). Compiled by NDK clang, not cabal.
  *
  * All functions run on the main/UI thread, the same thread that
- * calls haskellRenderUI from Java.
+ * calls haskellRenderUI from Java.  The Java side posts connection
+ * events back on the UI thread as well (runOnUiThread), so g_env
+ * stays valid for every callback.
  */
 
 #include <jni.h>
@@ -17,8 +20,9 @@
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 
-/* Haskell FFI export (dispatches scan result back to Haskell callback) */
+/* Haskell FFI exports (dispatch results back to Haskell callbacks) */
 extern void haskellOnBleScanResult(void *ctx, const char *name, const char *address, int32_t rssi);
+extern void haskellOnBleConnectionEvent(void *ctx, int32_t event);
 
 /* ---- Global state (valid only on the UI thread) ---- */
 static JNIEnv  *g_env          = NULL;
@@ -29,6 +33,8 @@ static void    *g_haskell_ctx   = NULL;   /* stored for async JNI callback */
 static jmethodID g_method_checkBleAdapter;
 static jmethodID g_method_startBleScan;
 static jmethodID g_method_stopBleScan;
+static jmethodID g_method_connectBleDevice;
+static jmethodID g_method_disconnectBleDevice;
 
 /* ---- BLE bridge implementations ---- */
 
@@ -83,6 +89,41 @@ static void android_ble_stop_scan(void)
     }
 }
 
+static void android_ble_connect(void *ctx, const char *address)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_connect: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("ble_connect(%s)", address ? address : "(null)");
+    jstring jaddress = (*env)->NewStringUTF(env, address ? address : "");
+    (*env)->CallVoidMethod(env, g_activity, g_method_connectBleDevice, jaddress);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_connect: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+    (*env)->DeleteLocalRef(env, jaddress);
+}
+
+static void android_ble_disconnect(void)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_disconnect: bridge not initialized");
+        return;
+    }
+
+    LOGI("ble_disconnect()");
+    (*env)->CallVoidMethod(env, g_activity, g_method_disconnectBleDevice);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_disconnect: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+}
+
 /* ---- Public API ---- */
 
 /*
@@ -109,22 +150,39 @@ void setup_android_ble_bridge(JNIEnv *env, jobject activity, void *haskellCtx)
     g_method_stopBleScan = (*env)->GetMethodID(env, actClass,
         "stopBleScan", "()V");
 
-    /* Clean up local reference */
-    (*env)->DeleteLocalRef(env, actClass);
-
     if (!g_method_checkBleAdapter || !g_method_startBleScan || !g_method_stopBleScan) {
         LOGE("Failed to resolve BLE JNI method IDs — BLE bridge disabled");
         (*env)->ExceptionClear(env);
+        (*env)->DeleteLocalRef(env, actClass);
         return;
     }
+
+    ble_register_impl(android_ble_check_adapter, android_ble_start_scan, android_ble_stop_scan);
+
+    /* Connect methods are resolved separately: a consumer Activity that
+     * predates the connect API keeps working scans, and ble_connect
+     * then reports BLE_CONNECTION_FAILED instead of crashing. */
+    g_method_connectBleDevice = (*env)->GetMethodID(env, actClass,
+        "connectBleDevice", "(Ljava/lang/String;)V");
+    g_method_disconnectBleDevice = (*env)->GetMethodID(env, actClass,
+        "disconnectBleDevice", "()V");
+
+    if (g_method_connectBleDevice && g_method_disconnectBleDevice) {
+        ble_register_connect_impl(android_ble_connect, android_ble_disconnect);
+    } else {
+        LOGE("BLE connect JNI methods missing, BLE connections disabled"
+             " (update the Activity to the current hatter android sources)");
+        (*env)->ExceptionClear(env);
+    }
+
+    /* Clean up local reference */
+    (*env)->DeleteLocalRef(env, actClass);
 
     /* Clear any unexpected pending exception before continuing */
     if ((*env)->ExceptionCheck(env)) {
         LOGE("Unexpected JNI exception after BLE method resolution");
         (*env)->ExceptionClear(env);
     }
-
-    ble_register_impl(android_ble_check_adapter, android_ble_start_scan, android_ble_stop_scan);
 
     LOGI("Android BLE bridge initialized");
 }
@@ -155,4 +213,15 @@ JNI_METHOD(onBleScanResult)(JNIEnv *env, jobject thiz, jstring jname, jstring ja
     if (caddr) {
         (*env)->ReleaseStringUTFChars(env, jaddr, caddr);
     }
+}
+
+/* ---- JNI callback from Java BLE connection state change ---- */
+
+JNIEXPORT void JNICALL
+JNI_METHOD(onBleConnectionEvent)(JNIEnv *env, jobject thiz, jint event)
+{
+    g_env = env;
+
+    LOGI("onBleConnectionEvent(event=%d)", event);
+    haskellOnBleConnectionEvent(g_haskell_ctx, (int32_t)event);
 }

--- a/docs/ble-emulator-simulation.md
+++ b/docs/ble-emulator-simulation.md
@@ -1,0 +1,91 @@
+# BLE simulation in the emulator integration tests
+
+The Android emulator job does not just check that the BLE code paths
+avoid crashing: it places a simulated peripheral on a virtual radio,
+scans for it from hatter code, connects to it, and disconnects again.
+This document explains the moving parts.
+
+## Architecture
+
+```
+ host                                         guest (emulator)
+ ─────────────────────────────────────        ──────────────────────────
+ ble_peripheral.py                            hatter BLE demo app
+   (bumble BLE stack,                           (test/BleDemoMain.hs)
+    "HatterBleSim",                                  │ Haskell callbacks
+    connectable GATT server)                    Hatter.Ble / BleBridge
+        │ HCI over gRPC                              │ JNI
+        ▼                                       HatterActivity
+     netsimd  ◄──────── HCI over gRPC ───────  virtual BT controller
+   (virtual radio,
+    spawned by the emulator)
+```
+
+- **netsim** is the Android emulator's virtual radio environment
+  (successor of rootcanal).  Passing `-packet-streamer-endpoint
+  default` to the emulator spawns a `netsimd` daemon and gives the
+  guest a working virtual Bluetooth controller.  `netsimd` publishes
+  its gRPC port in `netsim.ini` inside `XDG_RUNTIME_DIR` (falling back
+  to `TMPDIR`); the harness pins both to the session work directory so
+  every process agrees on the discovery location.
+- **bumble** (Google's Python BLE stack, packaged in nixpkgs) connects
+  to the same `netsimd` as a second virtual controller and runs a
+  complete BLE device on it: `test/android/ble_peripheral.py`
+  advertises as a connectable peripheral named `HatterBleSim` with a
+  small GATT service.
+- The guest's Bluetooth stack receives those advertisements exactly as
+  it would from a physical device, so the whole hatter path is
+  exercised for real: `BluetoothLeScanner` → JNI (`onBleScanResult`)
+  → C bridge → `haskellOnBleScanResult` → the app's Haskell callback,
+  and for connections `connectGatt` → `onConnectionStateChange` → JNI
+  → `haskellOnBleConnectionEvent`.
+
+The test (`test/android/ble.sh`, `BLE_SIM=1`) asserts through logcat:
+
+1. `BLE adapter: BleAdapterOn`: the netsim-backed adapter is up.
+2. `BLE scan result: ... HatterBleSim ...`: the Haskell scan callback
+   received the simulated advertisement.
+3. `BLE connection event: BleConnectionEstablished`: hatter connected
+   to the peripheral (the peripheral's log independently confirms with
+   `PERIPHERAL_CONNECTED`).
+4. `BLE connection event: BleConnectionClosed`: hatter disconnected.
+
+## Platform coverage
+
+| platform            | BLE simulation | reason |
+|---------------------|----------------|--------|
+| Android aarch64 job (API 34 image) | yes | netsim needs an API 33+ image |
+| Android armv7a job (API 30 image)  | no  | guest lacks the virtio BT chip; old adapter-check-only test |
+| iOS / watchOS simulator            | no  | Apple removed CoreBluetooth support from the simulator; there is no virtual HCI to inject into |
+
+On the iOS simulator the adapter reports `Unsupported`; the iOS test
+asserts the connect attempt still round-trips through the bridge and
+fails visibly (`BleConnectionFailed`) instead of hanging.
+
+## Guest Bluetooth stack flakiness
+
+The guest Bluetooth stack aborts with `assertion 'init_status ==
+std::future_status::ready' failed` when its module startup exceeds a
+fixed deadline, which can happen on a starved emulator (observed under
+software emulation without KVM; CI runners have KVM).  Recovery
+handling lives in `ble.sh`: `ensure_guest_bluetooth_on` before the
+test, and a `cmd bluetooth_manager disable`/`enable` cycle after a
+failed attempt so the next `run_with_retry` attempt starts with a
+fresh stack.
+
+## Running it locally
+
+```
+nix-build nix/ci.nix -A emulator-all -o result-emulator-all
+./result-emulator-all/bin/test-all
+```
+
+To poke at the pieces by hand: boot the emulator with
+`-packet-streamer-endpoint default`, point `XDG_RUNTIME_DIR` at the
+emulator's temp dir, and run
+`python3 test/android/ble_peripheral.py` with bumble available
+(`nix-shell -p 'python3.withPackages (p: [p.bumble])'`).  netsimd's
+logs land in `$TMPDIR/android-$USER/netsimd/netsim_stderr.log`, and its
+per-device TX/RX counters in `netsim_session_stats.json` next to it;
+that file is the quickest way to see whether advertisement packets are
+actually flowing.

--- a/include/BleBridge.h
+++ b/include/BleBridge.h
@@ -9,16 +9,23 @@
 #define BLE_ADAPTER_UNAUTHORIZED 2
 #define BLE_ADAPTER_UNSUPPORTED  3
 
+/* BLE connection event codes (must match Hatter.Ble) */
+#define BLE_CONNECTION_ESTABLISHED 0
+#define BLE_CONNECTION_CLOSED      1
+#define BLE_CONNECTION_FAILED      2
+
 /*
- * Platform-agnostic BLE scanning bridge.
+ * Platform-agnostic BLE bridge.
  *
- * Haskell calls ble_check_adapter / ble_start_scan / ble_stop_scan
- * through these wrappers.  When no platform callbacks are registered
- * (desktop), stubs return BLE_ADAPTER_ON and log no-ops so that
- * cabal build/test works without native code.
+ * Haskell calls ble_check_adapter / ble_start_scan / ble_stop_scan /
+ * ble_connect / ble_disconnect through these wrappers.  When no
+ * platform callbacks are registered (desktop), stubs return
+ * BLE_ADAPTER_ON, log no-ops, and fail connection attempts loudly so
+ * that cabal build/test works without native code.
  *
  * On Android/iOS the platform-specific setup function fills in real
- * implementations via ble_register_impl().
+ * implementations via ble_register_impl() and, when the platform
+ * supports GATT connections, ble_register_connect_impl().
  */
 
 /* Check the BLE adapter status (synchronous).
@@ -32,11 +39,31 @@ void ble_start_scan(void *ctx);
 /* Stop a running BLE scan. */
 void ble_stop_scan(void);
 
-/* Register platform-specific implementations.
+/* Connect to a BLE device by address (MAC on Android, peripheral UUID
+ * on iOS). Connection state changes are delivered asynchronously via
+ * haskellOnBleConnectionEvent() with a BLE_CONNECTION_* code.
+ * When no connect implementation is registered, dispatches
+ * BLE_CONNECTION_FAILED immediately so callers always receive an event. */
+void ble_connect(void *ctx, const char *address);
+
+/* Disconnect the active BLE connection. Completion is delivered via
+ * haskellOnBleConnectionEvent() with BLE_CONNECTION_CLOSED. */
+void ble_disconnect(void);
+
+/* Register platform-specific scan implementations.
  * Called by platform setup functions (setup_android_ble_bridge, etc). */
 void ble_register_impl(
     int32_t (*check_adapter)(void),
     void (*start_scan)(void *),
     void (*stop_scan)(void));
+
+/* Register platform-specific connection implementations.
+ * Registered separately from ble_register_impl so that consumer apps
+ * whose Activity predates the connect API keep working scans: the
+ * Android bridge only registers these when the connect JNI methods
+ * resolve. */
+void ble_register_connect_impl(
+    void (*connect)(void *, const char *),
+    void (*disconnect)(void));
 
 #endif /* BLE_BRIDGE_H */

--- a/include/Hatter.h
+++ b/include/Hatter.h
@@ -132,6 +132,11 @@ void haskellOnSecureStorageResult(void *ctx, int32_t requestId,
  * ctx must be a pointer returned by haskellRunMain(). */
 void haskellOnBleScanResult(void *ctx, const char *name, const char *address, int32_t rssi);
 
+/* Dispatch a BLE connection event from native code back to Haskell.
+ * event: one of the BLE_CONNECTION_* codes from BleBridge.h.
+ * ctx must be a pointer returned by haskellRunMain(). */
+void haskellOnBleConnectionEvent(void *ctx, int32_t event);
+
 /* Dialog action codes */
 #define DIALOG_BUTTON_1   0
 #define DIALOG_BUTTON_2   1

--- a/ios/Hatter/BleBridgeIOS.m
+++ b/ios/Hatter/BleBridgeIOS.m
@@ -1,10 +1,15 @@
 /*
- * iOS implementation of the BLE scanning bridge callbacks.
+ * iOS implementation of the BLE bridge callbacks.
  *
- * Uses CoreBluetooth (CBCentralManager) to check adapter state
- * and scan for peripherals. Compiled by Xcode, not GHC.
+ * Uses CoreBluetooth (CBCentralManager) to check adapter state,
+ * scan for peripherals and manage GATT connections.
+ * Compiled by Xcode, not GHC.
  *
  * All Haskell callbacks are dispatched on the main thread.
+ *
+ * Note: the iOS simulator does not support CoreBluetooth (the manager
+ * reports CBManagerStateUnsupported), so on the simulator scans find
+ * nothing and connection attempts fail with BLE_CONNECTION_FAILED.
  */
 
 #import <CoreBluetooth/CoreBluetooth.h>
@@ -17,21 +22,35 @@ static os_log_t g_log;
 #define LOGI(fmt, ...) os_log_info(g_log, fmt, ##__VA_ARGS__)
 #define LOGE(fmt, ...) os_log_error(g_log, fmt, ##__VA_ARGS__)
 
-/* Haskell FFI export (dispatches scan result back to Haskell callback) */
+/* Haskell FFI exports (dispatch results back to Haskell callbacks) */
 extern void haskellOnBleScanResult(void *ctx, const char *name, const char *address, int32_t rssi);
+extern void haskellOnBleConnectionEvent(void *ctx, int32_t event);
 
 /* ---- Module-level state (declared before use in delegate methods) ---- */
 
 static BOOL g_scanning_requested = NO;
 
-/* ---- Scan delegate ---- */
+/* ---- Scan + connection delegate ---- */
 
 @interface BleScanDelegate : NSObject <CBCentralManagerDelegate>
 @property (nonatomic, assign) void *haskellCtx;
 @property (nonatomic, strong) CBCentralManager *centralManager;
+/* Peripherals seen during scanning, keyed by identifier UUID string.
+ * CoreBluetooth can only connect to CBPeripheral instances it handed
+ * out earlier, so ble_connect looks the address up here. */
+@property (nonatomic, strong) NSMutableDictionary<NSString *, CBPeripheral *> *discoveredPeripherals;
+@property (nonatomic, strong) CBPeripheral *connectedPeripheral;
 @end
 
 @implementation BleScanDelegate
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _discoveredPeripherals = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
 
 - (void)centralManagerDidUpdateState:(CBCentralManager *)central {
     LOGI("CBCentralManager state: %ld", (long)central.state);
@@ -47,13 +66,46 @@ static BOOL g_scanning_requested = NO;
  didDiscoverPeripheral:(CBPeripheral *)peripheral
      advertisementData:(NSDictionary<NSString *, id> *)advertisementData
                   RSSI:(NSNumber *)RSSI {
+    NSString *identifier = [peripheral.identifier UUIDString];
+    self.discoveredPeripherals[identifier] = peripheral;
+
     const char *name = peripheral.name ? [peripheral.name UTF8String] : NULL;
-    const char *address = [[peripheral.identifier UUIDString] UTF8String];
+    const char *address = [identifier UTF8String];
     int32_t rssi = [RSSI intValue];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         haskellOnBleScanResult(self.haskellCtx, name, address, rssi);
     });
+}
+
+- (void)dispatchConnectionEvent:(int32_t)event {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        haskellOnBleConnectionEvent(self.haskellCtx, event);
+    });
+}
+
+- (void)centralManager:(CBCentralManager *)central
+  didConnectPeripheral:(CBPeripheral *)peripheral {
+    LOGI("didConnectPeripheral: %@", peripheral.identifier);
+    self.connectedPeripheral = peripheral;
+    [self dispatchConnectionEvent:BLE_CONNECTION_ESTABLISHED];
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didFailToConnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error {
+    LOGE("didFailToConnectPeripheral: %@", error);
+    self.connectedPeripheral = nil;
+    [self dispatchConnectionEvent:BLE_CONNECTION_FAILED];
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didDisconnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error {
+    LOGI("didDisconnectPeripheral: %@", error);
+    self.connectedPeripheral = nil;
+    [self dispatchConnectionEvent:error == nil ? BLE_CONNECTION_CLOSED
+                                               : BLE_CONNECTION_FAILED];
 }
 
 @end
@@ -85,20 +137,30 @@ static int32_t ios_ble_check_adapter(void)
     return BLE_ADAPTER_UNSUPPORTED;
 }
 
-static void ios_ble_start_scan(void *ctx)
+/* Create the central manager on first use, remembering the Haskell
+ * context for callbacks. */
+static void ios_ble_ensure_manager(void *ctx)
 {
-    LOGI("ios_ble_start_scan()");
-
     if (!g_delegate) {
         g_delegate = [[BleScanDelegate alloc] init];
     }
     g_delegate.haskellCtx = ctx;
 
     if (!g_delegate.centralManager) {
-        g_scanning_requested = YES;
         g_delegate.centralManager = [[CBCentralManager alloc]
             initWithDelegate:g_delegate
                        queue:dispatch_get_main_queue()];
+    }
+}
+
+static void ios_ble_start_scan(void *ctx)
+{
+    LOGI("ios_ble_start_scan()");
+
+    BOOL managerExisted = g_delegate && g_delegate.centralManager;
+    ios_ble_ensure_manager(ctx);
+    if (!managerExisted) {
+        g_scanning_requested = YES;
         return;
     }
 
@@ -123,6 +185,33 @@ static void ios_ble_stop_scan(void)
     }
 }
 
+static void ios_ble_connect(void *ctx, const char *address)
+{
+    LOGI("ios_ble_connect(%s)", address ? address : "(null)");
+
+    ios_ble_ensure_manager(ctx);
+
+    NSString *identifier = address ? [NSString stringWithUTF8String:address] : @"";
+    CBPeripheral *peripheral = g_delegate.discoveredPeripherals[identifier];
+
+    if (!peripheral || g_delegate.centralManager.state != CBManagerStatePoweredOn) {
+        LOGE("ios_ble_connect: peripheral unknown or adapter not powered on");
+        [g_delegate dispatchConnectionEvent:BLE_CONNECTION_FAILED];
+        return;
+    }
+
+    [g_delegate.centralManager connectPeripheral:peripheral options:nil];
+}
+
+static void ios_ble_disconnect(void)
+{
+    LOGI("ios_ble_disconnect()");
+
+    if (g_delegate && g_delegate.centralManager && g_delegate.connectedPeripheral) {
+        [g_delegate.centralManager cancelPeripheralConnection:g_delegate.connectedPeripheral];
+    }
+}
+
 /* ---- Public API ---- */
 
 /*
@@ -134,6 +223,7 @@ void setup_ios_ble_bridge(void *haskellCtx)
     g_log = os_log_create("me.jappie.hatter", LOG_TAG);
 
     ble_register_impl(ios_ble_check_adapter, ios_ble_start_scan, ios_ble_stop_scan);
+    ble_register_connect_impl(ios_ble_connect, ios_ble_disconnect);
 
     LOGI("iOS BLE bridge initialized");
 }

--- a/ios/Hatter/BleBridgeIOS.m
+++ b/ios/Hatter/BleBridgeIOS.m
@@ -40,6 +40,8 @@ static BOOL g_scanning_requested = NO;
  * out earlier, so ble_connect looks the address up here. */
 @property (nonatomic, strong) NSMutableDictionary<NSString *, CBPeripheral *> *discoveredPeripherals;
 @property (nonatomic, strong) CBPeripheral *connectedPeripheral;
+/* Dispatch a BLE_CONNECTION_* event to Haskell on the main thread. */
+- (void)dispatchConnectionEvent:(int32_t)event;
 @end
 
 @implementation BleScanDelegate

--- a/ios/Hatter/ContentView.swift
+++ b/ios/Hatter/ContentView.swift
@@ -31,6 +31,21 @@ struct HaskellUIView: UIViewControllerRepresentable {
             }
         }
 
+        // CI auto-test: exercise the BLE connect path.  Event ids follow
+        // the action creation order in test/BleDemoMain.hs: 0 = Check
+        // Adapter, 1 = Start Scan, 2 = Stop Scan, 3 = Connect,
+        // 4 = Disconnect.  The simulator has no CoreBluetooth support,
+        // so Connect must round-trip through the bridge and log
+        // BleConnectionFailed without crashing.
+        if CommandLine.arguments.contains("--autotest-ble") {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
+                HaskellBridge.onUIEvent(3)  // Connect
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 12) {
+                HaskellBridge.onUIEvent(4)  // Disconnect
+            }
+        }
+
         // CI auto-test: exercise both "+" and "-" buttons.
         // Sequence: +, +, -, -, - → Counter: 1, 2, 1, 0, -1
         if CommandLine.arguments.contains("--autotest-buttons") {

--- a/nix/emulator-all.nix
+++ b/nix/emulator-all.nix
@@ -28,6 +28,12 @@ let
   # API 30 still has 32-bit ARM translation, needed for Wear OS armv7a APKs.
   emulatorApiLevel = { aarch64 = "34"; armv7a = "30"; }.${androidArch};
 
+  # Virtual Bluetooth (netsim) needs guest-side support that only
+  # API 33+ system images ship; the API 30 image used for armv7a has
+  # no virtio Bluetooth chip, so its BLE test keeps the old
+  # no-simulation behaviour (adapter check + no crash).
+  bleSimulationSupported = { aarch64 = true; armv7a = false; }.${androidArch};
+
   lib = import ./lib.nix { inherit sources androidArch; };
 
   counterAndroid = import ./android.nix {
@@ -395,6 +401,11 @@ let
   sdk = androidComposition.androidsdk;
   sdkRoot = "${sdk}/libexec/android-sdk";
 
+  # Python with Google's bumble BLE stack.  ble_peripheral.py uses it
+  # to place a virtual, connectable BLE peripheral in the emulator's
+  # netsim radio scene (see the Decision comment in that script).
+  bumblePython = pkgs.python3.withPackages (pythonPackages: [ pythonPackages.bumble ]);
+
   platformVersion = emulatorApiLevel;
   systemImageType = "google_apis";
   abiVersion = "x86_64";
@@ -456,6 +467,11 @@ PACKAGE="me.jappie.hatter"
 ACTIVITY=".MainActivity"
 DEVICE_NAME="test_all"
 TEST_SCRIPTS="${testScripts}"
+# Virtual Bluetooth: 1 = emulator runs with netsim and the BLE test
+# simulates a peripheral (see test/android/ble.sh), 0 = adapter-check
+# only (API 30 image, no guest netsim support).
+BLE_SIM="${if bleSimulationSupported then "1" else "0"}"
+BUMBLE_PYTHON="${bumblePython}/bin/python3"
 
 # --- .so size guard (see docs/ci-ram-regression-110.md) ---
 # Fail fast if any test .so exceeds 120 MB.  The counter app is ~80 MB;
@@ -545,6 +561,11 @@ export ANDROID_USER_HOME="$WORK_DIR/user-home"
 export ANDROID_AVD_HOME="$WORK_DIR/avd"
 export ANDROID_EMULATOR_HOME="$WORK_DIR/emulator-home"
 export TMPDIR="$WORK_DIR/tmp"
+# netsimd (spawned by the emulator for Bluetooth emulation) publishes
+# its gRPC port in netsim.ini inside this directory; bumble discovers
+# it there.  Both check XDG_RUNTIME_DIR before TMPDIR on Linux, so pin
+# it explicitly to keep them in the same session-private directory.
+export XDG_RUNTIME_DIR="$WORK_DIR/tmp"
 mkdir -p "$HOME" "$ANDROID_USER_HOME" "$ANDROID_AVD_HOME" "$ANDROID_EMULATOR_HOME" "$TMPDIR"
 
 "$ADB" kill-server 2>/dev/null || true
@@ -648,6 +669,14 @@ fi
 
 # --- Boot emulator ---
 echo "=== Booting emulator ==="
+# -packet-streamer-endpoint default spawns netsimd, the virtual radio
+# that gives the guest a working Bluetooth controller; the BLE test's
+# simulated peripheral joins the same netsim scene.
+if [ "$BLE_SIM" = "1" ]; then
+    BLE_EMULATOR_FLAGS="-packet-streamer-endpoint default"
+else
+    BLE_EMULATOR_FLAGS=""
+fi
 "$EMULATOR" \
     -avd "$DEVICE_NAME" \
     -no-window \
@@ -659,6 +688,7 @@ echo "=== Booting emulator ==="
     -no-snapshot \
     -memory 6144 \
     $ACCEL_FLAG \
+    $BLE_EMULATOR_FLAGS \
     &
 EMU_PID=$!
 echo "Emulator PID: $EMU_PID"
@@ -700,7 +730,7 @@ done
 # ===========================================================================
 # PHASE 1 + PHASE 2 — Run test scripts
 # ===========================================================================
-export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK KEYFRAME_APK FILES_DIR_APK DEVICE_INFO_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK REDRAW_APK CONFETTI_REPRO_APK PACKAGE ACTIVITY WORK_DIR
+export ADB EMULATOR_SERIAL COUNTER_APK SCROLL_APK TEXTINPUT_APK SCROLL_TEXTINPUT_APK PERMISSION_APK SECURE_STORAGE_APK IMAGE_APK NODEPOOL_APK BLE_APK DIALOG_APK LOCATION_APK WEBVIEW_APK AUTH_SESSION_APK PLATFORM_SIGN_IN_APK CAMERA_APK BOTTOM_SHEET_APK HTTP_APK NETWORK_STATUS_APK MAPVIEW_APK ANIMATION_APK KEYFRAME_APK FILES_DIR_APK DEVICE_INFO_APK TEXTINPUT_RERENDER_APK STACK_APK SCROLLVIEW_SWITCH_APK STYLED_TYPE_CHANGE_APK HORIZONTAL_SCROLL_APK ASYNC_OOM_APK REDRAW_APK CONFETTI_REPRO_APK PACKAGE ACTIVITY WORK_DIR BLE_SIM BUMBLE_PYTHON
 
 PHASE1_EXIT=0
 PHASE2_EXIT=0

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -145,7 +145,7 @@ import Hatter.Animation (dispatchAnimationFrame)
 import Hatter.AppContext (AppContext(..), newAppContext, derefAppContext)
 import Hatter.AuthSession (dispatchAuthSessionResult)
 import Hatter.PlatformSignIn (dispatchPlatformSignInResult)
-import Hatter.Ble (dispatchBleScanResult)
+import Hatter.Ble (dispatchBleScanResult, dispatchBleConnectionEvent)
 import Hatter.BottomSheet (dispatchBottomSheetResult)
 import Hatter.Camera
   ( dispatchCameraResult
@@ -357,6 +357,16 @@ haskellOnBleScanResult ctxPtr cName cAddr cRssi =
     dispatchBleScanResult (acBleState appCtx) cName cAddr cRssi
 
 foreign export ccall haskellOnBleScanResult :: Ptr AppContext -> CString -> CString -> CInt -> IO ()
+
+-- | Handle a BLE connection event from native code. Dispatches to the
+-- callback registered by 'Hatter.Ble.connectBleDevice'.
+haskellOnBleConnectionEvent :: Ptr AppContext -> CInt -> IO ()
+haskellOnBleConnectionEvent ctxPtr eventCode =
+  withExceptionHandler ctxPtr $ do
+    appCtx <- derefAppContext ctxPtr
+    dispatchBleConnectionEvent (acBleState appCtx) eventCode
+
+foreign export ccall haskellOnBleConnectionEvent :: Ptr AppContext -> CInt -> IO ()
 
 -- | Handle a dialog result from native code. Dispatches to the
 -- callback registered by 'Hatter.Dialog.showDialog'.

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -130,6 +130,7 @@ import Foreign.C.Types (CDouble(..), CInt(..))
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
 import Data.ByteString qualified as BS
 import Data.Word (Word8)
+import System.IO (hPutStrLn, stderr)
 import Unwitch.Convert.CInt qualified as CInt
 import Hatter.Action
   ( Action(..)
@@ -145,7 +146,7 @@ import Hatter.Animation (dispatchAnimationFrame)
 import Hatter.AppContext (AppContext(..), newAppContext, derefAppContext)
 import Hatter.AuthSession (dispatchAuthSessionResult)
 import Hatter.PlatformSignIn (dispatchPlatformSignInResult)
-import Hatter.Ble (dispatchBleScanResult, dispatchBleConnectionEvent)
+import Hatter.Ble (dispatchBleScanResult, dispatchBleConnectionEvent, bleConnectionEventFromInt)
 import Hatter.BottomSheet (dispatchBottomSheetResult)
 import Hatter.Camera
   ( dispatchCameraResult
@@ -358,13 +359,18 @@ haskellOnBleScanResult ctxPtr cName cAddr cRssi =
 
 foreign export ccall haskellOnBleScanResult :: Ptr AppContext -> CString -> CString -> CInt -> IO ()
 
--- | Handle a BLE connection event from native code. Dispatches to the
--- callback registered by 'Hatter.Ble.connectBleDevice'.
+-- | Handle a BLE connection event from native code. Decodes the C
+-- event code here at the FFI boundary so 'dispatchBleConnectionEvent'
+-- only deals in 'Hatter.Ble.BleConnectionEvent', then dispatches to
+-- the callback registered by 'Hatter.Ble.connectBleDevice'.
 haskellOnBleConnectionEvent :: Ptr AppContext -> CInt -> IO ()
 haskellOnBleConnectionEvent ctxPtr eventCode =
   withExceptionHandler ctxPtr $ do
     appCtx <- derefAppContext ctxPtr
-    dispatchBleConnectionEvent (acBleState appCtx) eventCode
+    case bleConnectionEventFromInt eventCode of
+      Nothing -> hPutStrLn stderr $
+        "haskellOnBleConnectionEvent: unknown event code " ++ show eventCode
+      Just event -> dispatchBleConnectionEvent (acBleState appCtx) event
 
 foreign export ccall haskellOnBleConnectionEvent :: Ptr AppContext -> CInt -> IO ()
 

--- a/src/Hatter/Ble.hs
+++ b/src/Hatter/Ble.hs
@@ -1,33 +1,41 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
--- | BLE (Bluetooth Low Energy) scanning API for mobile platforms.
+-- | BLE (Bluetooth Low Energy) API for mobile platforms.
 --
--- Provides adapter status check and start\/stop scan functionality.
--- Scan results are delivered via a streaming callback (multiple
--- invocations per scan), unlike the permission bridge which uses
--- one callback per request.
+-- Provides adapter status check, start\/stop scan, and GATT
+-- connection management.  Scan results and connection events are
+-- delivered via streaming callbacks (multiple invocations per
+-- registration), unlike the permission bridge which uses one
+-- callback per request.
 --
 -- On desktop (no platform bridge registered) the C stub reports
--- the adapter as on and start\/stop scan are no-ops, so @cabal test@
+-- the adapter as on, start\/stop scan are no-ops, and connection
+-- attempts immediately deliver 'BleConnectionFailed', so @cabal test@
 -- works without native code.
 module Hatter.Ble
   ( BleAdapterStatus(..)
   , BleScanResult(..)
+  , BleConnectionEvent(..)
   , BleState(..)
   , newBleState
   , bleAdapterStatusFromInt
   , bleAdapterStatusToInt
+  , bleConnectionEventFromInt
+  , bleConnectionEventToInt
   , checkBleAdapter
   , startBleScan
   , stopBleScan
+  , connectBleDevice
+  , disconnectBleDevice
   , dispatchBleScanResult
+  , dispatchBleConnectionEvent
   )
 where
 
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Text (Text, pack)
-import Foreign.C.String (CString, peekCString)
+import Data.Text (Text, pack, unpack)
+import Foreign.C.String (CString, peekCString, withCString)
 import Foreign.C.Types (CInt(..))
 import Foreign.Ptr (Ptr, nullPtr)
 import System.IO (hPutStrLn, stderr)
@@ -48,27 +56,48 @@ data BleScanResult = BleScanResult
   , bsrRssi          :: Int
   } deriving (Show, Eq)
 
--- | Mutable state for the BLE scanning subsystem.
+-- | A connection state change delivered by the platform for the
+-- connection requested via 'connectBleDevice'.
+data BleConnectionEvent
+  = BleConnectionEstablished
+    -- ^ The GATT connection is up.
+  | BleConnectionClosed
+    -- ^ An established connection ended normally (peer or
+    -- 'disconnectBleDevice' initiated).
+  | BleConnectionFailed
+    -- ^ The connection attempt failed, or an established connection
+    -- was lost with an error.
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+-- | Mutable state for the BLE subsystem.
 -- Uses 'IORef (Maybe callback)' instead of 'IntMap' because only
--- one scan can be active at a time.
+-- one scan and one connection can be active at a time.
 data BleState = BleState
   { blesScanCallback :: IORef (Maybe (BleScanResult -> IO ()))
     -- ^ Active scan result callback, or 'Nothing' if not scanning.
+  , blesConnectionCallback :: IORef (Maybe (BleConnectionEvent -> IO ()))
+    -- ^ Active connection event callback, registered by
+    -- 'connectBleDevice'.  Stays registered after a disconnect so
+    -- that late events (e.g. the 'BleConnectionClosed' following a
+    -- 'disconnectBleDevice') still reach the app; a new
+    -- 'connectBleDevice' call overwrites it.
   , blesContextPtr   :: IORef (Ptr ())
     -- ^ Opaque context pointer passed to the C bridge.
     -- Set by 'AppContext.newAppContext' after the 'StablePtr' is created.
   }
 
--- | Create a fresh 'BleState' with no active scan.
+-- | Create a fresh 'BleState' with no active scan or connection.
 -- The context pointer is initially null and must be set via
--- 'blesContextPtr' before calling 'startBleScan'.
+-- 'blesContextPtr' before calling 'startBleScan' or 'connectBleDevice'.
 newBleState :: IO BleState
 newBleState = do
-  scanCallback <- newIORef Nothing
-  contextPtr   <- newIORef nullPtr
+  scanCallback       <- newIORef Nothing
+  connectionCallback <- newIORef Nothing
+  contextPtr         <- newIORef nullPtr
   pure BleState
-    { blesScanCallback = scanCallback
-    , blesContextPtr   = contextPtr
+    { blesScanCallback       = scanCallback
+    , blesConnectionCallback = connectionCallback
+    , blesContextPtr         = contextPtr
     }
 
 -- | Convert a C bridge adapter status code to 'BleAdapterStatus'.
@@ -87,6 +116,21 @@ bleAdapterStatusToInt BleAdapterOff          = 0
 bleAdapterStatusToInt BleAdapterOn           = 1
 bleAdapterStatusToInt BleAdapterUnauthorized = 2
 bleAdapterStatusToInt BleAdapterUnsupported  = 3
+
+-- | Convert a C bridge connection event code to 'BleConnectionEvent'.
+-- Returns 'Nothing' for unknown codes.
+bleConnectionEventFromInt :: CInt -> Maybe BleConnectionEvent
+bleConnectionEventFromInt 0 = Just BleConnectionEstablished
+bleConnectionEventFromInt 1 = Just BleConnectionClosed
+bleConnectionEventFromInt 2 = Just BleConnectionFailed
+bleConnectionEventFromInt _ = Nothing
+
+-- | Convert a 'BleConnectionEvent' to its C bridge integer code.
+-- Must match the @BLE_CONNECTION_*@ constants in @BleBridge.h@.
+bleConnectionEventToInt :: BleConnectionEvent -> CInt
+bleConnectionEventToInt BleConnectionEstablished = 0
+bleConnectionEventToInt BleConnectionClosed      = 1
+bleConnectionEventToInt BleConnectionFailed      = 2
 
 -- | Check the BLE adapter status (synchronous).
 checkBleAdapter :: IO BleAdapterStatus
@@ -118,6 +162,27 @@ stopBleScan bleState = do
   writeIORef (blesScanCallback bleState) Nothing
   c_bleStopScan
 
+-- | Connect to a BLE device by address (MAC address on Android,
+-- peripheral identifier UUID on iOS, both exactly as delivered in
+-- 'bsrDeviceAddress').  Registers the callback and calls the C
+-- bridge; the callback is invoked for every connection state change
+-- ('BleConnectionEstablished', then eventually 'BleConnectionClosed'
+-- or 'BleConnectionFailed') until a new 'connectBleDevice' call
+-- replaces it.  Only one connection is held at a time: connecting
+-- again closes the previous connection first (handled by the
+-- platform side).
+connectBleDevice :: BleState -> Text -> (BleConnectionEvent -> IO ()) -> IO ()
+connectBleDevice bleState address callback = do
+  writeIORef (blesConnectionCallback bleState) (Just callback)
+  ctx <- readIORef (blesContextPtr bleState)
+  withCString (unpack address) (c_bleConnect ctx)
+
+-- | Disconnect the active BLE connection. The registered connection
+-- callback stays in place so the resulting 'BleConnectionClosed'
+-- event is still delivered.  A no-op when nothing is connected.
+disconnectBleDevice :: BleState -> IO ()
+disconnectBleDevice _bleState = c_bleDisconnect
+
 -- | Dispatch a BLE scan result from the platform back to the
 -- registered Haskell callback. Called from the FFI entry point.
 -- If no scan is active (callback is 'Nothing'), the result is
@@ -141,6 +206,25 @@ dispatchBleScanResult bleState cName cAddr cRssi = do
             }
       callback scanResult
 
+-- | Dispatch a BLE connection event from the platform back to the
+-- registered Haskell callback. Called from the FFI entry point.
+-- Unlike scan results, connection events without a registered
+-- callback indicate a platform bug (events can only follow a
+-- 'connectBleDevice' call), so they are logged loudly instead of
+-- silently dropped.
+dispatchBleConnectionEvent :: BleState -> CInt -> IO ()
+dispatchBleConnectionEvent bleState eventCode =
+  case bleConnectionEventFromInt eventCode of
+    Nothing -> hPutStrLn stderr $
+      "dispatchBleConnectionEvent: unknown event code " ++ show eventCode
+    Just event -> do
+      maybeCallback <- readIORef (blesConnectionCallback bleState)
+      case maybeCallback of
+        Nothing -> hPutStrLn stderr $
+          "dispatchBleConnectionEvent: received " ++ show event
+          ++ " without an active connection callback"
+        Just callback -> callback event
+
 -- | FFI import: check BLE adapter status via the C bridge.
 foreign import ccall "ble_check_adapter"
   c_bleCheckAdapter :: IO CInt
@@ -152,3 +236,11 @@ foreign import ccall "ble_start_scan"
 -- | FFI import: stop BLE scan via the C bridge.
 foreign import ccall "ble_stop_scan"
   c_bleStopScan :: IO ()
+
+-- | FFI import: connect to a BLE device via the C bridge.
+foreign import ccall "ble_connect"
+  c_bleConnect :: Ptr () -> CString -> IO ()
+
+-- | FFI import: disconnect the active BLE connection via the C bridge.
+foreign import ccall "ble_disconnect"
+  c_bleDisconnect :: IO ()

--- a/src/Hatter/Ble.hs
+++ b/src/Hatter/Ble.hs
@@ -16,6 +16,7 @@
 module Hatter.Ble
   ( BleAdapterStatus(..)
   , BleScanResult(..)
+  , BleDeviceAddress(..)
   , BleConnectionEvent(..)
   , BleState(..)
   , newBleState
@@ -49,10 +50,16 @@ data BleAdapterStatus
   | BleAdapterUnsupported
   deriving (Show, Eq, Ord, Enum, Bounded)
 
+-- | A BLE device address as delivered by the platform: a MAC address
+-- on Android, a peripheral identifier UUID on iOS.  Opaque to
+-- applications; pass it back verbatim to 'connectBleDevice'.
+newtype BleDeviceAddress = BleDeviceAddress { unBleDeviceAddress :: Text }
+  deriving (Show, Eq, Ord)
+
 -- | A single BLE scan result delivered by the platform.
 data BleScanResult = BleScanResult
   { bsrDeviceName    :: Text
-  , bsrDeviceAddress :: Text
+  , bsrDeviceAddress :: BleDeviceAddress
   , bsrRssi          :: Int
   } deriving (Show, Eq)
 
@@ -162,20 +169,19 @@ stopBleScan bleState = do
   writeIORef (blesScanCallback bleState) Nothing
   c_bleStopScan
 
--- | Connect to a BLE device by address (MAC address on Android,
--- peripheral identifier UUID on iOS, both exactly as delivered in
--- 'bsrDeviceAddress').  Registers the callback and calls the C
+-- | Connect to a BLE device by the address a scan delivered in
+-- 'bsrDeviceAddress'.  Registers the callback and calls the C
 -- bridge; the callback is invoked for every connection state change
 -- ('BleConnectionEstablished', then eventually 'BleConnectionClosed'
 -- or 'BleConnectionFailed') until a new 'connectBleDevice' call
 -- replaces it.  Only one connection is held at a time: connecting
 -- again closes the previous connection first (handled by the
 -- platform side).
-connectBleDevice :: BleState -> Text -> (BleConnectionEvent -> IO ()) -> IO ()
+connectBleDevice :: BleState -> BleDeviceAddress -> (BleConnectionEvent -> IO ()) -> IO ()
 connectBleDevice bleState address callback = do
   writeIORef (blesConnectionCallback bleState) (Just callback)
   ctx <- readIORef (blesContextPtr bleState)
-  withCString (unpack address) (c_bleConnect ctx)
+  withCString (unpack (unBleDeviceAddress address)) (c_bleConnect ctx)
 
 -- | Disconnect the active BLE connection. The registered connection
 -- callback stays in place so the resulting 'BleConnectionClosed'
@@ -201,29 +207,27 @@ dispatchBleScanResult bleState cName cAddr cRssi = do
         else pack <$> peekCString cAddr
       let scanResult = BleScanResult
             { bsrDeviceName    = nameStr
-            , bsrDeviceAddress = addrStr
+            , bsrDeviceAddress = BleDeviceAddress addrStr
             , bsrRssi          = CInt.toInt cRssi
             }
       callback scanResult
 
 -- | Dispatch a BLE connection event from the platform back to the
--- registered Haskell callback. Called from the FFI entry point.
+-- registered Haskell callback.  The FFI entry point
+-- ('Hatter.haskellOnBleConnectionEvent') decodes the C event code
+-- before calling this, so the public API only sees the sum type.
 -- Unlike scan results, connection events without a registered
 -- callback indicate a platform bug (events can only follow a
 -- 'connectBleDevice' call), so they are logged loudly instead of
 -- silently dropped.
-dispatchBleConnectionEvent :: BleState -> CInt -> IO ()
-dispatchBleConnectionEvent bleState eventCode =
-  case bleConnectionEventFromInt eventCode of
+dispatchBleConnectionEvent :: BleState -> BleConnectionEvent -> IO ()
+dispatchBleConnectionEvent bleState event = do
+  maybeCallback <- readIORef (blesConnectionCallback bleState)
+  case maybeCallback of
     Nothing -> hPutStrLn stderr $
-      "dispatchBleConnectionEvent: unknown event code " ++ show eventCode
-    Just event -> do
-      maybeCallback <- readIORef (blesConnectionCallback bleState)
-      case maybeCallback of
-        Nothing -> hPutStrLn stderr $
-          "dispatchBleConnectionEvent: received " ++ show event
-          ++ " without an active connection callback"
-        Just callback -> callback event
+      "dispatchBleConnectionEvent: received " ++ show event
+      ++ " without an active connection callback"
+    Just callback -> callback event
 
 -- | FFI import: check BLE adapter status via the C bridge.
 foreign import ccall "ble_check_adapter"

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -17,7 +17,7 @@
 module Main where
 
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Text (Text, pack)
+import Data.Text (pack)
 import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
@@ -33,6 +33,7 @@ import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Ble
   ( BleState(..)
   , BleScanResult(..)
+  , BleDeviceAddress(..)
   , checkBleAdapter
   , startBleScan
   , stopBleScan
@@ -46,7 +47,7 @@ main = do
   platformLog "BLE demo app registered"
   actionState <- newActionState
   bleStateRef <- newIORef (Nothing :: Maybe BleState)
-  lastAddressRef <- newIORef (Nothing :: Maybe Text)
+  lastAddressRef <- newIORef (Nothing :: Maybe BleDeviceAddress)
   (onCheckAdapter, onStartScan, onStopScan, onConnect, onDisconnect) <-
     runActionM actionState $ do
       check <- createAction $ do
@@ -63,7 +64,7 @@ main = do
       connect <- createAction $ do
         Just bleState <- readIORef bleStateRef
         address <- connectTargetAddress lastAddressRef
-        platformLog ("BLE connecting to " <> address)
+        platformLog ("BLE connecting to " <> unBleDeviceAddress address)
         connectBleDevice bleState address $ \event ->
           platformLog ("BLE connection event: " <> pack (show event))
       disconnect <- createAction $ do
@@ -83,7 +84,7 @@ main = do
 
 -- | Scan callback: log the result and remember its address as the
 -- Connect target.
-logAndRememberScanResult :: IORef (Maybe Text) -> BleScanResult -> IO ()
+logAndRememberScanResult :: IORef (Maybe BleDeviceAddress) -> BleScanResult -> IO ()
 logAndRememberScanResult lastAddressRef scanResult = do
   platformLog ("BLE scan result: " <> pack (show scanResult))
   writeIORef lastAddressRef (Just (bsrDeviceAddress scanResult))
@@ -91,14 +92,14 @@ logAndRememberScanResult lastAddressRef scanResult = do
 -- | Address the Connect button targets: the last discovered device,
 -- or a placeholder when nothing was discovered yet (so the connect
 -- path is still exercised and fails visibly).
-connectTargetAddress :: IORef (Maybe Text) -> IO Text
+connectTargetAddress :: IORef (Maybe BleDeviceAddress) -> IO BleDeviceAddress
 connectTargetAddress lastAddressRef = do
   maybeAddress <- readIORef lastAddressRef
   case maybeAddress of
     Just address -> pure address
     Nothing -> do
       platformLog "BLE connect: no scan result yet, using placeholder address"
-      pure "00:11:22:33:44:55"
+      pure (BleDeviceAddress "00:11:22:33:44:55")
 
 -- | Builds a Column with a label, adapter check button, scan buttons,
 -- and connection buttons.

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -7,10 +7,17 @@
 -- The view function is kept pure (no IO / FFI calls) to avoid
 -- JNI reentrancy issues on armv7a.  The adapter check runs on
 -- button press instead.
+--
+-- The scan callback remembers the address of the last discovered
+-- device; Connect targets that device.  When Connect is pressed
+-- before any device was discovered a placeholder address is used, so
+-- the connect bridge path is exercised (and fails with
+-- 'BleConnectionFailed') even on platforms where scanning finds
+-- nothing, such as the iOS simulator.
 module Main where
 
-import Data.IORef (newIORef, readIORef, writeIORef)
-import Data.Text (pack)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Text (Text, pack)
 import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
@@ -23,7 +30,15 @@ import Hatter
   , createAction
   )
 import Hatter.AppContext (AppContext(..), derefAppContext)
-import Hatter.Ble (BleState(..), checkBleAdapter, startBleScan, stopBleScan)
+import Hatter.Ble
+  ( BleState(..)
+  , BleScanResult(..)
+  , checkBleAdapter
+  , startBleScan
+  , stopBleScan
+  , connectBleDevice
+  , disconnectBleDevice
+  )
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 main :: IO (Ptr AppContext)
@@ -31,32 +46,64 @@ main = do
   platformLog "BLE demo app registered"
   actionState <- newActionState
   bleStateRef <- newIORef (Nothing :: Maybe BleState)
-  (onCheckAdapter, onStartScan, onStopScan) <- runActionM actionState $ do
-    check <- createAction $ do
-      adapterStatus <- checkBleAdapter
-      platformLog ("BLE adapter: " <> pack (show adapterStatus))
-    start <- createAction $ do
-      Just bleState <- readIORef bleStateRef
-      startBleScan bleState $ \scanResult ->
-        platformLog ("BLE scan result: " <> pack (show scanResult))
-      platformLog "BLE scan started"
-    stop <- createAction $ do
-      Just bleState <- readIORef bleStateRef
-      stopBleScan bleState
-      platformLog "BLE scan stopped"
-    pure (check, start, stop)
+  lastAddressRef <- newIORef (Nothing :: Maybe Text)
+  (onCheckAdapter, onStartScan, onStopScan, onConnect, onDisconnect) <-
+    runActionM actionState $ do
+      check <- createAction $ do
+        adapterStatus <- checkBleAdapter
+        platformLog ("BLE adapter: " <> pack (show adapterStatus))
+      start <- createAction $ do
+        Just bleState <- readIORef bleStateRef
+        startBleScan bleState (logAndRememberScanResult lastAddressRef)
+        platformLog "BLE scan started"
+      stop <- createAction $ do
+        Just bleState <- readIORef bleStateRef
+        stopBleScan bleState
+        platformLog "BLE scan stopped"
+      connect <- createAction $ do
+        Just bleState <- readIORef bleStateRef
+        address <- connectTargetAddress lastAddressRef
+        platformLog ("BLE connecting to " <> address)
+        connectBleDevice bleState address $ \event ->
+          platformLog ("BLE connection event: " <> pack (show event))
+      disconnect <- createAction $ do
+        Just bleState <- readIORef bleStateRef
+        disconnectBleDevice bleState
+        platformLog "BLE disconnect requested"
+      pure (check, start, stop, connect, disconnect)
   ctxPtr <- startMobileApp MobileApp
     { maContext     = loggingMobileContext
-    , maView        = \_userState -> bleDemoView onCheckAdapter onStartScan onStopScan
+    , maView        = \_userState ->
+        bleDemoView onCheckAdapter onStartScan onStopScan onConnect onDisconnect
     , maActionState = actionState
     }
   appCtx <- derefAppContext ctxPtr
   writeIORef bleStateRef (Just (acBleState appCtx))
   pure ctxPtr
 
--- | Builds a Column with a label, adapter check button, and scan buttons.
-bleDemoView :: Action -> Action -> Action -> IO Widget
-bleDemoView onCheckAdapter onStartScan onStopScan = pure $ column
+-- | Scan callback: log the result and remember its address as the
+-- Connect target.
+logAndRememberScanResult :: IORef (Maybe Text) -> BleScanResult -> IO ()
+logAndRememberScanResult lastAddressRef scanResult = do
+  platformLog ("BLE scan result: " <> pack (show scanResult))
+  writeIORef lastAddressRef (Just (bsrDeviceAddress scanResult))
+
+-- | Address the Connect button targets: the last discovered device,
+-- or a placeholder when nothing was discovered yet (so the connect
+-- path is still exercised and fails visibly).
+connectTargetAddress :: IORef (Maybe Text) -> IO Text
+connectTargetAddress lastAddressRef = do
+  maybeAddress <- readIORef lastAddressRef
+  case maybeAddress of
+    Just address -> pure address
+    Nothing -> do
+      platformLog "BLE connect: no scan result yet, using placeholder address"
+      pure "00:11:22:33:44:55"
+
+-- | Builds a Column with a label, adapter check button, scan buttons,
+-- and connection buttons.
+bleDemoView :: Action -> Action -> Action -> Action -> Action -> IO Widget
+bleDemoView onCheckAdapter onStartScan onStopScan onConnect onDisconnect = pure $ column
   [ Text TextConfig { tcLabel = "BLE Demo", tcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel = "Check Adapter", bcAction = onCheckAdapter, bcFontConfig = Nothing }
@@ -64,4 +111,8 @@ bleDemoView onCheckAdapter onStartScan onStopScan = pure $ column
       { bcLabel = "Start Scan", bcAction = onStartScan, bcFontConfig = Nothing }
   , Button ButtonConfig
       { bcLabel = "Stop Scan", bcAction = onStopScan, bcFontConfig = Nothing }
+  , Button ButtonConfig
+      { bcLabel = "Connect", bcAction = onConnect, bcFontConfig = Nothing }
+  , Button ButtonConfig
+      { bcLabel = "Disconnect", bcAction = onDisconnect, bcFontConfig = Nothing }
   ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -4,6 +4,7 @@ import Test.Tasty
 
 import Hatter (startMobileApp)
 import Hatter.AppContext (AppContext(..), derefAppContext)
+import Hatter.Ble (BleState)
 import Hatter.Permission (PermissionState)
 import Hatter.SecureStorage (SecureStorageState)
 import Hatter.Dialog (DialogState)
@@ -31,14 +32,15 @@ main = do
   defaultMain (tests
     (acPermissionState ffiAppCtx)
     (acSecureStorageState ffiAppCtx)
+    (acBleState ffiAppCtx)
     (acDialogState ffiAppCtx)
     (acAuthSessionState ffiAppCtx)
     (acPlatformSignInState ffiAppCtx)
     (acBottomSheetState ffiAppCtx)
     (acHttpState ffiAppCtx))
 
-tests :: PermissionState -> SecureStorageState -> DialogState -> AuthSessionState -> PlatformSignInState -> BottomSheetState -> HttpState -> TestTree
-tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiPlatformSignInState ffiBottomSheetState ffiHttpState =
+tests :: PermissionState -> SecureStorageState -> BleState -> DialogState -> AuthSessionState -> PlatformSignInState -> BottomSheetState -> HttpState -> TestTree
+tests ffiPermState ffiSecureStorageState ffiBleState ffiDialogState ffiAuthSessionState ffiPlatformSignInState ffiBottomSheetState ffiHttpState =
   testGroup "Tests"
     [ qcProps
     , unitTests
@@ -58,7 +60,7 @@ tests ffiPermState ffiSecureStorageState ffiDialogState ffiAuthSessionState ffiP
     , i18nTests
     , permissionTests ffiPermState
     , secureStorageTests ffiSecureStorageState
-    , bleTests
+    , bleTests ffiBleState
     , dialogTests ffiDialogState
     , locationTests
     , cameraTests

--- a/test/Test/PlatformTests.hs
+++ b/test/Test/PlatformTests.hs
@@ -52,14 +52,20 @@ import Hatter.SecureStorage
 import Hatter.Ble
   ( BleAdapterStatus(..)
   , BleScanResult(..)
+  , BleConnectionEvent(..)
   , BleState(..)
   , newBleState
   , bleAdapterStatusFromInt
   , bleAdapterStatusToInt
+  , bleConnectionEventFromInt
+  , bleConnectionEventToInt
   , checkBleAdapter
   , startBleScan
   , stopBleScan
+  , connectBleDevice
+  , disconnectBleDevice
   , dispatchBleScanResult
+  , dispatchBleConnectionEvent
   )
 import Hatter.Dialog
   ( DialogAction(..)
@@ -337,9 +343,12 @@ secureStorageTests ffiSecureStorageState = sequentialTestGroup "SecureStorage" A
       count @?= 0
   ]
 
--- | BLE scanning tests.
-bleTests :: TestTree
-bleTests = testGroup "BLE"
+-- | BLE scanning and connection tests.  The 'BleState' argument is
+-- wired to a real FFI app context, so the connect test exercises the
+-- actual desktop C stub round trip (Haskell -> ble_connect ->
+-- haskellOnBleConnectionEvent -> callback).
+bleTests :: BleState -> TestTree
+bleTests ffiBleState = testGroup "BLE"
   [ testCase "bleAdapterStatusFromInt roundtrips all constructors" $ do
       let allStatuses = [BleAdapterOff, BleAdapterOn, BleAdapterUnauthorized, BleAdapterUnsupported]
       mapM_ (\status ->
@@ -456,6 +465,59 @@ bleTests = testGroup "BLE"
         Just scanResult -> do
           bsrDeviceName scanResult @?= ""
           bsrDeviceAddress scanResult @?= "FF:EE:DD:CC:BB:AA"
+
+  , testCase "bleConnectionEventFromInt roundtrips all constructors" $ do
+      let allEvents = [BleConnectionEstablished, BleConnectionClosed, BleConnectionFailed]
+      mapM_ (\event ->
+        bleConnectionEventFromInt (bleConnectionEventToInt event) @?= Just event
+        ) allEvents
+
+  , testCase "bleConnectionEventFromInt returns Nothing for unknown codes" $ do
+      bleConnectionEventFromInt 3 @?= Nothing
+      bleConnectionEventFromInt (-1) @?= Nothing
+      bleConnectionEventFromInt 100 @?= Nothing
+
+  , testCase "desktop stub fails connections through the C bridge" $ do
+      -- No platform connect implementation is registered on desktop,
+      -- so ble_connect must dispatch BleConnectionFailed back through
+      -- haskellOnBleConnectionEvent, so the caller is never left hanging.
+      ref <- newIORef (Nothing :: Maybe BleConnectionEvent)
+      connectBleDevice ffiBleState "AA:BB:CC:DD:EE:FF" (\event -> writeIORef ref (Just event))
+      result <- readIORef ref
+      result @?= Just BleConnectionFailed
+
+  , testCase "dispatchBleConnectionEvent fires registered callback" $ do
+      bleState <- newBleState
+      ref <- newIORef ([] :: [BleConnectionEvent])
+      connectBleDevice bleState "11:22:33:44:55:66" (\event -> modifyIORef' ref (++ [event]))
+      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionEstablished)
+      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionClosed)
+      events <- readIORef ref
+      events @?= [BleConnectionEstablished, BleConnectionClosed]
+
+  , testCase "dispatchBleConnectionEvent with unknown code does not fire callback" $ do
+      bleState <- newBleState
+      ref <- newIORef (0 :: Int)
+      connectBleDevice bleState "11:22:33:44:55:66" (\_ -> modifyIORef' ref (+ 1))
+      dispatchBleConnectionEvent bleState 42
+      count <- readIORef ref
+      count @?= 0
+
+  , testCase "dispatchBleConnectionEvent without callback is safe" $ do
+      bleState <- newBleState
+      -- Logs loudly to stderr but must not crash
+      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionClosed)
+
+  , testCase "disconnectBleDevice keeps the connection callback" $ do
+      -- The BleConnectionClosed event arrives after the disconnect
+      -- call, so the callback must survive disconnectBleDevice.
+      bleState <- newBleState
+      ref <- newIORef (Nothing :: Maybe BleConnectionEvent)
+      connectBleDevice bleState "11:22:33:44:55:66" (\event -> writeIORef ref (Just event))
+      disconnectBleDevice bleState
+      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionClosed)
+      result <- readIORef ref
+      result @?= Just BleConnectionClosed
   ]
 
 -- | Dialog tests.

--- a/test/Test/PlatformTests.hs
+++ b/test/Test/PlatformTests.hs
@@ -52,6 +52,7 @@ import Hatter.SecureStorage
 import Hatter.Ble
   ( BleAdapterStatus(..)
   , BleScanResult(..)
+  , BleDeviceAddress(..)
   , BleConnectionEvent(..)
   , BleState(..)
   , newBleState
@@ -401,7 +402,7 @@ bleTests ffiBleState = testGroup "BLE"
         Nothing -> assertFailure "callback should have been fired"
         Just scanResult -> do
           bsrDeviceName scanResult @?= "TestDevice"
-          bsrDeviceAddress scanResult @?= "AA:BB:CC:DD:EE:FF"
+          bsrDeviceAddress scanResult @?= BleDeviceAddress "AA:BB:CC:DD:EE:FF"
           bsrRssi scanResult @?= (-42)
 
   , testCase "dispatchBleScanResult with no active scan is no-op" $ do
@@ -464,7 +465,7 @@ bleTests ffiBleState = testGroup "BLE"
         Nothing -> assertFailure "callback should have been fired"
         Just scanResult -> do
           bsrDeviceName scanResult @?= ""
-          bsrDeviceAddress scanResult @?= "FF:EE:DD:CC:BB:AA"
+          bsrDeviceAddress scanResult @?= BleDeviceAddress "FF:EE:DD:CC:BB:AA"
 
   , testCase "bleConnectionEventFromInt roundtrips all constructors" $ do
       let allEvents = [BleConnectionEstablished, BleConnectionClosed, BleConnectionFailed]
@@ -482,40 +483,35 @@ bleTests ffiBleState = testGroup "BLE"
       -- so ble_connect must dispatch BleConnectionFailed back through
       -- haskellOnBleConnectionEvent, so the caller is never left hanging.
       ref <- newIORef (Nothing :: Maybe BleConnectionEvent)
-      connectBleDevice ffiBleState "AA:BB:CC:DD:EE:FF" (\event -> writeIORef ref (Just event))
+      connectBleDevice ffiBleState (BleDeviceAddress "AA:BB:CC:DD:EE:FF")
+        (\event -> writeIORef ref (Just event))
       result <- readIORef ref
       result @?= Just BleConnectionFailed
 
   , testCase "dispatchBleConnectionEvent fires registered callback" $ do
       bleState <- newBleState
       ref <- newIORef ([] :: [BleConnectionEvent])
-      connectBleDevice bleState "11:22:33:44:55:66" (\event -> modifyIORef' ref (++ [event]))
-      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionEstablished)
-      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionClosed)
+      connectBleDevice bleState (BleDeviceAddress "11:22:33:44:55:66")
+        (\event -> modifyIORef' ref (++ [event]))
+      dispatchBleConnectionEvent bleState BleConnectionEstablished
+      dispatchBleConnectionEvent bleState BleConnectionClosed
       events <- readIORef ref
       events @?= [BleConnectionEstablished, BleConnectionClosed]
-
-  , testCase "dispatchBleConnectionEvent with unknown code does not fire callback" $ do
-      bleState <- newBleState
-      ref <- newIORef (0 :: Int)
-      connectBleDevice bleState "11:22:33:44:55:66" (\_ -> modifyIORef' ref (+ 1))
-      dispatchBleConnectionEvent bleState 42
-      count <- readIORef ref
-      count @?= 0
 
   , testCase "dispatchBleConnectionEvent without callback is safe" $ do
       bleState <- newBleState
       -- Logs loudly to stderr but must not crash
-      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionClosed)
+      dispatchBleConnectionEvent bleState BleConnectionClosed
 
   , testCase "disconnectBleDevice keeps the connection callback" $ do
       -- The BleConnectionClosed event arrives after the disconnect
       -- call, so the callback must survive disconnectBleDevice.
       bleState <- newBleState
       ref <- newIORef (Nothing :: Maybe BleConnectionEvent)
-      connectBleDevice bleState "11:22:33:44:55:66" (\event -> writeIORef ref (Just event))
+      connectBleDevice bleState (BleDeviceAddress "11:22:33:44:55:66")
+        (\event -> writeIORef ref (Just event))
       disconnectBleDevice bleState
-      dispatchBleConnectionEvent bleState (bleConnectionEventToInt BleConnectionClosed)
+      dispatchBleConnectionEvent bleState BleConnectionClosed
       result <- readIORef ref
       result @?= Just BleConnectionClosed
   ]

--- a/test/android/ble.sh
+++ b/test/android/ble.sh
@@ -15,7 +15,6 @@
 #   ADB, EMULATOR_SERIAL, BLE_APK, PACKAGE, ACTIVITY, WORK_DIR
 # Additionally when BLE_SIM=1:
 #   BUMBLE_PYTHON: python interpreter with the bumble package
-#   TEST_SCRIPTS:  test-tree root (for ble_peripheral.py)
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
@@ -61,9 +60,11 @@ ensure_guest_bluetooth_on() {
 
 if [ "$BLE_SIM" = "1" ]; then
     # Start the virtual peripheral first so it is already advertising
-    # in the netsim scene when the app starts scanning.
+    # in the netsim scene when the app starts scanning.  The script
+    # lives next to this one (dirname, like helpers.sh above): the
+    # harness only exports BUMBLE_PYTHON, not the test-tree root.
     PERIPHERAL_LOG="$WORK_DIR/ble_peripheral.log"
-    "$BUMBLE_PYTHON" "$TEST_SCRIPTS/android/ble_peripheral.py" > "$PERIPHERAL_LOG" 2>&1 &
+    "$BUMBLE_PYTHON" "$(dirname "$0")/ble_peripheral.py" > "$PERIPHERAL_LOG" 2>&1 &
     PERIPHERAL_PID=$!
     PERIPHERAL_WAIT=0
     while [ $PERIPHERAL_WAIT -lt 30 ]; do

--- a/test/android/ble.sh
+++ b/test/android/ble.sh
@@ -2,14 +2,103 @@
 # Android BLE test: install BLE APK, launch app, verify adapter check
 # runs and start/stop scan don't crash.
 #
+# When BLE_SIM=1 (API 33+ emulator with netsim virtual Bluetooth,
+# see emulator-all.nix) the test additionally:
+#   - starts a virtual BLE peripheral (ble_peripheral.py via bumble)
+#     in the emulator's netsim radio scene,
+#   - asserts the hatter scan callback receives its advertisement
+#     ("BLE scan result: ... HatterBleSim ..."),
+#   - connects to it from hatter code and asserts the connection
+#     round trip (BleConnectionEstablished / BleConnectionClosed).
+#
 # Required env vars (set by emulator-all.nix harness):
 #   ADB, EMULATOR_SERIAL, BLE_APK, PACKAGE, ACTIVITY, WORK_DIR
+# Additionally when BLE_SIM=1:
+#   BUMBLE_PYTHON: python interpreter with the bumble package
+#   TEST_SCRIPTS:  test-tree root (for ble_peripheral.py)
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
 EXIT_CODE=0
+BLE_SIM="${BLE_SIM:-0}"
+PERIPHERAL_PID=""
+
+cleanup_peripheral() {
+    if [ -n "$PERIPHERAL_PID" ] && kill -0 "$PERIPHERAL_PID" 2>/dev/null; then
+        kill "$PERIPHERAL_PID" 2>/dev/null || true
+        wait "$PERIPHERAL_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_peripheral EXIT
+
+# ensure_guest_bluetooth_on
+# The netsim-backed adapter is normally on after boot, but the stack
+# can wedge on a slow emulator (startup-timeout SIGABRT); a disable/
+# enable cycle recovers it on the next test attempt.
+ensure_guest_bluetooth_on() {
+    local bt_on
+    bt_on=$("$ADB" -s "$EMULATOR_SERIAL" shell settings get global bluetooth_on 2>/dev/null | tr -d '\r\n')
+    if [ "$bt_on" != "1" ]; then
+        echo "Bluetooth is off (bluetooth_on=$bt_on), enabling..."
+        "$ADB" -s "$EMULATOR_SERIAL" shell cmd bluetooth_manager enable 2>/dev/null || true
+        local elapsed=0
+        while [ $elapsed -lt 60 ]; do
+            bt_on=$("$ADB" -s "$EMULATOR_SERIAL" shell settings get global bluetooth_on 2>/dev/null | tr -d '\r\n')
+            if [ "$bt_on" = "1" ]; then
+                break
+            fi
+            sleep 5
+            elapsed=$((elapsed + 5))
+        done
+    fi
+    if [ "$bt_on" != "1" ]; then
+        echo "FAIL: guest Bluetooth did not come on"
+        return 1
+    fi
+    echo "Guest Bluetooth is on"
+    return 0
+}
+
+if [ "$BLE_SIM" = "1" ]; then
+    # Start the virtual peripheral first so it is already advertising
+    # in the netsim scene when the app starts scanning.
+    PERIPHERAL_LOG="$WORK_DIR/ble_peripheral.log"
+    "$BUMBLE_PYTHON" "$TEST_SCRIPTS/android/ble_peripheral.py" > "$PERIPHERAL_LOG" 2>&1 &
+    PERIPHERAL_PID=$!
+    PERIPHERAL_WAIT=0
+    while [ $PERIPHERAL_WAIT -lt 30 ]; do
+        if grep -q "ADVERTISING_STARTED" "$PERIPHERAL_LOG" 2>/dev/null; then
+            break
+        fi
+        if ! kill -0 "$PERIPHERAL_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        PERIPHERAL_WAIT=$((PERIPHERAL_WAIT + 1))
+    done
+    if ! grep -q "ADVERTISING_STARTED" "$PERIPHERAL_LOG" 2>/dev/null; then
+        echo "FAIL: virtual BLE peripheral did not start advertising"
+        cat "$PERIPHERAL_LOG"
+        exit 1
+    fi
+    echo "Virtual BLE peripheral is advertising (pid $PERIPHERAL_PID)"
+
+    ensure_guest_bluetooth_on || exit 1
+fi
 
 start_app "$BLE_APK" "ble"
+
+if [ "$BLE_SIM" = "1" ]; then
+    # BLUETOOTH_SCAN/CONNECT are runtime permissions on API 31+; the
+    # manifest's BLUETOOTH_SCAN has no neverForLocation flag, so scan
+    # results are also gated on fine location.
+    for permission in android.permission.BLUETOOTH_SCAN \
+                      android.permission.BLUETOOTH_CONNECT \
+                      android.permission.ACCESS_FINE_LOCATION; do
+        "$ADB" -s "$EMULATOR_SERIAL" shell pm grant "$PACKAGE" "$permission" 2>/dev/null \
+            || echo "WARNING: could not grant $permission"
+    done
+fi
 
 wait_for_logcat "setRoot" 120 || true
 wait_for_logcat "BLE bridge" 30 || true
@@ -27,10 +116,44 @@ wait_for_logcat "BLE adapter:" 15 || true
 LOGCAT_FILE1B="$WORK_DIR/ble_logcat1b.txt"
 "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_FILE1B" 2>&1 || true
 assert_logcat "$LOGCAT_FILE1B" "BLE adapter:" "BLE adapter check logged"
+if [ "$BLE_SIM" = "1" ]; then
+    # With netsim the virtual adapter must report as on.
+    assert_logcat "$LOGCAT_FILE1B" "BLE adapter: BleAdapterOn" "BLE adapter is on (netsim)"
+fi
 
 # Tap Start Scan button — should not crash
 tap_button "Start Scan" || { echo "WARNING: could not tap Start Scan"; }
-sleep 1
+
+if [ "$BLE_SIM" = "1" ]; then
+    # The virtual peripheral advertises every ~100ms; scan results
+    # normally arrive within a few seconds.
+    wait_for_logcat "BLE scan result:.*HatterBleSim" 90 || true
+    LOGCAT_SCAN="$WORK_DIR/ble_logcat_scan.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_SCAN" 2>&1 || true
+    assert_logcat "$LOGCAT_SCAN" "BLE scan result:.*HatterBleSim" \
+        "hatter received the simulated advertisement"
+
+    # Connect to the discovered peripheral from hatter code.
+    tap_button "Connect" || { echo "WARNING: could not tap Connect"; }
+    wait_for_logcat "BLE connection event: BleConnectionEstablished" 60 || true
+    LOGCAT_CONNECT="$WORK_DIR/ble_logcat_connect.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_CONNECT" 2>&1 || true
+    assert_logcat "$LOGCAT_CONNECT" "BLE connection event: BleConnectionEstablished" \
+        "hatter connected to the simulated peripheral"
+    # Host-side proof: the peripheral saw the central connect.
+    assert_logcat "$PERIPHERAL_LOG" "PERIPHERAL_CONNECTED" \
+        "virtual peripheral registered the connection"
+
+    # Disconnect again from hatter code.
+    tap_button "Disconnect" || { echo "WARNING: could not tap Disconnect"; }
+    wait_for_logcat "BLE connection event: BleConnectionClosed" 30 || true
+    LOGCAT_DISCONNECT="$WORK_DIR/ble_logcat_disconnect.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_DISCONNECT" 2>&1 || true
+    assert_logcat "$LOGCAT_DISCONNECT" "BLE connection event: BleConnectionClosed" \
+        "hatter disconnected from the simulated peripheral"
+else
+    sleep 1
+fi
 
 # Tap Stop Scan button — should not crash
 tap_button "Stop Scan" || { echo "WARNING: could not tap Stop Scan"; }
@@ -49,5 +172,17 @@ else
 fi
 
 "$ADB" -s "$EMULATOR_SERIAL" uninstall "$PACKAGE" 2>/dev/null || true
+
+# A failed simulation attempt is usually a wedged guest Bluetooth stack
+# (it can SIGABRT on startup timeouts under emulation).  bluetooth_on
+# stays 1 in that state, so ensure_guest_bluetooth_on alone won't
+# recover it, so cycle the stack now and the next run_with_retry attempt
+# starts from a fresh one.
+if [ "$BLE_SIM" = "1" ] && [ $EXIT_CODE -ne 0 ]; then
+    echo "Cycling guest Bluetooth for the next attempt..."
+    "$ADB" -s "$EMULATOR_SERIAL" shell cmd bluetooth_manager disable 2>/dev/null || true
+    sleep 5
+    "$ADB" -s "$EMULATOR_SERIAL" shell cmd bluetooth_manager enable 2>/dev/null || true
+fi
 
 exit $EXIT_CODE

--- a/test/android/ble_peripheral.py
+++ b/test/android/ble_peripheral.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Virtual BLE peripheral for the Android emulator integration tests.
+#
+# Connects to the emulator's netsim virtual radio (gRPC packet
+# streamer, discovered through netsim.ini in XDG_RUNTIME_DIR/TMPDIR)
+# and advertises as a connectable peripheral named "HatterBleSim" with
+# a small GATT service.  The emulator's Bluetooth stack receives these
+# advertisements exactly as it would from a physical device, so the
+# hatter BLE scan and connect paths are exercised end to end.
+#
+# Decision: Google's bumble Python stack + the emulator's netsim
+# virtual controller were chosen to simulate BLE traffic.
+# Alternatives considered: a second emulator running an advertiser app
+# (heavy: another system image boot per CI run) and netsimd's built-in
+# --test-beacons (advertise-only, cannot accept GATT connections, and
+# not controllable per test).  bumble is packaged in nixpkgs, connects
+# to the same netsimd instance the emulator spawns, and gives us a
+# named, connectable peripheral with a scriptable GATT server.
+#
+# Usage: ble_peripheral.py [transport]   (default: android-netsim)
+#
+# Prints ADVERTISING_STARTED once the peripheral is on the air and
+# PERIPHERAL_CONNECTED when a central connects; the test harness waits
+# for these markers.
+
+import asyncio
+import sys
+
+from bumble.core import AdvertisingData
+from bumble.device import Device
+from bumble.gatt import Characteristic, Service
+from bumble.hci import Address
+from bumble.transport import open_transport
+
+PERIPHERAL_NAME = 'HatterBleSim'
+PERIPHERAL_ADDRESS = 'F0:F1:F2:F3:F4:F5'
+TEST_SERVICE_UUID = '50DB505C-8AC4-4738-8448-3B1D9CC09CC5'
+TEST_CHARACTERISTIC_UUID = '486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5'
+
+
+async def run_peripheral(transport_name):
+    print(f'Opening transport: {transport_name}', flush=True)
+    async with await open_transport(transport_name) as hci_transport:
+        device = Device.with_hci(
+            PERIPHERAL_NAME,
+            Address(PERIPHERAL_ADDRESS),
+            hci_transport.source,
+            hci_transport.sink,
+        )
+        device.add_service(
+            Service(
+                TEST_SERVICE_UUID,
+                [
+                    Characteristic(
+                        TEST_CHARACTERISTIC_UUID,
+                        Characteristic.Properties.READ,
+                        Characteristic.READABLE,
+                        b'hatter',
+                    )
+                ],
+            )
+        )
+        device.advertising_data = bytes(
+            AdvertisingData(
+                [
+                    (AdvertisingData.FLAGS, bytes([0x06])),
+                    (
+                        AdvertisingData.COMPLETE_LOCAL_NAME,
+                        PERIPHERAL_NAME.encode('utf-8'),
+                    ),
+                ]
+            )
+        )
+        device.on(
+            'connection',
+            lambda connection: print(f'PERIPHERAL_CONNECTED: {connection}', flush=True),
+        )
+        await device.power_on()
+        # auto_restart: resume advertising after a central disconnects,
+        # so a retried test attempt finds the peripheral again.
+        await device.start_advertising(auto_restart=True)
+        print('ADVERTISING_STARTED', flush=True)
+        await asyncio.get_running_loop().create_future()
+
+
+def main():
+    transport_name = sys.argv[1] if len(sys.argv) > 1 else 'android-netsim'
+    asyncio.run(run_peripheral(transport_name))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/android/helpers.sh
+++ b/test/android/helpers.sh
@@ -47,7 +47,15 @@ FATAL_PATTERNS="UnsatisfiedLinkError|dlopen failed|cannot locate symbol|SIGABRT|
 check_fatal_logcat() {
     local logcat_poll="$WORK_DIR/logcat_fatal.txt"
     "$ADB" -s "$EMULATOR_SERIAL" logcat -d > "$logcat_poll" 2>&1 || true
-    if grep -qE "$FATAL_PATTERNS" "$logcat_poll" 2>/dev/null; then
+    # The linker logs benign probe failures at debug level on process
+    # start, e.g.: dlerror set to "dlopen failed: library
+    # "libnetd_client.so" not found".  Those contain "dlopen failed"
+    # but are not crashes; a real load failure surfaces separately as
+    # UnsatisfiedLinkError or Fatal signal.  Filter the probe lines
+    # out before matching, otherwise any test that waits longer than
+    # the 10s fatal-check interval (async-oom's slow hs_init on
+    # armv7a) is spuriously reported as crashed.
+    if grep -v 'dlerror set to' "$logcat_poll" 2>/dev/null | grep -qE "$FATAL_PATTERNS"; then
         echo ""
         echo "=== FATAL: App crashed ==="
         # Print the full logcat so the debuggerd native backtrace,

--- a/test/ios/ble.sh
+++ b/test/ios/ble.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# iOS BLE test: install BLE app, launch with --autotest, verify adapter
-# check runs and app doesn't crash.
+# iOS BLE test: install BLE app, launch with --autotest --autotest-ble,
+# verify adapter check runs, the connect bridge round-trips, and the
+# app doesn't crash.
+#
+# The iOS simulator has no CoreBluetooth support (the adapter reports
+# Unsupported and scans find nothing), so BLE traffic cannot be
+# simulated here; that end-to-end path is covered by the Android
+# emulator test (test/android/ble.sh + netsim + bumble).  What this
+# test does prove: the connect API reaches the CoreBluetooth bridge
+# and fails visibly with BleConnectionFailed instead of hanging or
+# crashing.
 #
 # Required env vars (set by simulator-all.nix harness):
 #   SIM_UDID, BUNDLE_ID, BLE_APP, WORK_DIR
@@ -9,12 +18,15 @@ source "$(dirname "$0")/helpers.sh"
 
 EXIT_CODE=0
 
-start_app "$BLE_APP" "ble" --autotest
+start_app "$BLE_APP" "ble" --autotest --autotest-ble
 wait_for_render "ble" --autotest
 wait_for_log "$STREAM_LOG" "BLE adapter:" 30 || true
+wait_for_log "$STREAM_LOG" "BLE connection event:" 60 || true
 collect_logs "ble"
 
 assert_log "$FULL_LOG" "BLE adapter:" "BLE adapter check logged"
+assert_log "$FULL_LOG" "BLE connection event: BleConnectionFailed" \
+    "connect on simulator fails visibly through the bridge"
 assert_log "$FULL_LOG" "createNode" "createNode called (app renders)"
 assert_log "$FULL_LOG" "setRoot" "setRoot"
 


### PR DESCRIPTION
## What

Two things, as requested: real BLE signals into the emulator so hatter's handling is integration-tested, and (stretch goal) a BLE connect API with the same level of CI coverage.

### BLE simulation in the Android emulator job

The emulator now boots with `-packet-streamer-endpoint default`, which spawns **netsim**, the emulator's virtual Bluetooth radio. A virtual peripheral built on Google's **bumble** stack (`test/android/ble_peripheral.py`, bumble comes straight from nixpkgs) joins the same netsim scene and advertises as a connectable device named `HatterBleSim` with a small GATT server.

The guest's Bluetooth stack receives those advertisements exactly as it would from a physical device, so `test/android/ble.sh` (in `BLE_SIM=1` mode) can assert the full path through hatter via logcat:

1. `BLE adapter: BleAdapterOn` (netsim-backed adapter is up)
2. `BLE scan result: ... HatterBleSim ...` (the **Haskell** scan callback received the simulated advertisement: BluetoothLeScanner -> JNI -> C bridge -> `haskellOnBleScanResult` -> app callback)
3. `BLE connection event: BleConnectionEstablished` (hatter code connected to the peripheral; the peripheral's own log confirms with `PERIPHERAL_CONNECTED`)
4. `BLE connection event: BleConnectionClosed` after tapping Disconnect

The armv7a job keeps the old adapter-check-only test: its API 30 image has no netsim guest support. Same for iOS/watchOS, Apple removed CoreBluetooth from the simulator entirely, there is no virtual HCI to inject into; the Android emulator is where the end-to-end coverage lives. Architecture and local-debugging notes in `docs/ble-emulator-simulation.md`.

### BLE connect (first slice of #108)

- `Hatter.Ble`: `connectBleDevice` / `disconnectBleDevice` + `BleConnectionEvent` (`BleConnectionEstablished` / `BleConnectionClosed` / `BleConnectionFailed`) with a streaming connection-state callback.
- C bridge: `ble_connect` / `ble_disconnect`; connect impls register separately (`ble_register_connect_impl`) so consumer Activities that predate the connect API keep working scans, and an unregistered connect fails visibly with `BleConnectionFailed` instead of hanging (no silent failure).
- Android: connects through the `BluetoothDevice` cached from scan results, which preserves the address type (`getRemoteDevice` assumes public addresses and would fail against random static addresses like bumble's). GATT state changes hop to the UI thread before entering Haskell.
- iOS: `CBCentralManager` connect using peripherals tracked by identifier during scans. `test/ios/ble.sh` (new `--autotest-ble` mode) asserts the connect attempt on the simulator round-trips with `BleConnectionFailed`, no hang, no crash.
- `BleDemoMain` gains Connect/Disconnect buttons; Connect targets the last-scanned device.
- Unit tests: event int conversions, dispatch behaviour (unknown codes, no callback, callback survives disconnect), and the desktop stub's failure dispatch through the real C bridge round trip.

GATT service discovery, characteristic read/write/subscribe and scan filtering stay open in #108; the C/Haskell API is shaped so they slot in next (the virtual peripheral already serves a readable characteristic for that future test).

## Verification done locally

- `cabal build` clean, `cabal test` passes (including the new BLE connection tests).
- The bumble peripheral was run against a real netsimd spawned by the nixpkgs emulator (36.3.10): netsim's session stats show the emulator chip receiving every advertisement packet (1391 TX from bumble = 1391 RX on the emulator chip), and the discovery via `netsim.ini` in `XDG_RUNTIME_DIR` works with the harness env exactly as wired here.
- The BLE APK with the new demo/Java/C code builds.
- Full in-guest scan/connect assertions could not be validated locally: this container has no KVM and the guest Bluetooth service under pure TCG emulation hits framework bind timeouts before it ever comes up (details in docs/ble-emulator-simulation.md). CI runners have KVM; `ble.sh` also self-heals a wedged guest stack by cycling Bluetooth between `run_with_retry` attempts.

Closes nothing; first slice of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)