### PR TITLE
GATT operations for Hatter.Ble: discovery, read/write, notifications, MTU, scan filtering (#108)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,9 +13,12 @@
   flight at a time; a second one fails immediately with
   `BleGattBusy`, and every operation completes exactly once with
   `Either BleGattError`.  New types: `BleServiceUuid`,
-  `BleCharacteristicUuid`, `BleDiscoveredCharacteristic`,
-  `BleCharacteristicProperty`, `BleWriteMode`, `BleGattOperation`,
-  `BleGattError`.
+  `BleCharacteristicUuid`, `BleCharacteristicValue`, `BleMtu`,
+  `NormalizedBleUuid`, `BleCharacteristicKey`,
+  `BleDiscoveredCharacteristic`, `BleCharacteristicProperty`,
+  `BleWriteMode`, `BleGattOperation`, `BleGattError`.  The UUID,
+  address and value newtypes derive `IsString`, so constants can be
+  written as string literals.
 - `startFilteredBleScan`: scan filtered by an advertised service
   UUID.
 - The emulator BLE integration test now covers the full GATT surface

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,26 @@
 
 ### Added
 
+- `Hatter.Ble` GATT operations, completing the core of issue #108 and
+  unblocking the kbeacon OTA tool: `discoverBleServices`,
+  `readBleCharacteristic`, `writeBleCharacteristic` (with or without
+  response), `subscribeBleCharacteristic` /
+  `unsubscribeBleCharacteristic` with streaming notification
+  callbacks, and `requestBleMtu`.  One GATT operation may be in
+  flight at a time; a second one fails immediately with
+  `BleGattBusy`, and every operation completes exactly once with
+  `Either BleGattError`.  New types: `BleServiceUuid`,
+  `BleCharacteristicUuid`, `BleDiscoveredCharacteristic`,
+  `BleCharacteristicProperty`, `BleWriteMode`, `BleGattOperation`,
+  `BleGattError`.
+- `startFilteredBleScan`: scan filtered by an advertised service
+  UUID.
+- The emulator BLE integration test now covers the full GATT surface
+  against the virtual peripheral: discovery listing the test service,
+  MTU negotiation, characteristic read, subscribe, a write echoed
+  back as a notification (asserted on both ends of the radio), and a
+  service-UUID-filtered scan.
+
 - `Hatter.Ble` connection API (issue #108, first slice):
   `connectBleDevice`, `disconnectBleDevice`, and the
   `BleConnectionEvent` sum type (`BleConnectionEstablished`,

--- a/Readme.md
+++ b/Readme.md
@@ -372,6 +372,16 @@ This lets you develop and test your app logic without a device.
 
 # Contributing
 
+Hatter is a bindings project to android and ios.
+It is not supposed to be a difficult to understand project.
+In fact, it is supposed to be kinda boring!
+Every platform feature follows the same shape:
+a Haskell state record, a C dispatcher with loud stubs,
+a platform implementation per OS, a foreign export,
+and a demo app with an integration test poking it.
+So: copy the pattern, newtype the primitives,
+and if a change feels clever, it is probably wrong for this repo.
+
 Always make sure to include tests.
 If we deal with platform integration or add native code
 we need tests in the simulator / emulator

--- a/android/java/me/jappie/hatter/HatterActivity.java
+++ b/android/java/me/jappie/hatter/HatterActivity.java
@@ -7,12 +7,18 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothProfile;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
+import android.os.ParcelUuid;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -77,6 +83,12 @@ public class HatterActivity extends Activity implements View.OnClickListener {
     private native void onSecureStorageResult(int requestId, int statusCode, String value);
     private native void onBleScanResult(String deviceName, String deviceAddress, int rssi);
     private native void onBleConnectionEvent(int event);
+    private native void onBleCharacteristicDiscovered(String serviceUuid,
+                                                      String characteristicUuid,
+                                                      int properties);
+    private native void onBleGattResult(int operation, int status, byte[] data, int mtu);
+    private native void onBleNotification(String serviceUuid, String characteristicUuid,
+                                          byte[] data);
     private native void onDialogResult(int requestId, int actionCode);
     private native void onLocationResult(double lat, double lon, double alt, double acc);
     private native void onAuthSessionResult(int requestId, int statusCode,
@@ -100,6 +112,18 @@ public class HatterActivity extends Activity implements View.OnClickListener {
     private BluetoothLeScanner bleScanner;
     private ScanCallback bleScanCallback;
     private BluetoothGatt bleGatt;
+    /**
+     * Client Characteristic Configuration descriptor: writing to it
+     * turns notifications on/off on the peripheral side.
+     */
+    private static final java.util.UUID BLE_CCCD_UUID =
+        java.util.UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
+    /**
+     * Which notification operation a pending CCCD descriptor write
+     * belongs to: 3 = subscribe, 4 = unsubscribe (BLE_GATT_OP_* codes).
+     * onDescriptorWrite reports the completion under this code.
+     */
+    private int bleNotificationOpInFlight = 3;
     /**
      * Devices seen during the current scan, keyed by address.  Connecting
      * through the scanned BluetoothDevice preserves the address type
@@ -258,8 +282,10 @@ public class HatterActivity extends Activity implements View.OnClickListener {
     /**
      * Start a BLE scan. Called from native code via JNI.
      * Scan results are delivered via onBleScanResult JNI callback.
+     * serviceUuidFilter: 128-bit service UUID string to filter
+     * advertisements by, or null for an unfiltered scan.
      */
-    public void startBleScan() {
+    public void startBleScan(String serviceUuidFilter) {
         try {
             BluetoothManager manager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
             if (manager == null) return;
@@ -288,7 +314,17 @@ public class HatterActivity extends Activity implements View.OnClickListener {
                 }
             };
 
-            bleScanner.startScan(bleScanCallback);
+            if (serviceUuidFilter != null) {
+                ScanFilter filter = new ScanFilter.Builder()
+                    .setServiceUuid(ParcelUuid.fromString(serviceUuidFilter))
+                    .build();
+                java.util.List<ScanFilter> filters = new java.util.ArrayList<>();
+                filters.add(filter);
+                ScanSettings settings = new ScanSettings.Builder().build();
+                bleScanner.startScan(filters, settings, bleScanCallback);
+            } else {
+                bleScanner.startScan(bleScanCallback);
+            }
         } catch (Exception e) {
             android.util.Log.e("BleBridge", "startBleScan failed: " + e.getMessage());
         }
@@ -361,6 +397,93 @@ public class HatterActivity extends Activity implements View.OnClickListener {
                         }
                     });
                 }
+
+                @Override
+                public void onServicesDiscovered(BluetoothGatt gatt, final int status) {
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (status == BluetoothGatt.GATT_SUCCESS) {
+                                for (BluetoothGattService service : gatt.getServices()) {
+                                    for (BluetoothGattCharacteristic characteristic
+                                             : service.getCharacteristics()) {
+                                        onBleCharacteristicDiscovered(
+                                            service.getUuid().toString(),
+                                            characteristic.getUuid().toString(),
+                                            blePropertyBits(characteristic.getProperties()));
+                                    }
+                                }
+                            }
+                            onBleGattResult(0 /* DISCOVER */, status, null, 0);
+                        }
+                    });
+                }
+
+                @Override
+                public void onCharacteristicRead(BluetoothGatt gatt,
+                                                 BluetoothGattCharacteristic characteristic,
+                                                 final int status) {
+                    final byte[] value = characteristic.getValue();
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            onBleGattResult(1 /* READ */, status,
+                                status == BluetoothGatt.GATT_SUCCESS ? value : null, 0);
+                        }
+                    });
+                }
+
+                @Override
+                public void onCharacteristicWrite(BluetoothGatt gatt,
+                                                  BluetoothGattCharacteristic characteristic,
+                                                  final int status) {
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            onBleGattResult(2 /* WRITE */, status, null, 0);
+                        }
+                    });
+                }
+
+                @Override
+                public void onDescriptorWrite(BluetoothGatt gatt,
+                                              BluetoothGattDescriptor descriptor,
+                                              final int status) {
+                    // The only descriptor this class writes is the CCCD, so a
+                    // descriptor write completing is a subscribe/unsubscribe
+                    // completing.
+                    final int operation = bleNotificationOpInFlight;
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            onBleGattResult(operation, status, null, 0);
+                        }
+                    });
+                }
+
+                @Override
+                public void onMtuChanged(BluetoothGatt gatt, final int mtu, final int status) {
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            onBleGattResult(5 /* MTU */, status, null, mtu);
+                        }
+                    });
+                }
+
+                @Override
+                public void onCharacteristicChanged(BluetoothGatt gatt,
+                                                    BluetoothGattCharacteristic characteristic) {
+                    final String serviceUuid = characteristic.getService().getUuid().toString();
+                    final String characteristicUuid = characteristic.getUuid().toString();
+                    final byte[] value = characteristic.getValue();
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            onBleNotification(serviceUuid, characteristicUuid, value);
+                        }
+                    });
+                }
             };
             bleGatt = device.connectGatt(this, false, gattCallback, BluetoothDevice.TRANSPORT_LE);
             if (bleGatt == null) {
@@ -385,6 +508,186 @@ public class HatterActivity extends Activity implements View.OnClickListener {
             }
         } catch (Exception e) {
             android.util.Log.e("BleBridge", "disconnectBleDevice failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Map Android characteristic property flags to the BLE_CHAR_PROP_*
+     * bits shared with the C bridge and Hatter.Ble.
+     */
+    private static int blePropertyBits(int androidProperties) {
+        int bits = 0;
+        if ((androidProperties & BluetoothGattCharacteristic.PROPERTY_READ) != 0) {
+            bits |= 1;
+        }
+        if ((androidProperties & BluetoothGattCharacteristic.PROPERTY_WRITE) != 0) {
+            bits |= 2;
+        }
+        if ((androidProperties & BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE) != 0) {
+            bits |= 4;
+        }
+        if ((androidProperties & BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0) {
+            bits |= 8;
+        }
+        return bits;
+    }
+
+    /**
+     * Report a GATT operation as failed before it reached the stack
+     * (no connection, characteristic not found).  Uses Android's
+     * generic GATT_FAILURE code (0x101) so the Haskell side sees a
+     * nonzero status.
+     */
+    private void bleGattFailEarly(int operation, String reason) {
+        android.util.Log.e("BleBridge", "GATT operation " + operation + " failed: " + reason);
+        onBleGattResult(operation, 0x101 /* GATT_FAILURE */, null, 0);
+    }
+
+    /**
+     * Look up a characteristic on the connected device.  Returns null
+     * (after reporting failure) when there is no connection or the
+     * service/characteristic does not exist.
+     */
+    private BluetoothGattCharacteristic bleFindCharacteristic(
+            int operation, String serviceUuid, String characteristicUuid) {
+        if (bleGatt == null) {
+            bleGattFailEarly(operation, "not connected");
+            return null;
+        }
+        BluetoothGattService service =
+            bleGatt.getService(java.util.UUID.fromString(serviceUuid));
+        if (service == null) {
+            bleGattFailEarly(operation, "service not found: " + serviceUuid);
+            return null;
+        }
+        BluetoothGattCharacteristic characteristic =
+            service.getCharacteristic(java.util.UUID.fromString(characteristicUuid));
+        if (characteristic == null) {
+            bleGattFailEarly(operation, "characteristic not found: " + characteristicUuid);
+            return null;
+        }
+        return characteristic;
+    }
+
+    /**
+     * Discover services and characteristics on the connected device.
+     * Called from native code via JNI.  Each characteristic is reported
+     * via onBleCharacteristicDiscovered; completion via onBleGattResult.
+     */
+    public void discoverBleServices() {
+        try {
+            if (bleGatt == null) {
+                bleGattFailEarly(0 /* DISCOVER */, "not connected");
+                return;
+            }
+            if (!bleGatt.discoverServices()) {
+                bleGattFailEarly(0 /* DISCOVER */, "discoverServices rejected");
+            }
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge", "discoverBleServices failed: " + e.getMessage());
+            bleGattFailEarly(0 /* DISCOVER */, String.valueOf(e.getMessage()));
+        }
+    }
+
+    /**
+     * Read a characteristic's value. Called from native code via JNI.
+     */
+    public void readBleCharacteristic(String serviceUuid, String characteristicUuid) {
+        try {
+            BluetoothGattCharacteristic characteristic =
+                bleFindCharacteristic(1 /* READ */, serviceUuid, characteristicUuid);
+            if (characteristic == null) {
+                return;
+            }
+            if (!bleGatt.readCharacteristic(characteristic)) {
+                bleGattFailEarly(1 /* READ */, "readCharacteristic rejected");
+            }
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge", "readBleCharacteristic failed: " + e.getMessage());
+            bleGattFailEarly(1 /* READ */, String.valueOf(e.getMessage()));
+        }
+    }
+
+    /**
+     * Write a characteristic's value. Called from native code via JNI.
+     * writeMode: 0 = without response, 1 = with response (BLE_WRITE_*).
+     */
+    public void writeBleCharacteristic(String serviceUuid, String characteristicUuid,
+                                       byte[] data, int writeMode) {
+        try {
+            BluetoothGattCharacteristic characteristic =
+                bleFindCharacteristic(2 /* WRITE */, serviceUuid, characteristicUuid);
+            if (characteristic == null) {
+                return;
+            }
+            characteristic.setWriteType(writeMode == 1
+                ? BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+                : BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
+            characteristic.setValue(data);
+            if (!bleGatt.writeCharacteristic(characteristic)) {
+                bleGattFailEarly(2 /* WRITE */, "writeCharacteristic rejected");
+            }
+            // Completion (both write modes) arrives via onCharacteristicWrite.
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge", "writeBleCharacteristic failed: " + e.getMessage());
+            bleGattFailEarly(2 /* WRITE */, String.valueOf(e.getMessage()));
+        }
+    }
+
+    /**
+     * Enable or disable notifications for a characteristic. Called from
+     * native code via JNI.  enable: 1 = subscribe, 0 = unsubscribe.
+     * Completion arrives via onDescriptorWrite after the CCCD write.
+     */
+    public void setBleCharacteristicNotification(String serviceUuid,
+                                                 String characteristicUuid,
+                                                 int enable) {
+        final int operation = enable != 0 ? 3 /* SUBSCRIBE */ : 4 /* UNSUBSCRIBE */;
+        try {
+            BluetoothGattCharacteristic characteristic =
+                bleFindCharacteristic(operation, serviceUuid, characteristicUuid);
+            if (characteristic == null) {
+                return;
+            }
+            if (!bleGatt.setCharacteristicNotification(characteristic, enable != 0)) {
+                bleGattFailEarly(operation, "setCharacteristicNotification rejected");
+                return;
+            }
+            BluetoothGattDescriptor cccd = characteristic.getDescriptor(BLE_CCCD_UUID);
+            if (cccd == null) {
+                bleGattFailEarly(operation, "CCCD descriptor missing");
+                return;
+            }
+            bleNotificationOpInFlight = operation;
+            cccd.setValue(enable != 0
+                ? BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                : BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE);
+            if (!bleGatt.writeDescriptor(cccd)) {
+                bleGattFailEarly(operation, "writeDescriptor rejected");
+            }
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge",
+                "setBleCharacteristicNotification failed: " + e.getMessage());
+            bleGattFailEarly(operation, String.valueOf(e.getMessage()));
+        }
+    }
+
+    /**
+     * Request a larger ATT MTU. Called from native code via JNI.
+     * The granted value arrives via onMtuChanged.
+     */
+    public void requestBleMtu(int mtu) {
+        try {
+            if (bleGatt == null) {
+                bleGattFailEarly(5 /* MTU */, "not connected");
+                return;
+            }
+            if (!bleGatt.requestMtu(mtu)) {
+                bleGattFailEarly(5 /* MTU */, "requestMtu rejected");
+            }
+        } catch (Exception e) {
+            android.util.Log.e("BleBridge", "requestBleMtu failed: " + e.getMessage());
+            bleGattFailEarly(5 /* MTU */, String.valueOf(e.getMessage()));
         }
     }
 

--- a/cbits/ble_bridge.c
+++ b/cbits/ble_bridge.c
@@ -17,23 +17,63 @@
 #include "BleBridge.h"
 #include <stdio.h>
 
-/* Haskell FFI export (dispatches connection events back to Haskell) */
+/* Haskell FFI exports (dispatch results back to Haskell) */
 extern void haskellOnBleConnectionEvent(void *ctx, int32_t event);
+extern void haskellOnBleGattResult(void *ctx, int32_t operation, int32_t status,
+                                   const uint8_t *data, int32_t length);
 
 static int32_t (*g_check_adapter_impl)(void) = NULL;
-static void (*g_start_scan_impl)(void *) = NULL;
+static void (*g_start_scan_impl)(void *, const char *) = NULL;
 static void (*g_stop_scan_impl)(void) = NULL;
 static void (*g_connect_impl)(void *, const char *) = NULL;
 static void (*g_disconnect_impl)(void) = NULL;
+static void (*g_discover_services_impl)(void *) = NULL;
+static void (*g_read_characteristic_impl)(void *, const char *, const char *) = NULL;
+static void (*g_write_characteristic_impl)(void *, const char *, const char *,
+                                           const uint8_t *, int32_t, int32_t) = NULL;
+static void (*g_set_notification_impl)(void *, const char *, const char *, int32_t) = NULL;
+static void (*g_request_mtu_impl)(void *, int32_t) = NULL;
 
 void ble_register_impl(
     int32_t (*check_adapter)(void),
-    void (*start_scan)(void *),
+    void (*start_scan)(void *, const char *),
     void (*stop_scan)(void))
 {
     g_check_adapter_impl = check_adapter;
     g_start_scan_impl = start_scan;
     g_stop_scan_impl = stop_scan;
+}
+
+void ble_register_gatt_impl(
+    void (*discover_services)(void *),
+    void (*read_characteristic)(void *, const char *, const char *),
+    void (*write_characteristic)(void *, const char *, const char *,
+                                 const uint8_t *, int32_t, int32_t),
+    void (*set_characteristic_notification)(void *, const char *,
+                                            const char *, int32_t),
+    void (*request_mtu)(void *, int32_t))
+{
+    g_discover_services_impl = discover_services;
+    g_read_characteristic_impl = read_characteristic;
+    g_write_characteristic_impl = write_characteristic;
+    g_set_notification_impl = set_characteristic_notification;
+    g_request_mtu_impl = request_mtu;
+}
+
+/* Fail a GATT operation that has no platform implementation.  Loud and
+ * always delivers a completion so callers are never left waiting. */
+static void ble_gatt_stub_fail(void *ctx, int32_t operation, const char *name)
+{
+    fprintf(stderr,
+            "[BleBridge stub] %s -> BLE_GATT_STATUS_NO_IMPL"
+            " (no platform GATT implementation registered)\n",
+            name);
+    if (ctx) {
+        haskellOnBleGattResult(ctx, operation, BLE_GATT_STATUS_NO_IMPL, NULL, 0);
+    } else {
+        fprintf(stderr, "[BleBridge stub] %s: null context,"
+                " cannot dispatch failure\n", name);
+    }
 }
 
 void ble_register_connect_impl(
@@ -54,14 +94,15 @@ int32_t ble_check_adapter(void)
     return BLE_ADAPTER_ON;
 }
 
-void ble_start_scan(void *ctx)
+void ble_start_scan(void *ctx, const char *service_uuid_filter)
 {
     if (g_start_scan_impl) {
-        g_start_scan_impl(ctx);
+        g_start_scan_impl(ctx, service_uuid_filter);
         return;
     }
     /* Desktop stub: no-op (no fabricated devices) */
-    fprintf(stderr, "[BleBridge stub] ble_start_scan() -> no-op\n");
+    fprintf(stderr, "[BleBridge stub] ble_start_scan(filter=%s) -> no-op\n",
+            service_uuid_filter ? service_uuid_filter : "(none)");
 }
 
 void ble_stop_scan(void)
@@ -104,4 +145,58 @@ void ble_disconnect(void)
     }
     /* Desktop stub: no-op (nothing can be connected without an impl) */
     fprintf(stderr, "[BleBridge stub] ble_disconnect() -> no-op\n");
+}
+
+void ble_discover_services(void *ctx)
+{
+    if (g_discover_services_impl) {
+        g_discover_services_impl(ctx);
+        return;
+    }
+    ble_gatt_stub_fail(ctx, BLE_GATT_OP_DISCOVER, "ble_discover_services()");
+}
+
+void ble_read_characteristic(void *ctx, const char *service_uuid,
+                             const char *characteristic_uuid)
+{
+    if (g_read_characteristic_impl) {
+        g_read_characteristic_impl(ctx, service_uuid, characteristic_uuid);
+        return;
+    }
+    ble_gatt_stub_fail(ctx, BLE_GATT_OP_READ, "ble_read_characteristic()");
+}
+
+void ble_write_characteristic(void *ctx, const char *service_uuid,
+                              const char *characteristic_uuid,
+                              const uint8_t *data, int32_t length,
+                              int32_t write_mode)
+{
+    if (g_write_characteristic_impl) {
+        g_write_characteristic_impl(ctx, service_uuid, characteristic_uuid,
+                                    data, length, write_mode);
+        return;
+    }
+    ble_gatt_stub_fail(ctx, BLE_GATT_OP_WRITE, "ble_write_characteristic()");
+}
+
+void ble_set_characteristic_notification(void *ctx, const char *service_uuid,
+                                         const char *characteristic_uuid,
+                                         int32_t enable)
+{
+    if (g_set_notification_impl) {
+        g_set_notification_impl(ctx, service_uuid, characteristic_uuid, enable);
+        return;
+    }
+    ble_gatt_stub_fail(ctx,
+                       enable ? BLE_GATT_OP_SUBSCRIBE : BLE_GATT_OP_UNSUBSCRIBE,
+                       "ble_set_characteristic_notification()");
+}
+
+void ble_request_mtu(void *ctx, int32_t mtu)
+{
+    if (g_request_mtu_impl) {
+        g_request_mtu_impl(ctx, mtu);
+        return;
+    }
+    ble_gatt_stub_fail(ctx, BLE_GATT_OP_MTU, "ble_request_mtu()");
 }

--- a/cbits/ble_bridge_android.c
+++ b/cbits/ble_bridge_android.c
@@ -23,6 +23,14 @@
 /* Haskell FFI exports (dispatch results back to Haskell callbacks) */
 extern void haskellOnBleScanResult(void *ctx, const char *name, const char *address, int32_t rssi);
 extern void haskellOnBleConnectionEvent(void *ctx, int32_t event);
+extern void haskellOnBleCharacteristicDiscovered(void *ctx, const char *serviceUuid,
+                                                 const char *characteristicUuid,
+                                                 int32_t properties);
+extern void haskellOnBleGattResult(void *ctx, int32_t operation, int32_t status,
+                                   const uint8_t *data, int32_t length);
+extern void haskellOnBleNotification(void *ctx, const char *serviceUuid,
+                                     const char *characteristicUuid,
+                                     const uint8_t *data, int32_t length);
 
 /* ---- Global state (valid only on the UI thread) ---- */
 static JNIEnv  *g_env          = NULL;
@@ -35,6 +43,11 @@ static jmethodID g_method_startBleScan;
 static jmethodID g_method_stopBleScan;
 static jmethodID g_method_connectBleDevice;
 static jmethodID g_method_disconnectBleDevice;
+static jmethodID g_method_discoverBleServices;
+static jmethodID g_method_readBleCharacteristic;
+static jmethodID g_method_writeBleCharacteristic;
+static jmethodID g_method_setBleCharacteristicNotification;
+static jmethodID g_method_requestBleMtu;
 
 /* ---- BLE bridge implementations ---- */
 
@@ -56,7 +69,7 @@ static int32_t android_ble_check_adapter(void)
     return (int32_t)result;
 }
 
-static void android_ble_start_scan(void *ctx)
+static void android_ble_start_scan(void *ctx, const char *service_uuid_filter)
 {
     JNIEnv *env = g_env;
     if (!env || !g_activity) {
@@ -65,11 +78,17 @@ static void android_ble_start_scan(void *ctx)
     }
 
     g_haskell_ctx = ctx;
-    LOGI("ble_start_scan()");
-    (*env)->CallVoidMethod(env, g_activity, g_method_startBleScan);
+    LOGI("ble_start_scan(filter=%s)", service_uuid_filter ? service_uuid_filter : "(none)");
+    jstring jfilter = service_uuid_filter
+        ? (*env)->NewStringUTF(env, service_uuid_filter)
+        : NULL;
+    (*env)->CallVoidMethod(env, g_activity, g_method_startBleScan, jfilter);
     if ((*env)->ExceptionCheck(env)) {
         LOGE("ble_start_scan: Java exception thrown");
         (*env)->ExceptionClear(env);
+    }
+    if (jfilter) {
+        (*env)->DeleteLocalRef(env, jfilter);
     }
 }
 
@@ -124,6 +143,119 @@ static void android_ble_disconnect(void)
     }
 }
 
+static void android_ble_discover_services(void *ctx)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_discover_services: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("ble_discover_services()");
+    (*env)->CallVoidMethod(env, g_activity, g_method_discoverBleServices);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_discover_services: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+}
+
+static void android_ble_read_characteristic(void *ctx, const char *service_uuid,
+                                            const char *characteristic_uuid)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_read_characteristic: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("ble_read_characteristic(%s, %s)", service_uuid, characteristic_uuid);
+    jstring jservice = (*env)->NewStringUTF(env, service_uuid);
+    jstring jcharacteristic = (*env)->NewStringUTF(env, characteristic_uuid);
+    (*env)->CallVoidMethod(env, g_activity, g_method_readBleCharacteristic,
+                           jservice, jcharacteristic);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_read_characteristic: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+    (*env)->DeleteLocalRef(env, jservice);
+    (*env)->DeleteLocalRef(env, jcharacteristic);
+}
+
+static void android_ble_write_characteristic(void *ctx, const char *service_uuid,
+                                             const char *characteristic_uuid,
+                                             const uint8_t *data, int32_t length,
+                                             int32_t write_mode)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_write_characteristic: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("ble_write_characteristic(%s, %s, %d bytes, mode=%d)",
+         service_uuid, characteristic_uuid, length, write_mode);
+    jstring jservice = (*env)->NewStringUTF(env, service_uuid);
+    jstring jcharacteristic = (*env)->NewStringUTF(env, characteristic_uuid);
+    jbyteArray jdata = (*env)->NewByteArray(env, length);
+    (*env)->SetByteArrayRegion(env, jdata, 0, length, (const jbyte *)data);
+    (*env)->CallVoidMethod(env, g_activity, g_method_writeBleCharacteristic,
+                           jservice, jcharacteristic, jdata, (jint)write_mode);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_write_characteristic: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+    (*env)->DeleteLocalRef(env, jservice);
+    (*env)->DeleteLocalRef(env, jcharacteristic);
+    (*env)->DeleteLocalRef(env, jdata);
+}
+
+static void android_ble_set_characteristic_notification(void *ctx,
+                                                        const char *service_uuid,
+                                                        const char *characteristic_uuid,
+                                                        int32_t enable)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_set_characteristic_notification: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("ble_set_characteristic_notification(%s, %s, %d)",
+         service_uuid, characteristic_uuid, enable);
+    jstring jservice = (*env)->NewStringUTF(env, service_uuid);
+    jstring jcharacteristic = (*env)->NewStringUTF(env, characteristic_uuid);
+    (*env)->CallVoidMethod(env, g_activity,
+                           g_method_setBleCharacteristicNotification,
+                           jservice, jcharacteristic, (jint)enable);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_set_characteristic_notification: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+    (*env)->DeleteLocalRef(env, jservice);
+    (*env)->DeleteLocalRef(env, jcharacteristic);
+}
+
+static void android_ble_request_mtu(void *ctx, int32_t mtu)
+{
+    JNIEnv *env = g_env;
+    if (!env || !g_activity) {
+        LOGE("ble_request_mtu: bridge not initialized");
+        return;
+    }
+
+    g_haskell_ctx = ctx;
+    LOGI("ble_request_mtu(%d)", mtu);
+    (*env)->CallVoidMethod(env, g_activity, g_method_requestBleMtu, (jint)mtu);
+    if ((*env)->ExceptionCheck(env)) {
+        LOGE("ble_request_mtu: Java exception thrown");
+        (*env)->ExceptionClear(env);
+    }
+}
+
 /* ---- Public API ---- */
 
 /*
@@ -146,7 +278,7 @@ void setup_android_ble_bridge(JNIEnv *env, jobject activity, void *haskellCtx)
     g_method_checkBleAdapter = (*env)->GetMethodID(env, actClass,
         "checkBleAdapter", "()I");
     g_method_startBleScan = (*env)->GetMethodID(env, actClass,
-        "startBleScan", "()V");
+        "startBleScan", "(Ljava/lang/String;)V");
     g_method_stopBleScan = (*env)->GetMethodID(env, actClass,
         "stopBleScan", "()V");
 
@@ -171,6 +303,34 @@ void setup_android_ble_bridge(JNIEnv *env, jobject activity, void *haskellCtx)
         ble_register_connect_impl(android_ble_connect, android_ble_disconnect);
     } else {
         LOGE("BLE connect JNI methods missing, BLE connections disabled"
+             " (update the Activity to the current hatter android sources)");
+        (*env)->ExceptionClear(env);
+    }
+
+    /* GATT operation methods, resolved with the same grace as connect:
+     * missing methods disable GATT (operations then fail visibly with
+     * BLE_GATT_STATUS_NO_IMPL) without breaking scanning. */
+    g_method_discoverBleServices = (*env)->GetMethodID(env, actClass,
+        "discoverBleServices", "()V");
+    g_method_readBleCharacteristic = (*env)->GetMethodID(env, actClass,
+        "readBleCharacteristic", "(Ljava/lang/String;Ljava/lang/String;)V");
+    g_method_writeBleCharacteristic = (*env)->GetMethodID(env, actClass,
+        "writeBleCharacteristic", "(Ljava/lang/String;Ljava/lang/String;[BI)V");
+    g_method_setBleCharacteristicNotification = (*env)->GetMethodID(env, actClass,
+        "setBleCharacteristicNotification", "(Ljava/lang/String;Ljava/lang/String;I)V");
+    g_method_requestBleMtu = (*env)->GetMethodID(env, actClass,
+        "requestBleMtu", "(I)V");
+
+    if (g_method_discoverBleServices && g_method_readBleCharacteristic
+        && g_method_writeBleCharacteristic
+        && g_method_setBleCharacteristicNotification && g_method_requestBleMtu) {
+        ble_register_gatt_impl(android_ble_discover_services,
+                               android_ble_read_characteristic,
+                               android_ble_write_characteristic,
+                               android_ble_set_characteristic_notification,
+                               android_ble_request_mtu);
+    } else {
+        LOGE("BLE GATT JNI methods missing, GATT operations disabled"
              " (update the Activity to the current hatter android sources)");
         (*env)->ExceptionClear(env);
     }
@@ -224,4 +384,68 @@ JNI_METHOD(onBleConnectionEvent)(JNIEnv *env, jobject thiz, jint event)
 
     LOGI("onBleConnectionEvent(event=%d)", event);
     haskellOnBleConnectionEvent(g_haskell_ctx, (int32_t)event);
+}
+
+/* ---- JNI callback: one discovered characteristic (streamed) ---- */
+
+JNIEXPORT void JNICALL
+JNI_METHOD(onBleCharacteristicDiscovered)(JNIEnv *env, jobject thiz,
+                                          jstring jservice, jstring jcharacteristic,
+                                          jint properties)
+{
+    g_env = env;
+
+    const char *service = (*env)->GetStringUTFChars(env, jservice, NULL);
+    const char *characteristic = (*env)->GetStringUTFChars(env, jcharacteristic, NULL);
+
+    haskellOnBleCharacteristicDiscovered(g_haskell_ctx, service, characteristic,
+                                         (int32_t)properties);
+
+    (*env)->ReleaseStringUTFChars(env, jservice, service);
+    (*env)->ReleaseStringUTFChars(env, jcharacteristic, characteristic);
+}
+
+/* ---- JNI callback: GATT operation completion ---- */
+
+JNIEXPORT void JNICALL
+JNI_METHOD(onBleGattResult)(JNIEnv *env, jobject thiz, jint operation,
+                            jint status, jbyteArray jdata, jint mtu)
+{
+    g_env = env;
+
+    LOGI("onBleGattResult(operation=%d, status=%d)", operation, status);
+
+    if (jdata) {
+        jsize length = (*env)->GetArrayLength(env, jdata);
+        jbyte *bytes = (*env)->GetByteArrayElements(env, jdata, NULL);
+        haskellOnBleGattResult(g_haskell_ctx, (int32_t)operation, (int32_t)status,
+                               (const uint8_t *)bytes, (int32_t)length);
+        (*env)->ReleaseByteArrayElements(env, jdata, bytes, JNI_ABORT);
+    } else {
+        /* No payload; the length field carries the granted MTU for
+         * BLE_GATT_OP_MTU completions and is 0 otherwise. */
+        haskellOnBleGattResult(g_haskell_ctx, (int32_t)operation, (int32_t)status,
+                               NULL, (int32_t)mtu);
+    }
+}
+
+/* ---- JNI callback: characteristic notification data ---- */
+
+JNIEXPORT void JNICALL
+JNI_METHOD(onBleNotification)(JNIEnv *env, jobject thiz, jstring jservice,
+                              jstring jcharacteristic, jbyteArray jdata)
+{
+    g_env = env;
+
+    const char *service = (*env)->GetStringUTFChars(env, jservice, NULL);
+    const char *characteristic = (*env)->GetStringUTFChars(env, jcharacteristic, NULL);
+    jsize length = (*env)->GetArrayLength(env, jdata);
+    jbyte *bytes = (*env)->GetByteArrayElements(env, jdata, NULL);
+
+    haskellOnBleNotification(g_haskell_ctx, service, characteristic,
+                             (const uint8_t *)bytes, (int32_t)length);
+
+    (*env)->ReleaseByteArrayElements(env, jdata, bytes, JNI_ABORT);
+    (*env)->ReleaseStringUTFChars(env, jservice, service);
+    (*env)->ReleaseStringUTFChars(env, jcharacteristic, characteristic);
 }

--- a/docs/ble-emulator-simulation.md
+++ b/docs/ble-emulator-simulation.md
@@ -48,7 +48,17 @@ The test (`test/android/ble.sh`, `BLE_SIM=1`) asserts through logcat:
 3. `BLE connection event: BleConnectionEstablished`: hatter connected
    to the peripheral (the peripheral's log independently confirms with
    `PERIPHERAL_CONNECTED`).
-4. `BLE connection event: BleConnectionClosed`: hatter disconnected.
+4. `BLE discovered: ...` and `BLE discovery complete:`: GATT service
+   discovery lists the peripheral's characteristics with their
+   properties.
+5. `BLE mtu granted:`: ATT MTU negotiation completed.
+6. `BLE subscribed`, `BLE read result: ...`, `BLE write completed`,
+   `BLE notification: ...`: characteristic read, acknowledged write,
+   and the peripheral echoing the written bytes back as a
+   notification (its own log confirms the write with `ECHO_WRITE`).
+7. `BLE connection event: BleConnectionClosed`: hatter disconnected.
+8. `BLE filtered scan result: ... HatterBleSim ...`: a scan filtered
+   by the advertised service UUID still finds the peripheral.
 
 ## Platform coverage
 

--- a/include/BleBridge.h
+++ b/include/BleBridge.h
@@ -14,6 +14,32 @@
 #define BLE_CONNECTION_CLOSED      1
 #define BLE_CONNECTION_FAILED      2
 
+/* BLE GATT operation codes (must match Hatter.Ble).
+ * Passed back through haskellOnBleGattResult so Haskell can sanity
+ * check that a completion belongs to the operation it has pending. */
+#define BLE_GATT_OP_DISCOVER    0
+#define BLE_GATT_OP_READ        1
+#define BLE_GATT_OP_WRITE       2
+#define BLE_GATT_OP_SUBSCRIBE   3
+#define BLE_GATT_OP_UNSUBSCRIBE 4
+#define BLE_GATT_OP_MTU         5
+
+/* GATT completion status: 0 = success; BLE_GATT_STATUS_NO_IMPL when no
+ * platform implementation is registered; anything else is the
+ * platform's own error code passed through verbatim. */
+#define BLE_GATT_STATUS_SUCCESS 0
+#define BLE_GATT_STATUS_NO_IMPL (-1)
+
+/* Characteristic property bits (must match Hatter.Ble) */
+#define BLE_CHAR_PROP_READ              1
+#define BLE_CHAR_PROP_WRITE             2
+#define BLE_CHAR_PROP_WRITE_NO_RESPONSE 4
+#define BLE_CHAR_PROP_NOTIFY            8
+
+/* Write modes for ble_write_characteristic */
+#define BLE_WRITE_WITHOUT_RESPONSE 0
+#define BLE_WRITE_WITH_RESPONSE    1
+
 /*
  * Platform-agnostic BLE bridge.
  *
@@ -33,8 +59,10 @@
 int32_t ble_check_adapter(void);
 
 /* Start a BLE scan. Discovered devices are delivered via
- * haskellOnBleScanResult(). ctx is the opaque Haskell context. */
-void ble_start_scan(void *ctx);
+ * haskellOnBleScanResult(). ctx is the opaque Haskell context.
+ * service_uuid_filter: 128-bit service UUID string to filter
+ * advertisements by, or NULL for an unfiltered scan. */
+void ble_start_scan(void *ctx, const char *service_uuid_filter);
 
 /* Stop a running BLE scan. */
 void ble_stop_scan(void);
@@ -50,12 +78,55 @@ void ble_connect(void *ctx, const char *address);
  * haskellOnBleConnectionEvent() with BLE_CONNECTION_CLOSED. */
 void ble_disconnect(void);
 
+/*
+ * GATT operations on the active connection.  All are asynchronous;
+ * exactly one may be outstanding at a time (enforced on the Haskell
+ * side).  Completions arrive via haskellOnBleGattResult(); discovered
+ * characteristics are streamed via
+ * haskellOnBleCharacteristicDiscovered() before the discover
+ * completion; notification data arrives via haskellOnBleNotification()
+ * for characteristics enabled with ble_set_characteristic_notification.
+ */
+
+/* Discover all services and characteristics on the connected device. */
+void ble_discover_services(void *ctx);
+
+/* Read a characteristic's value. */
+void ble_read_characteristic(void *ctx, const char *service_uuid,
+                             const char *characteristic_uuid);
+
+/* Write a characteristic's value. write_mode is BLE_WRITE_*. */
+void ble_write_characteristic(void *ctx, const char *service_uuid,
+                              const char *characteristic_uuid,
+                              const uint8_t *data, int32_t length,
+                              int32_t write_mode);
+
+/* Enable (1) or disable (0) notifications for a characteristic. */
+void ble_set_characteristic_notification(void *ctx, const char *service_uuid,
+                                         const char *characteristic_uuid,
+                                         int32_t enable);
+
+/* Request a larger ATT MTU (Android negotiates; iOS reports the
+ * already-negotiated maximum). Granted value is delivered in the
+ * completion's length field. */
+void ble_request_mtu(void *ctx, int32_t mtu);
+
 /* Register platform-specific scan implementations.
  * Called by platform setup functions (setup_android_ble_bridge, etc). */
 void ble_register_impl(
     int32_t (*check_adapter)(void),
-    void (*start_scan)(void *),
+    void (*start_scan)(void *, const char *),
     void (*stop_scan)(void));
+
+/* Register platform-specific GATT operation implementations. */
+void ble_register_gatt_impl(
+    void (*discover_services)(void *),
+    void (*read_characteristic)(void *, const char *, const char *),
+    void (*write_characteristic)(void *, const char *, const char *,
+                                 const uint8_t *, int32_t, int32_t),
+    void (*set_characteristic_notification)(void *, const char *,
+                                            const char *, int32_t),
+    void (*request_mtu)(void *, int32_t));
 
 /* Register platform-specific connection implementations.
  * Registered separately from ble_register_impl so that consumer apps

--- a/include/Hatter.h
+++ b/include/Hatter.h
@@ -137,6 +137,26 @@ void haskellOnBleScanResult(void *ctx, const char *name, const char *address, in
  * ctx must be a pointer returned by haskellRunMain(). */
 void haskellOnBleConnectionEvent(void *ctx, int32_t event);
 
+/* Dispatch one discovered GATT characteristic back to Haskell
+ * (streamed during service discovery, before the discover completion).
+ * properties: BLE_CHAR_PROP_* bit mask from BleBridge.h. */
+void haskellOnBleCharacteristicDiscovered(void *ctx, const char *serviceUuid,
+                                          const char *characteristicUuid,
+                                          int32_t properties);
+
+/* Dispatch a GATT operation completion back to Haskell.
+ * operation: BLE_GATT_OP_* code; status: 0 = success.
+ * data/length: read payload for BLE_GATT_OP_READ; for completions
+ * without a payload (data == NULL) length carries the granted MTU for
+ * BLE_GATT_OP_MTU and is 0 otherwise. */
+void haskellOnBleGattResult(void *ctx, int32_t operation, int32_t status,
+                            const uint8_t *data, int32_t length);
+
+/* Dispatch characteristic notification data back to Haskell. */
+void haskellOnBleNotification(void *ctx, const char *serviceUuid,
+                              const char *characteristicUuid,
+                              const uint8_t *data, int32_t length);
+
 /* Dialog action codes */
 #define DIALOG_BUTTON_1   0
 #define DIALOG_BUTTON_2   1

--- a/ios/Hatter/BleBridgeIOS.m
+++ b/ios/Hatter/BleBridgeIOS.m
@@ -1,15 +1,15 @@
 /*
  * iOS implementation of the BLE bridge callbacks.
  *
- * Uses CoreBluetooth (CBCentralManager) to check adapter state,
- * scan for peripherals and manage GATT connections.
- * Compiled by Xcode, not GHC.
+ * Uses CoreBluetooth (CBCentralManager/CBPeripheral) to check adapter
+ * state, scan for peripherals, manage GATT connections and perform
+ * GATT operations.  Compiled by Xcode, not GHC.
  *
  * All Haskell callbacks are dispatched on the main thread.
  *
  * Note: the iOS simulator does not support CoreBluetooth (the manager
  * reports CBManagerStateUnsupported), so on the simulator scans find
- * nothing and connection attempts fail with BLE_CONNECTION_FAILED.
+ * nothing and connection attempts / GATT operations fail visibly.
  */
 
 #import <CoreBluetooth/CoreBluetooth.h>
@@ -25,14 +25,30 @@ static os_log_t g_log;
 /* Haskell FFI exports (dispatch results back to Haskell callbacks) */
 extern void haskellOnBleScanResult(void *ctx, const char *name, const char *address, int32_t rssi);
 extern void haskellOnBleConnectionEvent(void *ctx, int32_t event);
+extern void haskellOnBleCharacteristicDiscovered(void *ctx, const char *serviceUuid,
+                                                 const char *characteristicUuid,
+                                                 int32_t properties);
+extern void haskellOnBleGattResult(void *ctx, int32_t operation, int32_t status,
+                                   const uint8_t *data, int32_t length);
+extern void haskellOnBleNotification(void *ctx, const char *serviceUuid,
+                                     const char *characteristicUuid,
+                                     const uint8_t *data, int32_t length);
 
 /* ---- Module-level state (declared before use in delegate methods) ---- */
 
 static BOOL g_scanning_requested = NO;
+/* Service UUID filter for a scan requested before the manager was
+ * ready; nil means unfiltered. */
+static NSArray<CBUUID *> *g_scan_filter = nil;
 
-/* ---- Scan + connection delegate ---- */
+/* Generic nonzero status for GATT failures that happen before the
+ * platform stack is involved (not connected, characteristic missing,
+ * simulator).  Mirrors Android's GATT_FAILURE. */
+#define IOS_GATT_FAILURE 0x101
 
-@interface BleScanDelegate : NSObject <CBCentralManagerDelegate>
+/* ---- Scan + connection + GATT delegate ---- */
+
+@interface BleScanDelegate : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate>
 @property (nonatomic, assign) void *haskellCtx;
 @property (nonatomic, strong) CBCentralManager *centralManager;
 /* Peripherals seen during scanning, keyed by identifier UUID string.
@@ -40,8 +56,21 @@ static BOOL g_scanning_requested = NO;
  * out earlier, so ble_connect looks the address up here. */
 @property (nonatomic, strong) NSMutableDictionary<NSString *, CBPeripheral *> *discoveredPeripherals;
 @property (nonatomic, strong) CBPeripheral *connectedPeripheral;
+/* Services whose characteristic discovery is still outstanding during
+ * a ble_discover_services run. */
+@property (nonatomic, assign) NSUInteger pendingServiceDiscoveries;
+/* Characteristic with an outstanding read.  didUpdateValueForCharacteristic
+ * fires for both reads and notifications; a matching pending read
+ * means read completion, anything else is a notification. */
+@property (nonatomic, strong) CBCharacteristic *pendingReadCharacteristic;
+/* Which operation a pending setNotifyValue belongs to:
+ * BLE_GATT_OP_SUBSCRIBE or BLE_GATT_OP_UNSUBSCRIBE. */
+@property (nonatomic, assign) int32_t notificationOpInFlight;
 /* Dispatch a BLE_CONNECTION_* event to Haskell on the main thread. */
 - (void)dispatchConnectionEvent:(int32_t)event;
+/* Dispatch a GATT completion to Haskell on the main thread. */
+- (void)dispatchGattResult:(int32_t)operation status:(int32_t)status
+                      data:(NSData *)data mtu:(int32_t)mtu;
 @end
 
 @implementation BleScanDelegate
@@ -50,6 +79,7 @@ static BOOL g_scanning_requested = NO;
     self = [super init];
     if (self) {
         _discoveredPeripherals = [NSMutableDictionary dictionary];
+        _notificationOpInFlight = BLE_GATT_OP_SUBSCRIBE;
     }
     return self;
 }
@@ -58,7 +88,7 @@ static BOOL g_scanning_requested = NO;
     LOGI("CBCentralManager state: %ld", (long)central.state);
     /* If scanning was requested before the manager was ready, start now */
     if (central.state == CBManagerStatePoweredOn && g_scanning_requested) {
-        [central scanForPeripheralsWithServices:nil
+        [central scanForPeripheralsWithServices:g_scan_filter
                                         options:@{CBCentralManagerScanOptionAllowDuplicatesKey: @NO}];
         LOGI("BLE scan started (deferred)");
     }
@@ -86,10 +116,23 @@ static BOOL g_scanning_requested = NO;
     });
 }
 
+- (void)dispatchGattResult:(int32_t)operation status:(int32_t)status
+                      data:(NSData *)data mtu:(int32_t)mtu {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (data) {
+            haskellOnBleGattResult(self.haskellCtx, operation, status,
+                                   (const uint8_t *)data.bytes, (int32_t)data.length);
+        } else {
+            haskellOnBleGattResult(self.haskellCtx, operation, status, NULL, mtu);
+        }
+    });
+}
+
 - (void)centralManager:(CBCentralManager *)central
   didConnectPeripheral:(CBPeripheral *)peripheral {
     LOGI("didConnectPeripheral: %@", peripheral.identifier);
     self.connectedPeripheral = peripheral;
+    peripheral.delegate = self;
     [self dispatchConnectionEvent:BLE_CONNECTION_ESTABLISHED];
 }
 
@@ -108,6 +151,118 @@ didDisconnectPeripheral:(CBPeripheral *)peripheral
     self.connectedPeripheral = nil;
     [self dispatchConnectionEvent:error == nil ? BLE_CONNECTION_CLOSED
                                                : BLE_CONNECTION_FAILED];
+}
+
+/* ---- CBPeripheralDelegate: GATT operations ---- */
+
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverServices:(NSError *)error {
+    if (error) {
+        LOGE("didDiscoverServices: %@", error);
+        [self dispatchGattResult:BLE_GATT_OP_DISCOVER status:(int32_t)error.code
+                            data:nil mtu:0];
+        return;
+    }
+    if (peripheral.services.count == 0) {
+        [self dispatchGattResult:BLE_GATT_OP_DISCOVER status:BLE_GATT_STATUS_SUCCESS
+                            data:nil mtu:0];
+        return;
+    }
+    self.pendingServiceDiscoveries = peripheral.services.count;
+    for (CBService *service in peripheral.services) {
+        [peripheral discoverCharacteristics:nil forService:service];
+    }
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverCharacteristicsForService:(CBService *)service
+             error:(NSError *)error {
+    if (error) {
+        LOGE("didDiscoverCharacteristicsForService: %@", error);
+    } else {
+        for (CBCharacteristic *characteristic in service.characteristics) {
+            int32_t properties = 0;
+            if (characteristic.properties & CBCharacteristicPropertyRead) {
+                properties |= BLE_CHAR_PROP_READ;
+            }
+            if (characteristic.properties & CBCharacteristicPropertyWrite) {
+                properties |= BLE_CHAR_PROP_WRITE;
+            }
+            if (characteristic.properties & CBCharacteristicPropertyWriteWithoutResponse) {
+                properties |= BLE_CHAR_PROP_WRITE_NO_RESPONSE;
+            }
+            if (characteristic.properties & CBCharacteristicPropertyNotify) {
+                properties |= BLE_CHAR_PROP_NOTIFY;
+            }
+            /* Capture the objects, not their UTF8String pointers: the
+             * C pointers do not outlive the autorelease pool, the
+             * block does. */
+            NSString *serviceUuidString = [service.UUID UUIDString];
+            NSString *characteristicUuidString = [characteristic.UUID UUIDString];
+            const int32_t propertyBits = properties;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                haskellOnBleCharacteristicDiscovered(self.haskellCtx,
+                                                     [serviceUuidString UTF8String],
+                                                     [characteristicUuidString UTF8String],
+                                                     propertyBits);
+            });
+        }
+    }
+    if (self.pendingServiceDiscoveries > 0) {
+        self.pendingServiceDiscoveries -= 1;
+    }
+    if (self.pendingServiceDiscoveries == 0) {
+        [self dispatchGattResult:BLE_GATT_OP_DISCOVER status:BLE_GATT_STATUS_SUCCESS
+                            data:nil mtu:0];
+    }
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    /* Fires for both read completions and notifications; a matching
+     * pending read means this is the read result. */
+    if (self.pendingReadCharacteristic == characteristic) {
+        self.pendingReadCharacteristic = nil;
+        if (error) {
+            [self dispatchGattResult:BLE_GATT_OP_READ status:(int32_t)error.code
+                                data:nil mtu:0];
+        } else {
+            [self dispatchGattResult:BLE_GATT_OP_READ status:BLE_GATT_STATUS_SUCCESS
+                                data:(characteristic.value ?: [NSData data]) mtu:0];
+        }
+        return;
+    }
+
+    if (error) {
+        LOGE("notification error: %@", error);
+        return;
+    }
+    /* Capture the objects, not their inner pointers (see discovery). */
+    NSData *value = characteristic.value ?: [NSData data];
+    NSString *serviceUuidString = [characteristic.service.UUID UUIDString];
+    NSString *characteristicUuidString = [characteristic.UUID UUIDString];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        haskellOnBleNotification(self.haskellCtx,
+                                 [serviceUuidString UTF8String],
+                                 [characteristicUuidString UTF8String],
+                                 (const uint8_t *)value.bytes, (int32_t)value.length);
+    });
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didWriteValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    [self dispatchGattResult:BLE_GATT_OP_WRITE
+                      status:(error ? (int32_t)error.code : BLE_GATT_STATUS_SUCCESS)
+                        data:nil mtu:0];
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    [self dispatchGattResult:self.notificationOpInFlight
+                      status:(error ? (int32_t)error.code : BLE_GATT_STATUS_SUCCESS)
+                        data:nil mtu:0];
 }
 
 @end
@@ -155,9 +310,14 @@ static void ios_ble_ensure_manager(void *ctx)
     }
 }
 
-static void ios_ble_start_scan(void *ctx)
+static void ios_ble_start_scan(void *ctx, const char *service_uuid_filter)
 {
-    LOGI("ios_ble_start_scan()");
+    LOGI("ios_ble_start_scan(filter=%s)",
+         service_uuid_filter ? service_uuid_filter : "(none)");
+
+    g_scan_filter = service_uuid_filter
+        ? @[[CBUUID UUIDWithString:[NSString stringWithUTF8String:service_uuid_filter]]]
+        : nil;
 
     BOOL managerExisted = g_delegate && g_delegate.centralManager;
     ios_ble_ensure_manager(ctx);
@@ -168,7 +328,7 @@ static void ios_ble_start_scan(void *ctx)
 
     if (g_delegate.centralManager.state == CBManagerStatePoweredOn) {
         g_scanning_requested = NO;
-        [g_delegate.centralManager scanForPeripheralsWithServices:nil
+        [g_delegate.centralManager scanForPeripheralsWithServices:g_scan_filter
                                                          options:@{CBCentralManagerScanOptionAllowDuplicatesKey: @NO}];
         LOGI("BLE scan started");
     } else {
@@ -214,6 +374,138 @@ static void ios_ble_disconnect(void)
     }
 }
 
+/* ---- GATT operations ---- */
+
+/* Fail a GATT operation before it reaches CoreBluetooth (no
+ * connection, unknown characteristic, simulator). */
+static void ios_ble_gatt_fail_early(void *ctx, int32_t operation, const char *reason)
+{
+    LOGE("GATT operation %d failed: %s", operation, reason);
+    ios_ble_ensure_manager(ctx);
+    [g_delegate dispatchGattResult:operation status:IOS_GATT_FAILURE data:nil mtu:0];
+}
+
+/* Look up a characteristic on the connected peripheral.  Requires a
+ * prior successful ble_discover_services run. Returns nil after
+ * reporting failure when not found. */
+static CBCharacteristic *ios_ble_find_characteristic(void *ctx, int32_t operation,
+                                                     const char *service_uuid,
+                                                     const char *characteristic_uuid)
+{
+    ios_ble_ensure_manager(ctx);
+    CBPeripheral *peripheral = g_delegate.connectedPeripheral;
+    if (!peripheral) {
+        ios_ble_gatt_fail_early(ctx, operation, "not connected");
+        return nil;
+    }
+    CBUUID *serviceUuid =
+        [CBUUID UUIDWithString:[NSString stringWithUTF8String:service_uuid]];
+    CBUUID *characteristicUuid =
+        [CBUUID UUIDWithString:[NSString stringWithUTF8String:characteristic_uuid]];
+    for (CBService *service in peripheral.services) {
+        if (![service.UUID isEqual:serviceUuid]) {
+            continue;
+        }
+        for (CBCharacteristic *characteristic in service.characteristics) {
+            if ([characteristic.UUID isEqual:characteristicUuid]) {
+                return characteristic;
+            }
+        }
+    }
+    ios_ble_gatt_fail_early(ctx, operation, "characteristic not found (discover first)");
+    return nil;
+}
+
+static void ios_ble_discover_services(void *ctx)
+{
+    LOGI("ios_ble_discover_services()");
+    ios_ble_ensure_manager(ctx);
+    CBPeripheral *peripheral = g_delegate.connectedPeripheral;
+    if (!peripheral) {
+        ios_ble_gatt_fail_early(ctx, BLE_GATT_OP_DISCOVER, "not connected");
+        return;
+    }
+    [peripheral discoverServices:nil];
+}
+
+static void ios_ble_read_characteristic(void *ctx, const char *service_uuid,
+                                        const char *characteristic_uuid)
+{
+    LOGI("ios_ble_read_characteristic(%s, %s)", service_uuid, characteristic_uuid);
+    CBCharacteristic *characteristic =
+        ios_ble_find_characteristic(ctx, BLE_GATT_OP_READ, service_uuid, characteristic_uuid);
+    if (!characteristic) {
+        return;
+    }
+    g_delegate.pendingReadCharacteristic = characteristic;
+    [g_delegate.connectedPeripheral readValueForCharacteristic:characteristic];
+}
+
+static void ios_ble_write_characteristic(void *ctx, const char *service_uuid,
+                                         const char *characteristic_uuid,
+                                         const uint8_t *data, int32_t length,
+                                         int32_t write_mode)
+{
+    LOGI("ios_ble_write_characteristic(%s, %s, %d bytes, mode=%d)",
+         service_uuid, characteristic_uuid, length, write_mode);
+    CBCharacteristic *characteristic =
+        ios_ble_find_characteristic(ctx, BLE_GATT_OP_WRITE, service_uuid, characteristic_uuid);
+    if (!characteristic) {
+        return;
+    }
+    NSData *payload = [NSData dataWithBytes:data length:(NSUInteger)length];
+    if (write_mode == BLE_WRITE_WITH_RESPONSE) {
+        [g_delegate.connectedPeripheral writeValue:payload
+                                 forCharacteristic:characteristic
+                                              type:CBCharacteristicWriteWithResponse];
+        /* Completion arrives via didWriteValueForCharacteristic. */
+    } else {
+        [g_delegate.connectedPeripheral writeValue:payload
+                                 forCharacteristic:characteristic
+                                              type:CBCharacteristicWriteWithoutResponse];
+        /* CoreBluetooth has no completion callback for unacknowledged
+         * writes; report success as soon as the write is queued. */
+        [g_delegate dispatchGattResult:BLE_GATT_OP_WRITE status:BLE_GATT_STATUS_SUCCESS
+                                  data:nil mtu:0];
+    }
+}
+
+static void ios_ble_set_characteristic_notification(void *ctx, const char *service_uuid,
+                                                    const char *characteristic_uuid,
+                                                    int32_t enable)
+{
+    LOGI("ios_ble_set_characteristic_notification(%s, %s, %d)",
+         service_uuid, characteristic_uuid, enable);
+    int32_t operation = enable ? BLE_GATT_OP_SUBSCRIBE : BLE_GATT_OP_UNSUBSCRIBE;
+    CBCharacteristic *characteristic =
+        ios_ble_find_characteristic(ctx, operation, service_uuid, characteristic_uuid);
+    if (!characteristic) {
+        return;
+    }
+    g_delegate.notificationOpInFlight = operation;
+    [g_delegate.connectedPeripheral setNotifyValue:(enable != 0)
+                                 forCharacteristic:characteristic];
+    /* Completion arrives via didUpdateNotificationStateForCharacteristic. */
+}
+
+static void ios_ble_request_mtu(void *ctx, int32_t mtu)
+{
+    LOGI("ios_ble_request_mtu(%d)", mtu);
+    ios_ble_ensure_manager(ctx);
+    CBPeripheral *peripheral = g_delegate.connectedPeripheral;
+    if (!peripheral) {
+        ios_ble_gatt_fail_early(ctx, BLE_GATT_OP_MTU, "not connected");
+        return;
+    }
+    /* iOS negotiates the MTU itself; report the usable value.  The
+     * +3 converts the write payload limit back to the ATT MTU
+     * convention Android uses. */
+    int32_t granted = (int32_t)[peripheral
+        maximumWriteValueLengthForType:CBCharacteristicWriteWithoutResponse] + 3;
+    [g_delegate dispatchGattResult:BLE_GATT_OP_MTU status:BLE_GATT_STATUS_SUCCESS
+                              data:nil mtu:granted];
+}
+
 /* ---- Public API ---- */
 
 /*
@@ -226,6 +518,11 @@ void setup_ios_ble_bridge(void *haskellCtx)
 
     ble_register_impl(ios_ble_check_adapter, ios_ble_start_scan, ios_ble_stop_scan);
     ble_register_connect_impl(ios_ble_connect, ios_ble_disconnect);
+    ble_register_gatt_impl(ios_ble_discover_services,
+                           ios_ble_read_characteristic,
+                           ios_ble_write_characteristic,
+                           ios_ble_set_characteristic_notification,
+                           ios_ble_request_mtu);
 
     LOGI("iOS BLE bridge initialized");
 }

--- a/ios/Hatter/ContentView.swift
+++ b/ios/Hatter/ContentView.swift
@@ -31,17 +31,34 @@ struct HaskellUIView: UIViewControllerRepresentable {
             }
         }
 
-        // CI auto-test: exercise the BLE connect path.  Event ids follow
-        // the action creation order in test/BleDemoMain.hs: 0 = Check
-        // Adapter, 1 = Start Scan, 2 = Stop Scan, 3 = Connect,
-        // 4 = Disconnect.  The simulator has no CoreBluetooth support,
-        // so Connect must round-trip through the bridge and log
-        // BleConnectionFailed without crashing.
+        // CI auto-test: exercise the BLE connect and GATT paths.  Event
+        // ids follow the action creation order in test/BleDemoMain.hs:
+        // 0 = Check Adapter, 1 = Start Scan, 2 = Stop Scan,
+        // 3 = Connect, 4 = Disconnect, 5 = Discover, 6 = Read,
+        // 7 = Write, 8 = Subscribe, 9 = Request Mtu, 10 = Filtered
+        // Scan.  The simulator has no CoreBluetooth support, so every
+        // operation must round-trip through the bridge and log a
+        // visible failure without hanging or crashing.
         if CommandLine.arguments.contains("--autotest-ble") {
             DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
                 HaskellBridge.onUIEvent(3)  // Connect
             }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
+                HaskellBridge.onUIEvent(5)  // Discover
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                HaskellBridge.onUIEvent(6)  // Read
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 12) {
+                HaskellBridge.onUIEvent(7)  // Write
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 14) {
+                HaskellBridge.onUIEvent(8)  // Subscribe
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 16) {
+                HaskellBridge.onUIEvent(9)  // Request Mtu
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 18) {
                 HaskellBridge.onUIEvent(4)  // Disconnect
             }
         }

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -146,7 +146,20 @@ import Hatter.Animation (dispatchAnimationFrame)
 import Hatter.AppContext (AppContext(..), newAppContext, derefAppContext)
 import Hatter.AuthSession (dispatchAuthSessionResult)
 import Hatter.PlatformSignIn (dispatchPlatformSignInResult)
-import Hatter.Ble (dispatchBleScanResult, dispatchBleConnectionEvent, bleConnectionEventFromInt)
+import Hatter.Ble
+  ( dispatchBleScanResult
+  , dispatchBleConnectionEvent
+  , dispatchBleCharacteristicDiscovered
+  , dispatchBleGattCompletion
+  , dispatchBleNotification
+  , bleConnectionEventFromInt
+  , bleGattOperationFromInt
+  , bleCharacteristicPropertiesFromBits
+  , BleGattCompletion(..)
+  , BleDiscoveredCharacteristic(..)
+  , BleServiceUuid(..)
+  , BleCharacteristicUuid(..)
+  )
 import Hatter.BottomSheet (dispatchBottomSheetResult)
 import Hatter.Camera
   ( dispatchCameraResult
@@ -373,6 +386,76 @@ haskellOnBleConnectionEvent ctxPtr eventCode =
       Just event -> dispatchBleConnectionEvent (acBleState appCtx) event
 
 foreign export ccall haskellOnBleConnectionEvent :: Ptr AppContext -> CInt -> IO ()
+
+-- | Handle one discovered GATT characteristic from native code,
+-- streamed during a 'Hatter.Ble.discoverBleServices' run.
+haskellOnBleCharacteristicDiscovered
+  :: Ptr AppContext -> CString -> CString -> CInt -> IO ()
+haskellOnBleCharacteristicDiscovered ctxPtr cService cCharacteristic cProperties =
+  withExceptionHandler ctxPtr $ do
+    appCtx <- derefAppContext ctxPtr
+    serviceUuid <- pack <$> peekCString cService
+    characteristicUuid <- pack <$> peekCString cCharacteristic
+    dispatchBleCharacteristicDiscovered (acBleState appCtx)
+      BleDiscoveredCharacteristic
+        { bdcService        = BleServiceUuid serviceUuid
+        , bdcCharacteristic = BleCharacteristicUuid characteristicUuid
+        , bdcProperties     = bleCharacteristicPropertiesFromBits cProperties
+        }
+
+foreign export ccall haskellOnBleCharacteristicDiscovered
+  :: Ptr AppContext -> CString -> CString -> CInt -> IO ()
+
+-- | Handle a GATT operation completion from native code.  Decodes the
+-- operation code, status, payload (read data) and granted MTU at the
+-- FFI boundary, then dispatches to the pending operation registered
+-- in 'Hatter.Ble.BleState'.
+haskellOnBleGattResult
+  :: Ptr AppContext -> CInt -> CInt -> Ptr Word8 -> CInt -> IO ()
+haskellOnBleGattResult ctxPtr cOperation cStatus dataPtr dataLength =
+  withExceptionHandler ctxPtr $ do
+    appCtx <- derefAppContext ctxPtr
+    case bleGattOperationFromInt cOperation of
+      Nothing -> hPutStrLn stderr $
+        "haskellOnBleGattResult: unknown operation code " ++ show cOperation
+      Just operation -> do
+        -- With a payload the length field is the payload size; without
+        -- one it carries the granted MTU (nonzero only for MTU
+        -- completions, see BleBridge.h).
+        payload <- if dataPtr == nullPtr || dataLength <= 0
+          then pure BS.empty
+          else BS.packCStringLen (castPtr dataPtr, CInt.toInt dataLength)
+        let grantedMtu = if dataPtr == nullPtr then CInt.toInt dataLength else 0
+        dispatchBleGattCompletion (acBleState appCtx) BleGattCompletion
+          { bgcOperation  = operation
+          , bgcStatusCode = CInt.toInt cStatus
+          , bgcPayload    = payload
+          , bgcGrantedMtu = grantedMtu
+          }
+
+foreign export ccall haskellOnBleGattResult
+  :: Ptr AppContext -> CInt -> CInt -> Ptr Word8 -> CInt -> IO ()
+
+-- | Handle characteristic notification data from native code.
+-- Dispatches to the callback registered by
+-- 'Hatter.Ble.subscribeBleCharacteristic'.
+haskellOnBleNotification
+  :: Ptr AppContext -> CString -> CString -> Ptr Word8 -> CInt -> IO ()
+haskellOnBleNotification ctxPtr cService cCharacteristic dataPtr dataLength =
+  withExceptionHandler ctxPtr $ do
+    appCtx <- derefAppContext ctxPtr
+    serviceUuid <- pack <$> peekCString cService
+    characteristicUuid <- pack <$> peekCString cCharacteristic
+    payload <- if dataPtr == nullPtr || dataLength <= 0
+      then pure BS.empty
+      else BS.packCStringLen (castPtr dataPtr, CInt.toInt dataLength)
+    dispatchBleNotification (acBleState appCtx)
+      (BleServiceUuid serviceUuid)
+      (BleCharacteristicUuid characteristicUuid)
+      payload
+
+foreign export ccall haskellOnBleNotification
+  :: Ptr AppContext -> CString -> CString -> Ptr Word8 -> CInt -> IO ()
 
 -- | Handle a dialog result from native code. Dispatches to the
 -- callback registered by 'Hatter.Dialog.showDialog'.

--- a/src/Hatter.hs
+++ b/src/Hatter.hs
@@ -159,6 +159,8 @@ import Hatter.Ble
   , BleDiscoveredCharacteristic(..)
   , BleServiceUuid(..)
   , BleCharacteristicUuid(..)
+  , BleCharacteristicValue(..)
+  , BleMtu(..)
   )
 import Hatter.BottomSheet (dispatchBottomSheetResult)
 import Hatter.Camera
@@ -429,8 +431,8 @@ haskellOnBleGattResult ctxPtr cOperation cStatus dataPtr dataLength =
         dispatchBleGattCompletion (acBleState appCtx) BleGattCompletion
           { bgcOperation  = operation
           , bgcStatusCode = CInt.toInt cStatus
-          , bgcPayload    = payload
-          , bgcGrantedMtu = grantedMtu
+          , bgcPayload    = BleCharacteristicValue payload
+          , bgcGrantedMtu = BleMtu grantedMtu
           }
 
 foreign export ccall haskellOnBleGattResult
@@ -452,7 +454,7 @@ haskellOnBleNotification ctxPtr cService cCharacteristic dataPtr dataLength =
     dispatchBleNotification (acBleState appCtx)
       (BleServiceUuid serviceUuid)
       (BleCharacteristicUuid characteristicUuid)
-      payload
+      (BleCharacteristicValue payload)
 
 foreign export ccall haskellOnBleNotification
   :: Ptr AppContext -> CString -> CString -> Ptr Word8 -> CInt -> IO ()

--- a/src/Hatter/Ble.hs
+++ b/src/Hatter/Ble.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | BLE (Bluetooth Low Energy) API for mobile platforms.
@@ -25,6 +27,10 @@ module Hatter.Ble
   , BleDeviceAddress(..)
   , BleServiceUuid(..)
   , BleCharacteristicUuid(..)
+  , NormalizedBleUuid(..)
+  , BleCharacteristicKey(..)
+  , BleCharacteristicValue(..)
+  , BleMtu(..)
   , BleConnectionEvent(..)
   , BleCharacteristicProperty(..)
   , BleDiscoveredCharacteristic(..)
@@ -35,6 +41,9 @@ module Hatter.Ble
   , PendingBleGattOperation(..)
   , BleState(..)
   , newBleState
+  , normalizeBleServiceUuid
+  , normalizeBleCharacteristicUuid
+  , bleCharacteristicKey
   , bleAdapterStatusFromInt
   , bleAdapterStatusToInt
   , bleConnectionEventFromInt
@@ -69,6 +78,7 @@ import Data.ByteString qualified as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.String (IsString)
 import Data.Text (Text, pack, toLower, unpack)
 import Foreign.C.String (CString, peekCString, withCString)
 import Foreign.C.Types (CInt(..))
@@ -91,15 +101,48 @@ data BleAdapterStatus
 -- applications; pass it back verbatim to 'connectBleDevice'.
 newtype BleDeviceAddress = BleDeviceAddress { unBleDeviceAddress :: Text }
   deriving (Show, Eq, Ord)
+  deriving newtype (IsString)
 
 -- | A 128-bit GATT service UUID string, e.g.
 -- @"50DB505C-8AC4-4738-8448-3B1D9CC09CC5"@.  Case-insensitive on both
 -- platforms.
 newtype BleServiceUuid = BleServiceUuid { unBleServiceUuid :: Text }
   deriving (Show, Eq, Ord)
+  deriving newtype (IsString)
 
 -- | A 128-bit GATT characteristic UUID string.
 newtype BleCharacteristicUuid = BleCharacteristicUuid { unBleCharacteristicUuid :: Text }
+  deriving (Show, Eq, Ord)
+  deriving newtype (IsString)
+
+-- | A UUID string normalized to lowercase for comparisons.  UUIDs are
+-- case-insensitive per the Bluetooth spec, but the platforms disagree
+-- on the case they report (Android lowercase, iOS uppercase), so raw
+-- strings must never be compared directly.  Constructed via
+-- 'normalizeBleServiceUuid' \/ 'normalizeBleCharacteristicUuid';
+-- deliberately no 'IsString' instance, a literal would bypass the
+-- normalization.
+newtype NormalizedBleUuid = NormalizedBleUuid { unNormalizedBleUuid :: Text }
+  deriving (Show, Eq, Ord)
+
+-- | Identifies one characteristic on the connected device: its
+-- containing service and its own UUID, case-normalized so lookups
+-- match across platforms.  Used as the notification-callback key.
+data BleCharacteristicKey = BleCharacteristicKey
+  { bckService        :: NormalizedBleUuid
+  , bckCharacteristic :: NormalizedBleUuid
+  } deriving (Show, Eq, Ord)
+
+-- | The bytes of a characteristic's value: read results, write
+-- payloads and notification payloads.
+newtype BleCharacteristicValue = BleCharacteristicValue
+  { unBleCharacteristicValue :: ByteString }
+  deriving (Show, Eq, Ord)
+  deriving newtype (IsString)
+
+-- | An ATT MTU in bytes.  Write payloads should stay within
+-- @'unBleMtu' granted - 3@ bytes (the 3 bytes are the ATT header).
+newtype BleMtu = BleMtu { unBleMtu :: Int }
   deriving (Show, Eq, Ord)
 
 -- | A single BLE scan result delivered by the platform.
@@ -176,10 +219,10 @@ data BleGattCompletion = BleGattCompletion
   { bgcOperation  :: BleGattOperation
   , bgcStatusCode :: Int
     -- ^ 0 = success.
-  , bgcPayload    :: ByteString
+  , bgcPayload    :: BleCharacteristicValue
     -- ^ Read data for 'BleGattRead'; empty otherwise.
-  , bgcGrantedMtu :: Int
-    -- ^ Granted MTU for 'BleGattRequestMtu'; 0 otherwise.
+  , bgcGrantedMtu :: BleMtu
+    -- ^ Granted MTU for 'BleGattRequestMtu'; 'BleMtu' 0 otherwise.
   } deriving (Show, Eq)
 
 -- | The one GATT operation currently in flight, with its
@@ -189,15 +232,13 @@ data BleGattCompletion = BleGattCompletion
 data PendingBleGattOperation
   = PendingBleDiscover (IORef [BleDiscoveredCharacteristic])
       (Either BleGattError [BleDiscoveredCharacteristic] -> IO ())
-  | PendingBleRead (Either BleGattError ByteString -> IO ())
+  | PendingBleRead (Either BleGattError BleCharacteristicValue -> IO ())
   | PendingBleWrite (Either BleGattError () -> IO ())
-  | PendingBleSubscribe (Text, Text)
+  | PendingBleSubscribe BleCharacteristicKey
       (Either BleGattError () -> IO ())
-    -- ^ Key: 'normalizedBleUuidPair' of the subscribed characteristic.
-  | PendingBleUnsubscribe (Text, Text)
+  | PendingBleUnsubscribe BleCharacteristicKey
       (Either BleGattError () -> IO ())
-    -- ^ Key: 'normalizedBleUuidPair' of the unsubscribed characteristic.
-  | PendingBleMtu (Either BleGattError Int -> IO ())
+  | PendingBleMtu (Either BleGattError BleMtu -> IO ())
 
 -- | Mutable state for the BLE subsystem.
 -- Uses 'IORef (Maybe callback)' instead of 'IntMap' because only
@@ -214,12 +255,10 @@ data BleState = BleState
     -- 'connectBleDevice' call overwrites it.
   , blesGattPending :: IORef (Maybe PendingBleGattOperation)
     -- ^ The GATT operation currently in flight, if any.
-  , blesNotificationCallbacks :: IORef (Map (Text, Text) (ByteString -> IO ()))
+  , blesNotificationCallbacks
+      :: IORef (Map BleCharacteristicKey (BleCharacteristicValue -> IO ()))
     -- ^ Per-characteristic notification callbacks, registered by
-    -- 'subscribeBleCharacteristic' and keyed by
-    -- 'normalizedBleUuidPair': Android reports UUIDs lowercase and
-    -- iOS uppercase, so the raw newtypes would never match across
-    -- the subscribe/notify round trip.
+    -- 'subscribeBleCharacteristic'.
   , blesContextPtr   :: IORef (Ptr ())
     -- ^ Opaque context pointer passed to the C bridge.
     -- Set by 'AppContext.newAppContext' after the 'StablePtr' is created.
@@ -297,15 +336,20 @@ bleGattOperationToInt BleGattSubscribe   = 3
 bleGattOperationToInt BleGattUnsubscribe = 4
 bleGattOperationToInt BleGattRequestMtu  = 5
 
--- | The case-normalized key identifying a characteristic in
--- 'blesNotificationCallbacks'.  UUID strings are case-insensitive per
--- the Bluetooth spec, but the platforms disagree on the case they
--- report (Android lowercase, iOS uppercase).
-normalizedBleUuidPair :: BleServiceUuid -> BleCharacteristicUuid -> (Text, Text)
-normalizedBleUuidPair serviceUuid characteristicUuid =
-  ( toLower (unBleServiceUuid serviceUuid)
-  , toLower (unBleCharacteristicUuid characteristicUuid)
-  )
+-- | Normalize a service UUID for comparisons.
+normalizeBleServiceUuid :: BleServiceUuid -> NormalizedBleUuid
+normalizeBleServiceUuid = NormalizedBleUuid . toLower . unBleServiceUuid
+
+-- | Normalize a characteristic UUID for comparisons.
+normalizeBleCharacteristicUuid :: BleCharacteristicUuid -> NormalizedBleUuid
+normalizeBleCharacteristicUuid = NormalizedBleUuid . toLower . unBleCharacteristicUuid
+
+-- | Build the notification-callback key for a characteristic.
+bleCharacteristicKey :: BleServiceUuid -> BleCharacteristicUuid -> BleCharacteristicKey
+bleCharacteristicKey serviceUuid characteristicUuid = BleCharacteristicKey
+  { bckService        = normalizeBleServiceUuid serviceUuid
+  , bckCharacteristic = normalizeBleCharacteristicUuid characteristicUuid
+  }
 
 -- | The @BLE_CHAR_PROP_*@ bit for one property (see @BleBridge.h@).
 bleCharacteristicPropertyBit :: BleCharacteristicProperty -> CInt
@@ -428,7 +472,7 @@ readBleCharacteristic
   :: BleState
   -> BleServiceUuid
   -> BleCharacteristicUuid
-  -> (Either BleGattError ByteString -> IO ())
+  -> (Either BleGattError BleCharacteristicValue -> IO ())
   -> IO ()
 readBleCharacteristic bleState serviceUuid characteristicUuid callback =
   startBleGattOperation bleState
@@ -448,7 +492,7 @@ writeBleCharacteristic
   -> BleServiceUuid
   -> BleCharacteristicUuid
   -> BleWriteMode
-  -> ByteString
+  -> BleCharacteristicValue
   -> (Either BleGattError () -> IO ())
   -> IO ()
 writeBleCharacteristic bleState serviceUuid characteristicUuid writeMode payload callback =
@@ -458,7 +502,7 @@ writeBleCharacteristic bleState serviceUuid characteristicUuid writeMode payload
     (do ctx <- readIORef (blesContextPtr bleState)
         withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
           withCString (unpack (unBleCharacteristicUuid characteristicUuid)) $ \cCharacteristic ->
-            BS.useAsCStringLen payload $ \(cPayload, payloadLength) -> do
+            BS.useAsCStringLen (unBleCharacteristicValue payload) $ \(cPayload, payloadLength) -> do
               cLength <- case Int.toCInt payloadLength of
                 Just converted -> pure converted
                 Nothing -> error $
@@ -479,20 +523,19 @@ subscribeBleCharacteristic
   :: BleState
   -> BleServiceUuid
   -> BleCharacteristicUuid
-  -> (ByteString -> IO ())              -- ^ onNotification
+  -> (BleCharacteristicValue -> IO ())  -- ^ onNotification
   -> (Either BleGattError () -> IO ())  -- ^ onSubscribed
   -> IO ()
 subscribeBleCharacteristic bleState serviceUuid characteristicUuid onNotification onSubscribed = do
+  let key = bleCharacteristicKey serviceUuid characteristicUuid
   -- Register the notification callback before asking the platform to
   -- enable notifications, so no early notification can be missed.  A
   -- failed subscription removes it again in 'dispatchBleGattCompletion'.
-  modifyIORef' (blesNotificationCallbacks bleState)
-    (Map.insert (normalizedBleUuidPair serviceUuid characteristicUuid) onNotification)
+  modifyIORef' (blesNotificationCallbacks bleState) (Map.insert key onNotification)
   startBleGattOperation bleState
-    (PendingBleSubscribe (normalizedBleUuidPair serviceUuid characteristicUuid) onSubscribed)
+    (PendingBleSubscribe key onSubscribed)
     (\gattError -> do
-        modifyIORef' (blesNotificationCallbacks bleState)
-          (Map.delete (normalizedBleUuidPair serviceUuid characteristicUuid))
+        modifyIORef' (blesNotificationCallbacks bleState) (Map.delete key)
         onSubscribed (Left gattError))
     (do ctx <- readIORef (blesContextPtr bleState)
         withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
@@ -509,7 +552,7 @@ unsubscribeBleCharacteristic
   -> IO ()
 unsubscribeBleCharacteristic bleState serviceUuid characteristicUuid callback =
   startBleGattOperation bleState
-    (PendingBleUnsubscribe (normalizedBleUuidPair serviceUuid characteristicUuid) callback)
+    (PendingBleUnsubscribe (bleCharacteristicKey serviceUuid characteristicUuid) callback)
     (callback . Left)
     (do ctx <- readIORef (blesContextPtr bleState)
         withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
@@ -518,19 +561,19 @@ unsubscribeBleCharacteristic bleState serviceUuid characteristicUuid callback =
 
 -- | Negotiate a larger ATT MTU.  Android asks the peripheral for the
 -- given value; iOS ignores it and reports the system-negotiated
--- maximum.  The callback receives the granted MTU; write payloads
--- should stay within @granted - 3@ bytes.
+-- maximum.  The callback receives the granted MTU (see 'BleMtu' for
+-- the usable write size).
 requestBleMtu
   :: BleState
-  -> Int
-  -> (Either BleGattError Int -> IO ())
+  -> BleMtu
+  -> (Either BleGattError BleMtu -> IO ())
   -> IO ()
 requestBleMtu bleState mtu callback =
   startBleGattOperation bleState
     (PendingBleMtu callback)
     (callback . Left)
     (do ctx <- readIORef (blesContextPtr bleState)
-        cMtu <- case Int.toCInt mtu of
+        cMtu <- case Int.toCInt (unBleMtu mtu) of
           Just converted -> pure converted
           Nothing -> error $ "requestBleMtu: MTU " ++ show mtu ++ " exceeds CInt"
         c_bleRequestMtu ctx cMtu)
@@ -680,10 +723,10 @@ completePendingBleGattOperation bleState pendingOperation completion =
 -- characteristic without a registered callback indicates a platform
 -- bug (or a notification racing an unsubscribe) and is logged loudly.
 dispatchBleNotification
-  :: BleState -> BleServiceUuid -> BleCharacteristicUuid -> ByteString -> IO ()
+  :: BleState -> BleServiceUuid -> BleCharacteristicUuid -> BleCharacteristicValue -> IO ()
 dispatchBleNotification bleState serviceUuid characteristicUuid payload = do
   callbacks <- readIORef (blesNotificationCallbacks bleState)
-  case Map.lookup (normalizedBleUuidPair serviceUuid characteristicUuid) callbacks of
+  case Map.lookup (bleCharacteristicKey serviceUuid characteristicUuid) callbacks of
     Nothing -> hPutStrLn stderr $
       "dispatchBleNotification: notification for "
       ++ show (serviceUuid, characteristicUuid)

--- a/src/Hatter/Ble.hs
+++ b/src/Hatter/Ble.hs
@@ -122,6 +122,14 @@ newtype BleCharacteristicUuid = BleCharacteristicUuid { unBleCharacteristicUuid 
 -- 'normalizeBleServiceUuid' \/ 'normalizeBleCharacteristicUuid';
 -- deliberately no 'IsString' instance, a literal would bypass the
 -- normalization.
+--
+-- Decision: case-insensitivity is a dedicated normalized newtype
+-- built only through smart constructors.  Alternatives considered:
+-- lowercasing ad hoc at each comparison site (error-prone, exactly
+-- how the original subscribe\/notify mismatch bug happened), and a
+-- case-insensitive 'Ord' on the raw UUID newtypes (invisible at use
+-- sites and surprising for anyone sorting or printing them).  A type
+-- that cannot exist un-normalized makes the mistake unrepresentable.
 newtype NormalizedBleUuid = NormalizedBleUuid { unNormalizedBleUuid :: Text }
   deriving (Show, Eq, Ord)
 

--- a/src/Hatter/Ble.hs
+++ b/src/Hatter/Ble.hs
@@ -3,44 +3,80 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- | BLE (Bluetooth Low Energy) API for mobile platforms.
 --
--- Provides adapter status check, start\/stop scan, and GATT
--- connection management.  Scan results and connection events are
--- delivered via streaming callbacks (multiple invocations per
--- registration), unlike the permission bridge which uses one
--- callback per request.
+-- Provides adapter status check, start\/stop scan (optionally filtered
+-- by service UUID), GATT connection management, and GATT operations:
+-- service discovery, characteristic read\/write, notification
+-- subscriptions and MTU negotiation.  Scan results, connection events
+-- and notifications are delivered via streaming callbacks (multiple
+-- invocations per registration); GATT operations complete exactly once
+-- per request.
+--
+-- Exactly one GATT operation may be outstanding at a time (matching
+-- the platform stacks); starting a second one fails it immediately
+-- with 'BleGattBusy'.
 --
 -- On desktop (no platform bridge registered) the C stub reports
 -- the adapter as on, start\/stop scan are no-ops, and connection
--- attempts immediately deliver 'BleConnectionFailed', so @cabal test@
--- works without native code.
+-- attempts and GATT operations immediately deliver visible failures,
+-- so @cabal test@ works without native code.
 module Hatter.Ble
   ( BleAdapterStatus(..)
   , BleScanResult(..)
   , BleDeviceAddress(..)
+  , BleServiceUuid(..)
+  , BleCharacteristicUuid(..)
   , BleConnectionEvent(..)
+  , BleCharacteristicProperty(..)
+  , BleDiscoveredCharacteristic(..)
+  , BleWriteMode(..)
+  , BleGattOperation(..)
+  , BleGattError(..)
+  , BleGattCompletion(..)
+  , PendingBleGattOperation(..)
   , BleState(..)
   , newBleState
   , bleAdapterStatusFromInt
   , bleAdapterStatusToInt
   , bleConnectionEventFromInt
   , bleConnectionEventToInt
+  , bleGattOperationFromInt
+  , bleGattOperationToInt
+  , bleCharacteristicPropertiesFromBits
+  , bleCharacteristicPropertiesToBits
   , checkBleAdapter
   , startBleScan
+  , startFilteredBleScan
   , stopBleScan
   , connectBleDevice
   , disconnectBleDevice
+  , discoverBleServices
+  , readBleCharacteristic
+  , writeBleCharacteristic
+  , subscribeBleCharacteristic
+  , unsubscribeBleCharacteristic
+  , requestBleMtu
   , dispatchBleScanResult
   , dispatchBleConnectionEvent
+  , dispatchBleCharacteristicDiscovered
+  , dispatchBleGattCompletion
+  , dispatchBleNotification
   )
 where
 
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Text (Text, pack, unpack)
+import Data.Bits ((.&.))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text, pack, toLower, unpack)
 import Foreign.C.String (CString, peekCString, withCString)
 import Foreign.C.Types (CInt(..))
+import Foreign.Marshal.Utils (maybeWith)
 import Foreign.Ptr (Ptr, nullPtr)
 import System.IO (hPutStrLn, stderr)
 import Unwitch.Convert.CInt qualified as CInt
+import Unwitch.Convert.Int qualified as Int
 
 -- | Status of the platform's BLE adapter.
 data BleAdapterStatus
@@ -54,6 +90,16 @@ data BleAdapterStatus
 -- on Android, a peripheral identifier UUID on iOS.  Opaque to
 -- applications; pass it back verbatim to 'connectBleDevice'.
 newtype BleDeviceAddress = BleDeviceAddress { unBleDeviceAddress :: Text }
+  deriving (Show, Eq, Ord)
+
+-- | A 128-bit GATT service UUID string, e.g.
+-- @"50DB505C-8AC4-4738-8448-3B1D9CC09CC5"@.  Case-insensitive on both
+-- platforms.
+newtype BleServiceUuid = BleServiceUuid { unBleServiceUuid :: Text }
+  deriving (Show, Eq, Ord)
+
+-- | A 128-bit GATT characteristic UUID string.
+newtype BleCharacteristicUuid = BleCharacteristicUuid { unBleCharacteristicUuid :: Text }
   deriving (Show, Eq, Ord)
 
 -- | A single BLE scan result delivered by the platform.
@@ -76,9 +122,87 @@ data BleConnectionEvent
     -- was lost with an error.
   deriving (Show, Eq, Ord, Enum, Bounded)
 
+-- | What a characteristic supports, as reported by discovery.
+data BleCharacteristicProperty
+  = BleCharacteristicRead
+  | BleCharacteristicWrite
+  | BleCharacteristicWriteNoResponse
+  | BleCharacteristicNotify
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+-- | One characteristic found by 'discoverBleServices'.
+data BleDiscoveredCharacteristic = BleDiscoveredCharacteristic
+  { bdcService        :: BleServiceUuid
+  , bdcCharacteristic :: BleCharacteristicUuid
+  , bdcProperties     :: [BleCharacteristicProperty]
+  } deriving (Show, Eq)
+
+-- | How to write a characteristic: acknowledged by the peripheral or
+-- fire-and-forget.
+data BleWriteMode
+  = BleWriteWithResponse
+  | BleWriteWithoutResponse
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+-- | The GATT operations that complete asynchronously.  Mirrors the
+-- @BLE_GATT_OP_*@ constants in @BleBridge.h@.
+data BleGattOperation
+  = BleGattDiscover
+  | BleGattRead
+  | BleGattWrite
+  | BleGattSubscribe
+  | BleGattUnsubscribe
+  | BleGattRequestMtu
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+-- | Why a GATT operation failed.
+data BleGattError
+  = BleGattBusy
+    -- ^ Another GATT operation is still outstanding; retry after its
+    -- callback fires.
+  | BleGattFailed Int
+    -- ^ The platform reported a nonzero status code.  @-1@ means no
+    -- platform implementation is registered (desktop, or an outdated
+    -- consumer Activity); @-2@ means the platform completed a
+    -- different operation than the one pending (a platform bug);
+    -- other values are passed through from Android
+    -- (@BluetoothGatt@ status) or iOS (@NSError@ code, with
+    -- @0x101@ for failures before CoreBluetooth was reached).
+  deriving (Show, Eq)
+
+-- | A decoded GATT completion from the platform, built at the FFI
+-- boundary ('Hatter.haskellOnBleGattResult').
+data BleGattCompletion = BleGattCompletion
+  { bgcOperation  :: BleGattOperation
+  , bgcStatusCode :: Int
+    -- ^ 0 = success.
+  , bgcPayload    :: ByteString
+    -- ^ Read data for 'BleGattRead'; empty otherwise.
+  , bgcGrantedMtu :: Int
+    -- ^ Granted MTU for 'BleGattRequestMtu'; 0 otherwise.
+  } deriving (Show, Eq)
+
+-- | The one GATT operation currently in flight, with its
+-- result callback.  'BleGattError' code @-2@ is delivered if the
+-- platform completes a different operation (see
+-- 'dispatchBleGattCompletion').
+data PendingBleGattOperation
+  = PendingBleDiscover (IORef [BleDiscoveredCharacteristic])
+      (Either BleGattError [BleDiscoveredCharacteristic] -> IO ())
+  | PendingBleRead (Either BleGattError ByteString -> IO ())
+  | PendingBleWrite (Either BleGattError () -> IO ())
+  | PendingBleSubscribe (Text, Text)
+      (Either BleGattError () -> IO ())
+    -- ^ Key: 'normalizedBleUuidPair' of the subscribed characteristic.
+  | PendingBleUnsubscribe (Text, Text)
+      (Either BleGattError () -> IO ())
+    -- ^ Key: 'normalizedBleUuidPair' of the unsubscribed characteristic.
+  | PendingBleMtu (Either BleGattError Int -> IO ())
+
 -- | Mutable state for the BLE subsystem.
 -- Uses 'IORef (Maybe callback)' instead of 'IntMap' because only
--- one scan and one connection can be active at a time.
+-- one scan, one connection and one GATT operation can be active at
+-- a time.
 data BleState = BleState
   { blesScanCallback :: IORef (Maybe (BleScanResult -> IO ()))
     -- ^ Active scan result callback, or 'Nothing' if not scanning.
@@ -88,23 +212,36 @@ data BleState = BleState
     -- that late events (e.g. the 'BleConnectionClosed' following a
     -- 'disconnectBleDevice') still reach the app; a new
     -- 'connectBleDevice' call overwrites it.
+  , blesGattPending :: IORef (Maybe PendingBleGattOperation)
+    -- ^ The GATT operation currently in flight, if any.
+  , blesNotificationCallbacks :: IORef (Map (Text, Text) (ByteString -> IO ()))
+    -- ^ Per-characteristic notification callbacks, registered by
+    -- 'subscribeBleCharacteristic' and keyed by
+    -- 'normalizedBleUuidPair': Android reports UUIDs lowercase and
+    -- iOS uppercase, so the raw newtypes would never match across
+    -- the subscribe/notify round trip.
   , blesContextPtr   :: IORef (Ptr ())
     -- ^ Opaque context pointer passed to the C bridge.
     -- Set by 'AppContext.newAppContext' after the 'StablePtr' is created.
   }
 
--- | Create a fresh 'BleState' with no active scan or connection.
--- The context pointer is initially null and must be set via
--- 'blesContextPtr' before calling 'startBleScan' or 'connectBleDevice'.
+-- | Create a fresh 'BleState' with no active scan, connection or
+-- GATT operation.  The context pointer is initially null and must be
+-- set via 'blesContextPtr' before calling anything that talks to the
+-- platform.
 newBleState :: IO BleState
 newBleState = do
-  scanCallback       <- newIORef Nothing
-  connectionCallback <- newIORef Nothing
-  contextPtr         <- newIORef nullPtr
+  scanCallback          <- newIORef Nothing
+  connectionCallback    <- newIORef Nothing
+  gattPending           <- newIORef Nothing
+  notificationCallbacks <- newIORef Map.empty
+  contextPtr            <- newIORef nullPtr
   pure BleState
-    { blesScanCallback       = scanCallback
-    , blesConnectionCallback = connectionCallback
-    , blesContextPtr         = contextPtr
+    { blesScanCallback          = scanCallback
+    , blesConnectionCallback    = connectionCallback
+    , blesGattPending           = gattPending
+    , blesNotificationCallbacks = notificationCallbacks
+    , blesContextPtr            = contextPtr
     }
 
 -- | Convert a C bridge adapter status code to 'BleAdapterStatus'.
@@ -139,6 +276,59 @@ bleConnectionEventToInt BleConnectionEstablished = 0
 bleConnectionEventToInt BleConnectionClosed      = 1
 bleConnectionEventToInt BleConnectionFailed      = 2
 
+-- | Convert a C bridge GATT operation code to 'BleGattOperation'.
+-- Returns 'Nothing' for unknown codes.
+bleGattOperationFromInt :: CInt -> Maybe BleGattOperation
+bleGattOperationFromInt 0 = Just BleGattDiscover
+bleGattOperationFromInt 1 = Just BleGattRead
+bleGattOperationFromInt 2 = Just BleGattWrite
+bleGattOperationFromInt 3 = Just BleGattSubscribe
+bleGattOperationFromInt 4 = Just BleGattUnsubscribe
+bleGattOperationFromInt 5 = Just BleGattRequestMtu
+bleGattOperationFromInt _ = Nothing
+
+-- | Convert a 'BleGattOperation' to its C bridge integer code.
+-- Must match the @BLE_GATT_OP_*@ constants in @BleBridge.h@.
+bleGattOperationToInt :: BleGattOperation -> CInt
+bleGattOperationToInt BleGattDiscover    = 0
+bleGattOperationToInt BleGattRead        = 1
+bleGattOperationToInt BleGattWrite       = 2
+bleGattOperationToInt BleGattSubscribe   = 3
+bleGattOperationToInt BleGattUnsubscribe = 4
+bleGattOperationToInt BleGattRequestMtu  = 5
+
+-- | The case-normalized key identifying a characteristic in
+-- 'blesNotificationCallbacks'.  UUID strings are case-insensitive per
+-- the Bluetooth spec, but the platforms disagree on the case they
+-- report (Android lowercase, iOS uppercase).
+normalizedBleUuidPair :: BleServiceUuid -> BleCharacteristicUuid -> (Text, Text)
+normalizedBleUuidPair serviceUuid characteristicUuid =
+  ( toLower (unBleServiceUuid serviceUuid)
+  , toLower (unBleCharacteristicUuid characteristicUuid)
+  )
+
+-- | The @BLE_CHAR_PROP_*@ bit for one property (see @BleBridge.h@).
+bleCharacteristicPropertyBit :: BleCharacteristicProperty -> CInt
+bleCharacteristicPropertyBit BleCharacteristicRead            = 1
+bleCharacteristicPropertyBit BleCharacteristicWrite           = 2
+bleCharacteristicPropertyBit BleCharacteristicWriteNoResponse = 4
+bleCharacteristicPropertyBit BleCharacteristicNotify          = 8
+
+-- | Whether a property's bit is set in a @BLE_CHAR_PROP_*@ mask.
+bleCharacteristicPropertyPresent :: CInt -> BleCharacteristicProperty -> Bool
+bleCharacteristicPropertyPresent bits property =
+  bits .&. bleCharacteristicPropertyBit property /= 0
+
+-- | Decode the @BLE_CHAR_PROP_*@ bit mask from @BleBridge.h@.
+bleCharacteristicPropertiesFromBits :: CInt -> [BleCharacteristicProperty]
+bleCharacteristicPropertiesFromBits bits =
+  filter (bleCharacteristicPropertyPresent bits) [minBound .. maxBound]
+
+-- | Encode 'BleCharacteristicProperty's back into the
+-- @BLE_CHAR_PROP_*@ bit mask (used by tests to check the roundtrip).
+bleCharacteristicPropertiesToBits :: [BleCharacteristicProperty] -> CInt
+bleCharacteristicPropertiesToBits = sum . map bleCharacteristicPropertyBit
+
 -- | Check the BLE adapter status (synchronous).
 checkBleAdapter :: IO BleAdapterStatus
 checkBleAdapter = do
@@ -149,18 +339,30 @@ checkBleAdapter = do
       hPutStrLn stderr $ "checkBleAdapter: unknown status code " ++ show result
       pure BleAdapterUnsupported
 
--- | Start a BLE scan. Stops any existing scan first, then registers
--- the callback and calls the C bridge. The callback will be invoked
--- for each discovered device until 'stopBleScan' is called.
+-- | Start an unfiltered BLE scan. Stops any existing scan first, then
+-- registers the callback and calls the C bridge. The callback will be
+-- invoked for each discovered device until 'stopBleScan' is called.
 startBleScan :: BleState -> (BleScanResult -> IO ()) -> IO ()
-startBleScan bleState callback = do
+startBleScan bleState callback =
+  startBleScanInternal bleState Nothing callback
+
+-- | Start a BLE scan that only reports devices advertising the given
+-- service UUID.  Otherwise identical to 'startBleScan'.
+startFilteredBleScan :: BleState -> BleServiceUuid -> (BleScanResult -> IO ()) -> IO ()
+startFilteredBleScan bleState serviceUuid callback =
+  startBleScanInternal bleState (Just serviceUuid) callback
+
+-- | Shared implementation of the scan starters.
+startBleScanInternal :: BleState -> Maybe BleServiceUuid -> (BleScanResult -> IO ()) -> IO ()
+startBleScanInternal bleState maybeServiceUuid callback = do
   -- Stop any existing scan first
   c_bleStopScan
   -- Register the new callback
   writeIORef (blesScanCallback bleState) (Just callback)
   -- Start scanning via C bridge
   ctx <- readIORef (blesContextPtr bleState)
-  c_bleStartScan ctx
+  maybeWith (withCString . unpack . unBleServiceUuid) maybeServiceUuid
+    (c_bleStartScan ctx)
 
 -- | Stop a running BLE scan. Clears the callback so that any
 -- late-arriving results are silently dropped.
@@ -188,6 +390,150 @@ connectBleDevice bleState address callback = do
 -- event is still delivered.  A no-op when nothing is connected.
 disconnectBleDevice :: BleState -> IO ()
 disconnectBleDevice _bleState = c_bleDisconnect
+
+-- | Register a GATT operation as pending, or fail it immediately with
+-- 'BleGattBusy' when one is already in flight.  Runs the given action
+-- (the C bridge call) only after successful registration.
+startBleGattOperation
+  :: BleState
+  -> PendingBleGattOperation
+  -> (BleGattError -> IO ())  -- ^ How to fail this operation's callback.
+  -> IO ()                    -- ^ The C bridge call.
+  -> IO ()
+startBleGattOperation bleState pending failWith bridgeCall = do
+  alreadyPending <- readIORef (blesGattPending bleState)
+  case alreadyPending of
+    Just _  -> failWith BleGattBusy
+    Nothing -> do
+      writeIORef (blesGattPending bleState) (Just pending)
+      bridgeCall
+
+-- | Discover all services and characteristics on the connected
+-- device.  The callback receives every characteristic (with its
+-- containing service and properties) or the failure.
+discoverBleServices
+  :: BleState
+  -> (Either BleGattError [BleDiscoveredCharacteristic] -> IO ())
+  -> IO ()
+discoverBleServices bleState callback = do
+  accumulator <- newIORef []
+  startBleGattOperation bleState
+    (PendingBleDiscover accumulator callback)
+    (callback . Left)
+    (do ctx <- readIORef (blesContextPtr bleState)
+        c_bleDiscoverServices ctx)
+
+-- | Read a characteristic's value.
+readBleCharacteristic
+  :: BleState
+  -> BleServiceUuid
+  -> BleCharacteristicUuid
+  -> (Either BleGattError ByteString -> IO ())
+  -> IO ()
+readBleCharacteristic bleState serviceUuid characteristicUuid callback =
+  startBleGattOperation bleState
+    (PendingBleRead callback)
+    (callback . Left)
+    (do ctx <- readIORef (blesContextPtr bleState)
+        withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
+          withCString (unpack (unBleCharacteristicUuid characteristicUuid)) $ \cCharacteristic ->
+            c_bleReadCharacteristic ctx cService cCharacteristic)
+
+-- | Write a characteristic's value.  'BleWriteWithoutResponse'
+-- completes as soon as the platform queued the write;
+-- 'BleWriteWithResponse' completes when the peripheral acknowledged
+-- it.
+writeBleCharacteristic
+  :: BleState
+  -> BleServiceUuid
+  -> BleCharacteristicUuid
+  -> BleWriteMode
+  -> ByteString
+  -> (Either BleGattError () -> IO ())
+  -> IO ()
+writeBleCharacteristic bleState serviceUuid characteristicUuid writeMode payload callback =
+  startBleGattOperation bleState
+    (PendingBleWrite callback)
+    (callback . Left)
+    (do ctx <- readIORef (blesContextPtr bleState)
+        withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
+          withCString (unpack (unBleCharacteristicUuid characteristicUuid)) $ \cCharacteristic ->
+            BS.useAsCStringLen payload $ \(cPayload, payloadLength) -> do
+              cLength <- case Int.toCInt payloadLength of
+                Just converted -> pure converted
+                Nothing -> error $
+                  "writeBleCharacteristic: payload of "
+                  ++ show payloadLength ++ " bytes exceeds CInt"
+              c_bleWriteCharacteristic ctx cService cCharacteristic
+                cPayload
+                cLength
+                (case writeMode of
+                   BleWriteWithResponse    -> 1
+                   BleWriteWithoutResponse -> 0))
+
+-- | Subscribe to a characteristic's notifications.  @onNotification@
+-- is invoked for every notification until
+-- 'unsubscribeBleCharacteristic'; @onSubscribed@ fires once with the
+-- subscription outcome.
+subscribeBleCharacteristic
+  :: BleState
+  -> BleServiceUuid
+  -> BleCharacteristicUuid
+  -> (ByteString -> IO ())              -- ^ onNotification
+  -> (Either BleGattError () -> IO ())  -- ^ onSubscribed
+  -> IO ()
+subscribeBleCharacteristic bleState serviceUuid characteristicUuid onNotification onSubscribed = do
+  -- Register the notification callback before asking the platform to
+  -- enable notifications, so no early notification can be missed.  A
+  -- failed subscription removes it again in 'dispatchBleGattCompletion'.
+  modifyIORef' (blesNotificationCallbacks bleState)
+    (Map.insert (normalizedBleUuidPair serviceUuid characteristicUuid) onNotification)
+  startBleGattOperation bleState
+    (PendingBleSubscribe (normalizedBleUuidPair serviceUuid characteristicUuid) onSubscribed)
+    (\gattError -> do
+        modifyIORef' (blesNotificationCallbacks bleState)
+          (Map.delete (normalizedBleUuidPair serviceUuid characteristicUuid))
+        onSubscribed (Left gattError))
+    (do ctx <- readIORef (blesContextPtr bleState)
+        withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
+          withCString (unpack (unBleCharacteristicUuid characteristicUuid)) $ \cCharacteristic ->
+            c_bleSetCharacteristicNotification ctx cService cCharacteristic 1)
+
+-- | Stop receiving notifications for a characteristic.  The
+-- notification callback is removed once the platform confirms.
+unsubscribeBleCharacteristic
+  :: BleState
+  -> BleServiceUuid
+  -> BleCharacteristicUuid
+  -> (Either BleGattError () -> IO ())
+  -> IO ()
+unsubscribeBleCharacteristic bleState serviceUuid characteristicUuid callback =
+  startBleGattOperation bleState
+    (PendingBleUnsubscribe (normalizedBleUuidPair serviceUuid characteristicUuid) callback)
+    (callback . Left)
+    (do ctx <- readIORef (blesContextPtr bleState)
+        withCString (unpack (unBleServiceUuid serviceUuid)) $ \cService ->
+          withCString (unpack (unBleCharacteristicUuid characteristicUuid)) $ \cCharacteristic ->
+            c_bleSetCharacteristicNotification ctx cService cCharacteristic 0)
+
+-- | Negotiate a larger ATT MTU.  Android asks the peripheral for the
+-- given value; iOS ignores it and reports the system-negotiated
+-- maximum.  The callback receives the granted MTU; write payloads
+-- should stay within @granted - 3@ bytes.
+requestBleMtu
+  :: BleState
+  -> Int
+  -> (Either BleGattError Int -> IO ())
+  -> IO ()
+requestBleMtu bleState mtu callback =
+  startBleGattOperation bleState
+    (PendingBleMtu callback)
+    (callback . Left)
+    (do ctx <- readIORef (blesContextPtr bleState)
+        cMtu <- case Int.toCInt mtu of
+          Just converted -> pure converted
+          Nothing -> error $ "requestBleMtu: MTU " ++ show mtu ++ " exceeds CInt"
+        c_bleRequestMtu ctx cMtu)
 
 -- | Dispatch a BLE scan result from the platform back to the
 -- registered Haskell callback. Called from the FFI entry point.
@@ -229,13 +575,129 @@ dispatchBleConnectionEvent bleState event = do
       ++ " without an active connection callback"
     Just callback -> callback event
 
+-- | Record one characteristic streamed by the platform during a
+-- pending 'discoverBleServices' run.  Without a pending discovery the
+-- report indicates a platform bug and is logged loudly.
+dispatchBleCharacteristicDiscovered :: BleState -> BleDiscoveredCharacteristic -> IO ()
+dispatchBleCharacteristicDiscovered bleState discovered = do
+  pending <- readIORef (blesGattPending bleState)
+  case pending of
+    Just (PendingBleDiscover accumulator _) ->
+      modifyIORef' accumulator (discovered :)
+    Just _ -> hPutStrLn stderr $
+      "dispatchBleCharacteristicDiscovered: received " ++ show discovered
+      ++ " while a non-discovery operation is pending"
+    Nothing -> hPutStrLn stderr $
+      "dispatchBleCharacteristicDiscovered: received " ++ show discovered
+      ++ " without a pending discovery"
+
+-- | Fail whichever operation is pending with the given error.
+failPendingBleGattOperation :: PendingBleGattOperation -> BleGattError -> IO ()
+failPendingBleGattOperation pending gattError =
+  case pending of
+    PendingBleDiscover _ callback    -> callback (Left gattError)
+    PendingBleRead callback          -> callback (Left gattError)
+    PendingBleWrite callback         -> callback (Left gattError)
+    PendingBleSubscribe _ callback   -> callback (Left gattError)
+    PendingBleUnsubscribe _ callback -> callback (Left gattError)
+    PendingBleMtu callback           -> callback (Left gattError)
+
+-- | Complete the pending GATT operation with a platform result.
+-- Called from the FFI entry point.  The pending operation is cleared
+-- before its callback runs, so the callback may start the next
+-- operation immediately.  A completion without a pending operation,
+-- or for a different operation than the pending one, indicates a
+-- platform bug: it is logged loudly and the pending operation (if
+-- any) fails with code @-2@ so its caller is not left waiting.
+dispatchBleGattCompletion :: BleState -> BleGattCompletion -> IO ()
+dispatchBleGattCompletion bleState completion = do
+  pending <- readIORef (blesGattPending bleState)
+  writeIORef (blesGattPending bleState) Nothing
+  case pending of
+    Nothing -> hPutStrLn stderr $
+      "dispatchBleGattCompletion: received " ++ show completion
+      ++ " without a pending operation"
+    Just pendingOperation ->
+      if pendingBleGattOperationKind pendingOperation /= bgcOperation completion
+        then do
+          hPutStrLn stderr $
+            "dispatchBleGattCompletion: received " ++ show (bgcOperation completion)
+            ++ " while " ++ show (pendingBleGattOperationKind pendingOperation)
+            ++ " was pending"
+          failPendingBleGattOperation pendingOperation (BleGattFailed (-2))
+        else completePendingBleGattOperation bleState pendingOperation completion
+
+-- | Which 'BleGattOperation' a pending operation belongs to.
+pendingBleGattOperationKind :: PendingBleGattOperation -> BleGattOperation
+pendingBleGattOperationKind (PendingBleDiscover _ _)    = BleGattDiscover
+pendingBleGattOperationKind (PendingBleRead _)          = BleGattRead
+pendingBleGattOperationKind (PendingBleWrite _)         = BleGattWrite
+pendingBleGattOperationKind (PendingBleSubscribe _ _)   = BleGattSubscribe
+pendingBleGattOperationKind (PendingBleUnsubscribe _ _) = BleGattUnsubscribe
+pendingBleGattOperationKind (PendingBleMtu _)           = BleGattRequestMtu
+
+-- | Deliver a matching completion to the pending operation's callback.
+completePendingBleGattOperation
+  :: BleState -> PendingBleGattOperation -> BleGattCompletion -> IO ()
+completePendingBleGattOperation bleState pendingOperation completion =
+  case pendingOperation of
+    PendingBleDiscover accumulator callback ->
+      if bgcStatusCode completion == 0
+        then do
+          discovered <- readIORef accumulator
+          callback (Right (reverse discovered))
+        else callback (Left (BleGattFailed (bgcStatusCode completion)))
+    PendingBleRead callback ->
+      if bgcStatusCode completion == 0
+        then callback (Right (bgcPayload completion))
+        else callback (Left (BleGattFailed (bgcStatusCode completion)))
+    PendingBleWrite callback ->
+      if bgcStatusCode completion == 0
+        then callback (Right ())
+        else callback (Left (BleGattFailed (bgcStatusCode completion)))
+    PendingBleSubscribe key callback ->
+      if bgcStatusCode completion == 0
+        then callback (Right ())
+        else do
+          -- The platform never enabled notifications; drop the
+          -- callback registered optimistically by
+          -- 'subscribeBleCharacteristic'.
+          modifyIORef' (blesNotificationCallbacks bleState) (Map.delete key)
+          callback (Left (BleGattFailed (bgcStatusCode completion)))
+    PendingBleUnsubscribe key callback ->
+      if bgcStatusCode completion == 0
+        then do
+          modifyIORef' (blesNotificationCallbacks bleState) (Map.delete key)
+          callback (Right ())
+        else callback (Left (BleGattFailed (bgcStatusCode completion)))
+    PendingBleMtu callback ->
+      if bgcStatusCode completion == 0
+        then callback (Right (bgcGrantedMtu completion))
+        else callback (Left (BleGattFailed (bgcStatusCode completion)))
+
+-- | Dispatch notification data from the platform to the callback
+-- registered by 'subscribeBleCharacteristic'.  Data for a
+-- characteristic without a registered callback indicates a platform
+-- bug (or a notification racing an unsubscribe) and is logged loudly.
+dispatchBleNotification
+  :: BleState -> BleServiceUuid -> BleCharacteristicUuid -> ByteString -> IO ()
+dispatchBleNotification bleState serviceUuid characteristicUuid payload = do
+  callbacks <- readIORef (blesNotificationCallbacks bleState)
+  case Map.lookup (normalizedBleUuidPair serviceUuid characteristicUuid) callbacks of
+    Nothing -> hPutStrLn stderr $
+      "dispatchBleNotification: notification for "
+      ++ show (serviceUuid, characteristicUuid)
+      ++ " without a registered callback"
+    Just callback -> callback payload
+
 -- | FFI import: check BLE adapter status via the C bridge.
 foreign import ccall "ble_check_adapter"
   c_bleCheckAdapter :: IO CInt
 
--- | FFI import: start BLE scan via the C bridge.
+-- | FFI import: start BLE scan via the C bridge.  The second argument
+-- is a service UUID filter, or null for an unfiltered scan.
 foreign import ccall "ble_start_scan"
-  c_bleStartScan :: Ptr () -> IO ()
+  c_bleStartScan :: Ptr () -> CString -> IO ()
 
 -- | FFI import: stop BLE scan via the C bridge.
 foreign import ccall "ble_stop_scan"
@@ -248,3 +710,25 @@ foreign import ccall "ble_connect"
 -- | FFI import: disconnect the active BLE connection via the C bridge.
 foreign import ccall "ble_disconnect"
   c_bleDisconnect :: IO ()
+
+-- | FFI import: discover services via the C bridge.
+foreign import ccall "ble_discover_services"
+  c_bleDiscoverServices :: Ptr () -> IO ()
+
+-- | FFI import: read a characteristic via the C bridge.
+foreign import ccall "ble_read_characteristic"
+  c_bleReadCharacteristic :: Ptr () -> CString -> CString -> IO ()
+
+-- | FFI import: write a characteristic via the C bridge.  The payload
+-- travels as a CString + explicit length pair (same convention as the
+-- HTTP bridge's request body).
+foreign import ccall "ble_write_characteristic"
+  c_bleWriteCharacteristic :: Ptr () -> CString -> CString -> CString -> CInt -> CInt -> IO ()
+
+-- | FFI import: enable/disable characteristic notifications via the C bridge.
+foreign import ccall "ble_set_characteristic_notification"
+  c_bleSetCharacteristicNotification :: Ptr () -> CString -> CString -> CInt -> IO ()
+
+-- | FFI import: request an ATT MTU via the C bridge.
+foreign import ccall "ble_request_mtu"
+  c_bleRequestMtu :: Ptr () -> CInt -> IO ()

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -42,6 +42,8 @@ import Hatter.Ble
   , BleDeviceAddress(..)
   , BleServiceUuid(..)
   , BleCharacteristicUuid(..)
+  , BleCharacteristicValue(..)
+  , BleMtu(..)
   , BleDiscoveredCharacteristic(..)
   , BleGattError
   , BleWriteMode(..)
@@ -61,19 +63,19 @@ import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
 
 -- | Service served by the virtual test peripheral.
 demoServiceUuid :: BleServiceUuid
-demoServiceUuid = BleServiceUuid "50DB505C-8AC4-4738-8448-3B1D9CC09CC5"
+demoServiceUuid = "50DB505C-8AC4-4738-8448-3B1D9CC09CC5"
 
 -- | Readable characteristic on the test peripheral (value "hatter").
 demoReadCharacteristicUuid :: BleCharacteristicUuid
-demoReadCharacteristicUuid = BleCharacteristicUuid "486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5"
+demoReadCharacteristicUuid = "486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5"
 
 -- | Write+notify characteristic on the test peripheral: written bytes
 -- are echoed back as a notification.
 demoEchoCharacteristicUuid :: BleCharacteristicUuid
-demoEchoCharacteristicUuid = BleCharacteristicUuid "8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB"
+demoEchoCharacteristicUuid = "8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB"
 
 -- | Payload the Write button sends (echoed back by the peripheral).
-demoWritePayload :: BS.ByteString
+demoWritePayload :: BleCharacteristicValue
 demoWritePayload = "hatter!"
 
 main :: IO (Ptr AppContext)
@@ -118,7 +120,8 @@ main = do
         case result of
           Left gattError -> platformLog ("BLE read failed: " <> pack (show gattError))
           Right payload  -> platformLog
-            ("BLE read result: " <> pack (show (BS.unpack payload)))
+            ("BLE read result: "
+             <> pack (show (BS.unpack (unBleCharacteristicValue payload))))
     writeCharacteristic <- createAction $ do
       Just bleState <- readIORef bleStateRef
       writeBleCharacteristic bleState demoServiceUuid demoEchoCharacteristicUuid
@@ -130,16 +133,17 @@ main = do
       Just bleState <- readIORef bleStateRef
       subscribeBleCharacteristic bleState demoServiceUuid demoEchoCharacteristicUuid
         (\payload -> platformLog
-          ("BLE notification: " <> pack (show (BS.unpack payload))))
+          ("BLE notification: "
+           <> pack (show (BS.unpack (unBleCharacteristicValue payload)))))
         (\result -> case result of
             Left gattError -> platformLog ("BLE subscribe failed: " <> pack (show gattError))
             Right ()       -> platformLog "BLE subscribed")
     mtu <- createAction $ do
       Just bleState <- readIORef bleStateRef
-      requestBleMtu bleState 247 $ \result ->
+      requestBleMtu bleState (BleMtu 247) $ \result ->
         case result of
           Left gattError -> platformLog ("BLE mtu failed: " <> pack (show gattError))
-          Right granted  -> platformLog ("BLE mtu granted: " <> pack (show granted))
+          Right granted  -> platformLog ("BLE mtu granted: " <> pack (show (unBleMtu granted)))
     filteredScan <- createAction $ do
       Just bleState <- readIORef bleStateRef
       startFilteredBleScan bleState demoServiceUuid $ \scanResult ->

--- a/test/BleDemoMain.hs
+++ b/test/BleDemoMain.hs
@@ -14,10 +14,16 @@
 -- the connect bridge path is exercised (and fails with
 -- 'BleConnectionFailed') even on platforms where scanning finds
 -- nothing, such as the iOS simulator.
+--
+-- The GATT buttons target the fixed UUIDs served by the virtual test
+-- peripheral (test/android/ble_peripheral.py); byte payloads are
+-- logged as decimal byte lists so the test scripts can assert them
+-- unambiguously.
 module Main where
 
+import Data.ByteString qualified as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Text (pack)
+import Data.Text (Text, pack)
 import Foreign.Ptr (Ptr)
 import Hatter
   ( MobileApp(..)
@@ -34,13 +40,41 @@ import Hatter.Ble
   ( BleState(..)
   , BleScanResult(..)
   , BleDeviceAddress(..)
+  , BleServiceUuid(..)
+  , BleCharacteristicUuid(..)
+  , BleDiscoveredCharacteristic(..)
+  , BleGattError
+  , BleWriteMode(..)
   , checkBleAdapter
   , startBleScan
+  , startFilteredBleScan
   , stopBleScan
   , connectBleDevice
   , disconnectBleDevice
+  , discoverBleServices
+  , readBleCharacteristic
+  , writeBleCharacteristic
+  , subscribeBleCharacteristic
+  , requestBleMtu
   )
 import Hatter.Widget (ButtonConfig(..), TextConfig(..), Widget(..), column)
+
+-- | Service served by the virtual test peripheral.
+demoServiceUuid :: BleServiceUuid
+demoServiceUuid = BleServiceUuid "50DB505C-8AC4-4738-8448-3B1D9CC09CC5"
+
+-- | Readable characteristic on the test peripheral (value "hatter").
+demoReadCharacteristicUuid :: BleCharacteristicUuid
+demoReadCharacteristicUuid = BleCharacteristicUuid "486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5"
+
+-- | Write+notify characteristic on the test peripheral: written bytes
+-- are echoed back as a notification.
+demoEchoCharacteristicUuid :: BleCharacteristicUuid
+demoEchoCharacteristicUuid = BleCharacteristicUuid "8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB"
+
+-- | Payload the Write button sends (echoed back by the peripheral).
+demoWritePayload :: BS.ByteString
+demoWritePayload = "hatter!"
 
 main :: IO (Ptr AppContext)
 main = do
@@ -48,34 +82,85 @@ main = do
   actionState <- newActionState
   bleStateRef <- newIORef (Nothing :: Maybe BleState)
   lastAddressRef <- newIORef (Nothing :: Maybe BleDeviceAddress)
-  (onCheckAdapter, onStartScan, onStopScan, onConnect, onDisconnect) <-
-    runActionM actionState $ do
-      check <- createAction $ do
-        adapterStatus <- checkBleAdapter
-        platformLog ("BLE adapter: " <> pack (show adapterStatus))
-      start <- createAction $ do
-        Just bleState <- readIORef bleStateRef
-        startBleScan bleState (logAndRememberScanResult lastAddressRef)
-        platformLog "BLE scan started"
-      stop <- createAction $ do
-        Just bleState <- readIORef bleStateRef
-        stopBleScan bleState
-        platformLog "BLE scan stopped"
-      connect <- createAction $ do
-        Just bleState <- readIORef bleStateRef
-        address <- connectTargetAddress lastAddressRef
-        platformLog ("BLE connecting to " <> unBleDeviceAddress address)
-        connectBleDevice bleState address $ \event ->
-          platformLog ("BLE connection event: " <> pack (show event))
-      disconnect <- createAction $ do
-        Just bleState <- readIORef bleStateRef
-        disconnectBleDevice bleState
-        platformLog "BLE disconnect requested"
-      pure (check, start, stop, connect, disconnect)
+  actions <- runActionM actionState $ do
+    -- Action creation order defines the iOS autotest event ids
+    -- (see ios/Hatter/ContentView.swift): 0 = Check Adapter,
+    -- 1 = Start Scan, 2 = Stop Scan, 3 = Connect, 4 = Disconnect,
+    -- 5 = Discover, 6 = Read, 7 = Write, 8 = Subscribe,
+    -- 9 = Request Mtu, 10 = Filtered Scan.
+    check <- createAction $ do
+      adapterStatus <- checkBleAdapter
+      platformLog ("BLE adapter: " <> pack (show adapterStatus))
+    start <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      startBleScan bleState (logAndRememberScanResult lastAddressRef)
+      platformLog "BLE scan started"
+    stop <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      stopBleScan bleState
+      platformLog "BLE scan stopped"
+    connect <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      address <- connectTargetAddress lastAddressRef
+      platformLog ("BLE connecting to " <> unBleDeviceAddress address)
+      connectBleDevice bleState address $ \event ->
+        platformLog ("BLE connection event: " <> pack (show event))
+    disconnect <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      disconnectBleDevice bleState
+      platformLog "BLE disconnect requested"
+    discover <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      discoverBleServices bleState logDiscoveryResult
+    readCharacteristic <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      readBleCharacteristic bleState demoServiceUuid demoReadCharacteristicUuid $ \result ->
+        case result of
+          Left gattError -> platformLog ("BLE read failed: " <> pack (show gattError))
+          Right payload  -> platformLog
+            ("BLE read result: " <> pack (show (BS.unpack payload)))
+    writeCharacteristic <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      writeBleCharacteristic bleState demoServiceUuid demoEchoCharacteristicUuid
+        BleWriteWithResponse demoWritePayload $ \result ->
+          case result of
+            Left gattError -> platformLog ("BLE write failed: " <> pack (show gattError))
+            Right ()       -> platformLog "BLE write completed"
+    subscribe <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      subscribeBleCharacteristic bleState demoServiceUuid demoEchoCharacteristicUuid
+        (\payload -> platformLog
+          ("BLE notification: " <> pack (show (BS.unpack payload))))
+        (\result -> case result of
+            Left gattError -> platformLog ("BLE subscribe failed: " <> pack (show gattError))
+            Right ()       -> platformLog "BLE subscribed")
+    mtu <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      requestBleMtu bleState 247 $ \result ->
+        case result of
+          Left gattError -> platformLog ("BLE mtu failed: " <> pack (show gattError))
+          Right granted  -> platformLog ("BLE mtu granted: " <> pack (show granted))
+    filteredScan <- createAction $ do
+      Just bleState <- readIORef bleStateRef
+      startFilteredBleScan bleState demoServiceUuid $ \scanResult ->
+        platformLog ("BLE filtered scan result: " <> pack (show scanResult))
+      platformLog "BLE filtered scan started"
+    pure
+      [ ("Check Adapter", check)
+      , ("Start Scan", start)
+      , ("Stop Scan", stop)
+      , ("Connect", connect)
+      , ("Disconnect", disconnect)
+      , ("Discover", discover)
+      , ("Read", readCharacteristic)
+      , ("Write", writeCharacteristic)
+      , ("Subscribe", subscribe)
+      , ("Request Mtu", mtu)
+      , ("Filtered Scan", filteredScan)
+      ]
   ctxPtr <- startMobileApp MobileApp
     { maContext     = loggingMobileContext
-    , maView        = \_userState ->
-        bleDemoView onCheckAdapter onStartScan onStopScan onConnect onDisconnect
+    , maView        = \_userState -> bleDemoView actions
     , maActionState = actionState
     }
   appCtx <- derefAppContext ctxPtr
@@ -101,19 +186,35 @@ connectTargetAddress lastAddressRef = do
       platformLog "BLE connect: no scan result yet, using placeholder address"
       pure (BleDeviceAddress "00:11:22:33:44:55")
 
--- | Builds a Column with a label, adapter check button, scan buttons,
--- and connection buttons.
-bleDemoView :: Action -> Action -> Action -> Action -> Action -> IO Widget
-bleDemoView onCheckAdapter onStartScan onStopScan onConnect onDisconnect = pure $ column
-  [ Text TextConfig { tcLabel = "BLE Demo", tcFontConfig = Nothing }
-  , Button ButtonConfig
-      { bcLabel = "Check Adapter", bcAction = onCheckAdapter, bcFontConfig = Nothing }
-  , Button ButtonConfig
-      { bcLabel = "Start Scan", bcAction = onStartScan, bcFontConfig = Nothing }
-  , Button ButtonConfig
-      { bcLabel = "Stop Scan", bcAction = onStopScan, bcFontConfig = Nothing }
-  , Button ButtonConfig
-      { bcLabel = "Connect", bcAction = onConnect, bcFontConfig = Nothing }
-  , Button ButtonConfig
-      { bcLabel = "Disconnect", bcAction = onDisconnect, bcFontConfig = Nothing }
-  ]
+-- | Log every discovered characteristic plus a completion line the
+-- integration test asserts on.
+logDiscoveryResult
+  :: Either BleGattError [BleDiscoveredCharacteristic] -> IO ()
+logDiscoveryResult result =
+  case result of
+    Left gattError -> platformLog ("BLE discovery failed: " <> pack (show gattError))
+    Right discovered -> do
+      mapM_ logDiscoveredCharacteristic discovered
+      platformLog
+        ("BLE discovery complete: "
+         <> pack (show (length discovered)) <> " characteristics")
+
+-- | One "BLE discovered:" line per characteristic.
+logDiscoveredCharacteristic :: BleDiscoveredCharacteristic -> IO ()
+logDiscoveredCharacteristic discovered = platformLog
+  ("BLE discovered: "
+   <> unBleServiceUuid (bdcService discovered)
+   <> " " <> unBleCharacteristicUuid (bdcCharacteristic discovered)
+   <> " " <> pack (show (bdcProperties discovered)))
+
+-- | Builds a Column with a label and one button per BLE action.
+bleDemoView :: [(Text, Action)] -> IO Widget
+bleDemoView actions = pure $ column
+  ( Text TextConfig { tcLabel = "BLE Demo", tcFontConfig = Nothing }
+  : map actionButton actions
+  )
+
+-- | A button for one labelled action.
+actionButton :: (Text, Action) -> Widget
+actionButton (label, action) = Button ButtonConfig
+  { bcLabel = label, bcAction = action, bcFontConfig = Nothing }

--- a/test/Test/PlatformTests.hs
+++ b/test/Test/PlatformTests.hs
@@ -53,20 +53,42 @@ import Hatter.Ble
   ( BleAdapterStatus(..)
   , BleScanResult(..)
   , BleDeviceAddress(..)
+  , BleServiceUuid(..)
+  , BleCharacteristicUuid(..)
   , BleConnectionEvent(..)
+  , BleCharacteristicProperty(..)
+  , BleDiscoveredCharacteristic(..)
+  , BleWriteMode(..)
+  , BleGattOperation(..)
+  , BleGattError(..)
+  , BleGattCompletion(..)
   , BleState(..)
   , newBleState
   , bleAdapterStatusFromInt
   , bleAdapterStatusToInt
   , bleConnectionEventFromInt
   , bleConnectionEventToInt
+  , bleGattOperationFromInt
+  , bleGattOperationToInt
+  , bleCharacteristicPropertiesFromBits
+  , bleCharacteristicPropertiesToBits
   , checkBleAdapter
   , startBleScan
+  , startFilteredBleScan
   , stopBleScan
   , connectBleDevice
   , disconnectBleDevice
+  , discoverBleServices
+  , readBleCharacteristic
+  , writeBleCharacteristic
+  , subscribeBleCharacteristic
+  , unsubscribeBleCharacteristic
+  , requestBleMtu
   , dispatchBleScanResult
   , dispatchBleConnectionEvent
+  , dispatchBleCharacteristicDiscovered
+  , dispatchBleGattCompletion
+  , dispatchBleNotification
   )
 import Hatter.Dialog
   ( DialogAction(..)
@@ -514,7 +536,207 @@ bleTests ffiBleState = testGroup "BLE"
       dispatchBleConnectionEvent bleState BleConnectionClosed
       result <- readIORef ref
       result @?= Just BleConnectionClosed
+
+  , testCase "bleGattOperationFromInt roundtrips all constructors" $ do
+      let allOperations =
+            [ BleGattDiscover, BleGattRead, BleGattWrite
+            , BleGattSubscribe, BleGattUnsubscribe, BleGattRequestMtu ]
+      mapM_ (\operation ->
+        bleGattOperationFromInt (bleGattOperationToInt operation) @?= Just operation
+        ) allOperations
+      bleGattOperationFromInt 6 @?= Nothing
+      bleGattOperationFromInt (-1) @?= Nothing
+
+  , testCase "characteristic property bits roundtrip every mask" $ do
+      mapM_ (\bits ->
+        bleCharacteristicPropertiesToBits (bleCharacteristicPropertiesFromBits bits)
+          @?= bits
+        ) [0 .. 15]
+      bleCharacteristicPropertiesFromBits 9
+        @?= [BleCharacteristicRead, BleCharacteristicNotify]
+
+  , testCase "desktop stub fails every GATT operation through the C bridge" $ do
+      -- No platform GATT implementation is registered on desktop, so
+      -- every operation must come back as BleGattFailed (-1) through
+      -- haskellOnBleGattResult; callers are never left waiting.
+      discoverRef <- newIORef (Nothing :: Maybe (Either BleGattError [BleDiscoveredCharacteristic]))
+      discoverBleServices ffiBleState (\result -> writeIORef discoverRef (Just result))
+      discoverResult <- readIORef discoverRef
+      discoverResult @?= Just (Left (BleGattFailed (-1)))
+
+      readRef <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      readBleCharacteristic ffiBleState testServiceUuid testCharacteristicUuid
+        (\result -> writeIORef readRef (Just result))
+      readResult <- readIORef readRef
+      readResult @?= Just (Left (BleGattFailed (-1)))
+
+      writeRef <- newIORef (Nothing :: Maybe (Either BleGattError ()))
+      writeBleCharacteristic ffiBleState testServiceUuid testCharacteristicUuid
+        BleWriteWithResponse "payload" (\result -> writeIORef writeRef (Just result))
+      writeResult <- readIORef writeRef
+      writeResult @?= Just (Left (BleGattFailed (-1)))
+
+      subscribeRef <- newIORef (Nothing :: Maybe (Either BleGattError ()))
+      subscribeBleCharacteristic ffiBleState testServiceUuid testCharacteristicUuid
+        (\_ -> pure ()) (\result -> writeIORef subscribeRef (Just result))
+      subscribeResult <- readIORef subscribeRef
+      subscribeResult @?= Just (Left (BleGattFailed (-1)))
+
+      mtuRef <- newIORef (Nothing :: Maybe (Either BleGattError Int))
+      requestBleMtu ffiBleState 247 (\result -> writeIORef mtuRef (Just result))
+      mtuResult <- readIORef mtuRef
+      mtuResult @?= Just (Left (BleGattFailed (-1)))
+
+  , testCase "second GATT operation while one is pending fails with BleGattBusy" $ do
+      -- A null-context BleState never receives the stub's completion,
+      -- so the first operation stays pending.
+      bleState <- newBleState
+      discoverBleServices bleState (\_ -> pure ())
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      readBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\result -> writeIORef ref (Just result))
+      result <- readIORef ref
+      result @?= Just (Left BleGattBusy)
+
+  , testCase "discovery accumulates streamed characteristics in order" $ do
+      bleState <- newBleState
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError [BleDiscoveredCharacteristic]))
+      discoverBleServices bleState (\result -> writeIORef ref (Just result))
+      dispatchBleCharacteristicDiscovered bleState testDiscoveredRead
+      dispatchBleCharacteristicDiscovered bleState testDiscoveredEcho
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattDiscover, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+      result <- readIORef ref
+      result @?= Just (Right [testDiscoveredRead, testDiscoveredEcho])
+
+  , testCase "read completion delivers the payload" $ do
+      bleState <- newBleState
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      readBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\result -> writeIORef ref (Just result))
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattRead, bgcStatusCode = 0
+        , bgcPayload = "hatter", bgcGrantedMtu = 0 }
+      result <- readIORef ref
+      result @?= Just (Right "hatter")
+
+  , testCase "mismatched completion fails the pending operation loudly" $ do
+      bleState <- newBleState
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      readBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\result -> writeIORef ref (Just result))
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattWrite, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+      result <- readIORef ref
+      result @?= Just (Left (BleGattFailed (-2)))
+
+  , testCase "subscription delivers notifications until unsubscribed" $ do
+      bleState <- newBleState
+      notificationsRef <- newIORef ([] :: [BS.ByteString])
+      subscribedRef <- newIORef (Nothing :: Maybe (Either BleGattError ()))
+      subscribeBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\payload -> modifyIORef' notificationsRef (++ [payload]))
+        (\result -> writeIORef subscribedRef (Just result))
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattSubscribe, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+      subscribed <- readIORef subscribedRef
+      subscribed @?= Just (Right ())
+      dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "one"
+      dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "two"
+      unsubscribeBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\_ -> pure ())
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattUnsubscribe, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+      -- After unsubscribing this is logged loudly but not delivered.
+      dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "three"
+      notifications <- readIORef notificationsRef
+      notifications @?= ["one", "two"]
+
+  , testCase "notifications match subscriptions case-insensitively" $ do
+      -- Apps subscribe with whatever case they wrote the UUID in;
+      -- Android dispatches notifications with lowercase UUIDs and iOS
+      -- with uppercase ones.
+      bleState <- newBleState
+      ref <- newIORef (Nothing :: Maybe BS.ByteString)
+      subscribeBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\payload -> writeIORef ref (Just payload))
+        (\_ -> pure ())
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattSubscribe, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+      dispatchBleNotification bleState
+        (BleServiceUuid "50db505c-8ac4-4738-8448-3b1d9cc09cc5")
+        (BleCharacteristicUuid "486f64c6-4b5f-4b3b-8aff-ede56a8b54f5")
+        "lowercase"
+      result <- readIORef ref
+      result @?= Just "lowercase"
+
+  , testCase "failed subscription removes the notification callback" $ do
+      bleState <- newBleState
+      notificationsRef <- newIORef (0 :: Int)
+      subscribedRef <- newIORef (Nothing :: Maybe (Either BleGattError ()))
+      subscribeBleCharacteristic bleState testServiceUuid testCharacteristicUuid
+        (\_ -> modifyIORef' notificationsRef (+ 1))
+        (\result -> writeIORef subscribedRef (Just result))
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattSubscribe, bgcStatusCode = 133
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+      subscribed <- readIORef subscribedRef
+      subscribed @?= Just (Left (BleGattFailed 133))
+      dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "x"
+      notifications <- readIORef notificationsRef
+      notifications @?= 0
+
+  , testCase "MTU completion delivers the granted value" $ do
+      bleState <- newBleState
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError Int))
+      requestBleMtu bleState 247 (\result -> writeIORef ref (Just result))
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattRequestMtu, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 247 }
+      result <- readIORef ref
+      result @?= Just (Right 247)
+
+  , testCase "completion without a pending operation is safe" $ do
+      bleState <- newBleState
+      -- Logs loudly to stderr but must not crash.
+      dispatchBleGattCompletion bleState BleGattCompletion
+        { bgcOperation = BleGattRead, bgcStatusCode = 0
+        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+
+  , testCase "startFilteredBleScan registers the scan callback" $ do
+      bleState <- newBleState
+      startFilteredBleScan bleState testServiceUuid (\_ -> pure ())
+      maybeCallback <- readIORef (blesScanCallback bleState)
+      case maybeCallback of
+        Nothing -> assertFailure "callback should be Just after startFilteredBleScan"
+        Just _  -> pure ()
   ]
+
+-- | Fixed UUIDs used by the GATT unit tests.
+testServiceUuid :: BleServiceUuid
+testServiceUuid = BleServiceUuid "50DB505C-8AC4-4738-8448-3B1D9CC09CC5"
+
+testCharacteristicUuid :: BleCharacteristicUuid
+testCharacteristicUuid = BleCharacteristicUuid "486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5"
+
+testDiscoveredRead :: BleDiscoveredCharacteristic
+testDiscoveredRead = BleDiscoveredCharacteristic
+  { bdcService        = testServiceUuid
+  , bdcCharacteristic = testCharacteristicUuid
+  , bdcProperties     = [BleCharacteristicRead]
+  }
+
+testDiscoveredEcho :: BleDiscoveredCharacteristic
+testDiscoveredEcho = BleDiscoveredCharacteristic
+  { bdcService        = testServiceUuid
+  , bdcCharacteristic = BleCharacteristicUuid "8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB"
+  , bdcProperties     = [BleCharacteristicWrite, BleCharacteristicNotify]
+  }
 
 -- | Dialog tests.
 dialogTests :: DialogState -> TestTree

--- a/test/Test/PlatformTests.hs
+++ b/test/Test/PlatformTests.hs
@@ -55,6 +55,8 @@ import Hatter.Ble
   , BleDeviceAddress(..)
   , BleServiceUuid(..)
   , BleCharacteristicUuid(..)
+  , BleCharacteristicValue(..)
+  , BleMtu(..)
   , BleConnectionEvent(..)
   , BleCharacteristicProperty(..)
   , BleDiscoveredCharacteristic(..)
@@ -564,7 +566,7 @@ bleTests ffiBleState = testGroup "BLE"
       discoverResult <- readIORef discoverRef
       discoverResult @?= Just (Left (BleGattFailed (-1)))
 
-      readRef <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      readRef <- newIORef (Nothing :: Maybe (Either BleGattError BleCharacteristicValue))
       readBleCharacteristic ffiBleState testServiceUuid testCharacteristicUuid
         (\result -> writeIORef readRef (Just result))
       readResult <- readIORef readRef
@@ -582,8 +584,8 @@ bleTests ffiBleState = testGroup "BLE"
       subscribeResult <- readIORef subscribeRef
       subscribeResult @?= Just (Left (BleGattFailed (-1)))
 
-      mtuRef <- newIORef (Nothing :: Maybe (Either BleGattError Int))
-      requestBleMtu ffiBleState 247 (\result -> writeIORef mtuRef (Just result))
+      mtuRef <- newIORef (Nothing :: Maybe (Either BleGattError BleMtu))
+      requestBleMtu ffiBleState (BleMtu 247) (\result -> writeIORef mtuRef (Just result))
       mtuResult <- readIORef mtuRef
       mtuResult @?= Just (Left (BleGattFailed (-1)))
 
@@ -592,7 +594,7 @@ bleTests ffiBleState = testGroup "BLE"
       -- so the first operation stays pending.
       bleState <- newBleState
       discoverBleServices bleState (\_ -> pure ())
-      ref <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BleCharacteristicValue))
       readBleCharacteristic bleState testServiceUuid testCharacteristicUuid
         (\result -> writeIORef ref (Just result))
       result <- readIORef ref
@@ -606,42 +608,42 @@ bleTests ffiBleState = testGroup "BLE"
       dispatchBleCharacteristicDiscovered bleState testDiscoveredEcho
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattDiscover, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
       result <- readIORef ref
       result @?= Just (Right [testDiscoveredRead, testDiscoveredEcho])
 
   , testCase "read completion delivers the payload" $ do
       bleState <- newBleState
-      ref <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BleCharacteristicValue))
       readBleCharacteristic bleState testServiceUuid testCharacteristicUuid
         (\result -> writeIORef ref (Just result))
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattRead, bgcStatusCode = 0
-        , bgcPayload = "hatter", bgcGrantedMtu = 0 }
+        , bgcPayload = "hatter", bgcGrantedMtu = BleMtu 0 }
       result <- readIORef ref
       result @?= Just (Right "hatter")
 
   , testCase "mismatched completion fails the pending operation loudly" $ do
       bleState <- newBleState
-      ref <- newIORef (Nothing :: Maybe (Either BleGattError BS.ByteString))
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BleCharacteristicValue))
       readBleCharacteristic bleState testServiceUuid testCharacteristicUuid
         (\result -> writeIORef ref (Just result))
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattWrite, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
       result <- readIORef ref
       result @?= Just (Left (BleGattFailed (-2)))
 
   , testCase "subscription delivers notifications until unsubscribed" $ do
       bleState <- newBleState
-      notificationsRef <- newIORef ([] :: [BS.ByteString])
+      notificationsRef <- newIORef ([] :: [BleCharacteristicValue])
       subscribedRef <- newIORef (Nothing :: Maybe (Either BleGattError ()))
       subscribeBleCharacteristic bleState testServiceUuid testCharacteristicUuid
         (\payload -> modifyIORef' notificationsRef (++ [payload]))
         (\result -> writeIORef subscribedRef (Just result))
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattSubscribe, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
       subscribed <- readIORef subscribedRef
       subscribed @?= Just (Right ())
       dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "one"
@@ -650,7 +652,7 @@ bleTests ffiBleState = testGroup "BLE"
         (\_ -> pure ())
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattUnsubscribe, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
       -- After unsubscribing this is logged loudly but not delivered.
       dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "three"
       notifications <- readIORef notificationsRef
@@ -661,13 +663,13 @@ bleTests ffiBleState = testGroup "BLE"
       -- Android dispatches notifications with lowercase UUIDs and iOS
       -- with uppercase ones.
       bleState <- newBleState
-      ref <- newIORef (Nothing :: Maybe BS.ByteString)
+      ref <- newIORef (Nothing :: Maybe BleCharacteristicValue)
       subscribeBleCharacteristic bleState testServiceUuid testCharacteristicUuid
         (\payload -> writeIORef ref (Just payload))
         (\_ -> pure ())
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattSubscribe, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
       dispatchBleNotification bleState
         (BleServiceUuid "50db505c-8ac4-4738-8448-3b1d9cc09cc5")
         (BleCharacteristicUuid "486f64c6-4b5f-4b3b-8aff-ede56a8b54f5")
@@ -684,7 +686,7 @@ bleTests ffiBleState = testGroup "BLE"
         (\result -> writeIORef subscribedRef (Just result))
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattSubscribe, bgcStatusCode = 133
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
       subscribed <- readIORef subscribedRef
       subscribed @?= Just (Left (BleGattFailed 133))
       dispatchBleNotification bleState testServiceUuid testCharacteristicUuid "x"
@@ -693,20 +695,20 @@ bleTests ffiBleState = testGroup "BLE"
 
   , testCase "MTU completion delivers the granted value" $ do
       bleState <- newBleState
-      ref <- newIORef (Nothing :: Maybe (Either BleGattError Int))
-      requestBleMtu bleState 247 (\result -> writeIORef ref (Just result))
+      ref <- newIORef (Nothing :: Maybe (Either BleGattError BleMtu))
+      requestBleMtu bleState (BleMtu 247) (\result -> writeIORef ref (Just result))
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattRequestMtu, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 247 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 247 }
       result <- readIORef ref
-      result @?= Just (Right 247)
+      result @?= Just (Right (BleMtu 247))
 
   , testCase "completion without a pending operation is safe" $ do
       bleState <- newBleState
       -- Logs loudly to stderr but must not crash.
       dispatchBleGattCompletion bleState BleGattCompletion
         { bgcOperation = BleGattRead, bgcStatusCode = 0
-        , bgcPayload = BS.empty, bgcGrantedMtu = 0 }
+        , bgcPayload = "", bgcGrantedMtu = BleMtu 0 }
 
   , testCase "startFilteredBleScan registers the scan callback" $ do
       bleState <- newBleState
@@ -719,10 +721,10 @@ bleTests ffiBleState = testGroup "BLE"
 
 -- | Fixed UUIDs used by the GATT unit tests.
 testServiceUuid :: BleServiceUuid
-testServiceUuid = BleServiceUuid "50DB505C-8AC4-4738-8448-3B1D9CC09CC5"
+testServiceUuid = "50DB505C-8AC4-4738-8448-3B1D9CC09CC5"
 
 testCharacteristicUuid :: BleCharacteristicUuid
-testCharacteristicUuid = BleCharacteristicUuid "486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5"
+testCharacteristicUuid = "486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5"
 
 testDiscoveredRead :: BleDiscoveredCharacteristic
 testDiscoveredRead = BleDiscoveredCharacteristic
@@ -734,7 +736,7 @@ testDiscoveredRead = BleDiscoveredCharacteristic
 testDiscoveredEcho :: BleDiscoveredCharacteristic
 testDiscoveredEcho = BleDiscoveredCharacteristic
   { bdcService        = testServiceUuid
-  , bdcCharacteristic = BleCharacteristicUuid "8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB"
+  , bdcCharacteristic = "8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB"
   , bdcProperties     = [BleCharacteristicWrite, BleCharacteristicNotify]
   }
 

--- a/test/android/ble.sh
+++ b/test/android/ble.sh
@@ -145,6 +145,60 @@ if [ "$BLE_SIM" = "1" ]; then
     assert_logcat "$PERIPHERAL_LOG" "PERIPHERAL_CONNECTED" \
         "virtual peripheral registered the connection"
 
+    # Discover the peripheral's GATT services from hatter code.
+    # Android reports UUIDs lowercase, hence the lowercase patterns.
+    tap_button "Discover" || { echo "WARNING: could not tap Discover"; }
+    wait_for_logcat "BLE discovery complete:" 60 || true
+    LOGCAT_DISCOVER="$WORK_DIR/ble_logcat_discover.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_DISCOVER" 2>&1 || true
+    assert_logcat "$LOGCAT_DISCOVER" \
+        "BLE discovered: 50db505c-8ac4-4738-8448-3b1d9cc09cc5 486f64c6-4b5f-4b3b-8aff-ede56a8b54f5" \
+        "discovery reports the test service's read characteristic"
+    assert_logcat "$LOGCAT_DISCOVER" \
+        "BLE discovered: .*8cb7c0f4-3b97-4653-9e4f-6f02bf97c7fb .*BleCharacteristicNotify" \
+        "discovery reports the echo characteristic with notify support"
+    assert_logcat "$LOGCAT_DISCOVER" "BLE discovery complete:" \
+        "discovery completed"
+
+    # Negotiate a larger MTU (the granted value depends on the stack).
+    tap_button "Request Mtu" || { echo "WARNING: could not tap Request Mtu"; }
+    wait_for_logcat "BLE mtu granted:" 30 || true
+    LOGCAT_MTU="$WORK_DIR/ble_logcat_mtu.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_MTU" 2>&1 || true
+    assert_logcat "$LOGCAT_MTU" "BLE mtu granted:" \
+        "MTU negotiation completed"
+
+    # Subscribe to the echo characteristic's notifications, then write
+    # to it: the peripheral echoes the bytes back as a notification, so
+    # one round trip covers write, subscribe and notification dispatch.
+    tap_button "Subscribe" || { echo "WARNING: could not tap Subscribe"; }
+    wait_for_logcat "BLE subscribed" 30 || true
+    LOGCAT_SUBSCRIBE="$WORK_DIR/ble_logcat_subscribe.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_SUBSCRIBE" 2>&1 || true
+    assert_logcat "$LOGCAT_SUBSCRIBE" "BLE subscribed" \
+        "hatter subscribed to the echo characteristic"
+
+    # Read the fixed characteristic: bytes of "hatter".
+    tap_button "Read" || { echo "WARNING: could not tap Read"; }
+    wait_for_logcat "BLE read result: \[104,97,116,116,101,114\]" 30 || true
+    LOGCAT_READ="$WORK_DIR/ble_logcat_read.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_READ" 2>&1 || true
+    assert_logcat "$LOGCAT_READ" "BLE read result: \[104,97,116,116,101,114\]" \
+        "hatter read the peripheral's characteristic value"
+
+    # Write "hatter!" and expect it echoed back as a notification.
+    tap_button "Write" || { echo "WARNING: could not tap Write"; }
+    wait_for_logcat "BLE notification: \[104,97,116,116,101,114,33\]" 30 || true
+    LOGCAT_WRITE="$WORK_DIR/ble_logcat_write.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_WRITE" 2>&1 || true
+    assert_logcat "$LOGCAT_WRITE" "BLE write completed" \
+        "hatter's characteristic write was acknowledged"
+    assert_logcat "$LOGCAT_WRITE" "BLE notification: \[104,97,116,116,101,114,33\]" \
+        "hatter received the echoed notification"
+    # Host-side proof: the peripheral saw the write arrive.
+    assert_logcat "$PERIPHERAL_LOG" "ECHO_WRITE: 68617474657221" \
+        "virtual peripheral received the written bytes"
+
     # Disconnect again from hatter code.
     tap_button "Disconnect" || { echo "WARNING: could not tap Disconnect"; }
     wait_for_logcat "BLE connection event: BleConnectionClosed" 30 || true
@@ -152,6 +206,15 @@ if [ "$BLE_SIM" = "1" ]; then
     "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_DISCONNECT" 2>&1 || true
     assert_logcat "$LOGCAT_DISCONNECT" "BLE connection event: BleConnectionClosed" \
         "hatter disconnected from the simulated peripheral"
+
+    # Scan filtered by the test service UUID: the peripheral advertises
+    # it (auto-restarted after the disconnect), so it must be found.
+    tap_button "Filtered Scan" || { echo "WARNING: could not tap Filtered Scan"; }
+    wait_for_logcat "BLE filtered scan result:.*HatterBleSim" 90 || true
+    LOGCAT_FILTERED="$WORK_DIR/ble_logcat_filtered.txt"
+    "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_FILTERED" 2>&1 || true
+    assert_logcat "$LOGCAT_FILTERED" "BLE filtered scan result:.*HatterBleSim" \
+        "service-UUID-filtered scan found the peripheral"
 else
     sleep 1
 fi

--- a/test/android/ble_peripheral.py
+++ b/test/android/ble_peripheral.py
@@ -3,10 +3,21 @@
 #
 # Connects to the emulator's netsim virtual radio (gRPC packet
 # streamer, discovered through netsim.ini in XDG_RUNTIME_DIR/TMPDIR)
-# and advertises as a connectable peripheral named "HatterBleSim" with
-# a small GATT service.  The emulator's Bluetooth stack receives these
-# advertisements exactly as it would from a physical device, so the
-# hatter BLE scan and connect paths are exercised end to end.
+# and advertises as a connectable peripheral named "HatterBleSim".
+# The emulator's Bluetooth stack receives these advertisements exactly
+# as it would from a physical device, so the hatter BLE scan, connect
+# and GATT paths are exercised end to end.
+#
+# GATT layout (UUIDs mirrored in test/BleDemoMain.hs):
+#   service 50DB505C-...:
+#     486F64C6-... : readable, value b'hatter'
+#     8CB7C0F4-... : write + notify; written bytes are echoed back as
+#                    a notification (exercises write and subscribe in
+#                    one round trip)
+#
+# The advertisement carries the service UUID (so service-UUID scan
+# filters match) and the device name travels in the scan response:
+# both together exceed the 31-byte legacy advertising limit.
 #
 # Decision: Google's bumble Python stack + the emulator's netsim
 # virtual controller were chosen to simulate BLE traffic.
@@ -19,23 +30,25 @@
 #
 # Usage: ble_peripheral.py [transport]   (default: android-netsim)
 #
-# Prints ADVERTISING_STARTED once the peripheral is on the air and
-# PERIPHERAL_CONNECTED when a central connects; the test harness waits
-# for these markers.
+# Prints ADVERTISING_STARTED once the peripheral is on the air,
+# PERIPHERAL_CONNECTED when a central connects, and ECHO_WRITE for
+# every write to the echo characteristic; the test harness waits for
+# these markers.
 
 import asyncio
 import sys
 
-from bumble.core import AdvertisingData
+from bumble.core import UUID, AdvertisingData
 from bumble.device import Device
-from bumble.gatt import Characteristic, Service
+from bumble.gatt import Characteristic, CharacteristicValue, Service
 from bumble.hci import Address
 from bumble.transport import open_transport
 
 PERIPHERAL_NAME = 'HatterBleSim'
 PERIPHERAL_ADDRESS = 'F0:F1:F2:F3:F4:F5'
 TEST_SERVICE_UUID = '50DB505C-8AC4-4738-8448-3B1D9CC09CC5'
-TEST_CHARACTERISTIC_UUID = '486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5'
+TEST_READ_CHARACTERISTIC_UUID = '486F64C6-4B5F-4B3B-8AFF-EDE56A8B54F5'
+TEST_ECHO_CHARACTERISTIC_UUID = '8CB7C0F4-3B97-4653-9E4F-6F02BF97C7FB'
 
 
 async def run_peripheral(transport_name):
@@ -47,16 +60,32 @@ async def run_peripheral(transport_name):
             hci_transport.source,
             hci_transport.sink,
         )
+
+        echo_characteristic = Characteristic(
+            TEST_ECHO_CHARACTERISTIC_UUID,
+            Characteristic.Properties.WRITE | Characteristic.Properties.NOTIFY,
+            Characteristic.WRITEABLE,
+        )
+
+        async def on_echo_write(connection, value):
+            print(f'ECHO_WRITE: {value.hex()}', flush=True)
+            # Echo the written bytes back as a notification so the
+            # test covers write and notify in one round trip.
+            await device.gatt_server.notify_subscribers(echo_characteristic, value)
+
+        echo_characteristic.value = CharacteristicValue(write=on_echo_write)
+
         device.add_service(
             Service(
                 TEST_SERVICE_UUID,
                 [
                     Characteristic(
-                        TEST_CHARACTERISTIC_UUID,
+                        TEST_READ_CHARACTERISTIC_UUID,
                         Characteristic.Properties.READ,
                         Characteristic.READABLE,
                         b'hatter',
-                    )
+                    ),
+                    echo_characteristic,
                 ],
             )
         )
@@ -65,12 +94,25 @@ async def run_peripheral(transport_name):
                 [
                     (AdvertisingData.FLAGS, bytes([0x06])),
                     (
-                        AdvertisingData.COMPLETE_LOCAL_NAME,
-                        PERIPHERAL_NAME.encode('utf-8'),
+                        AdvertisingData.COMPLETE_LIST_OF_128_BIT_SERVICE_CLASS_UUIDS,
+                        UUID(TEST_SERVICE_UUID).to_bytes(),
                     ),
                 ]
             )
         )
+        # The name travels in the scan response: it does not fit in the
+        # 31-byte advertisement next to a 128-bit service UUID list.
+        scan_response = bytes(
+            AdvertisingData(
+                [
+                    (
+                        AdvertisingData.COMPLETE_LOCAL_NAME,
+                        PERIPHERAL_NAME.encode('utf-8'),
+                    )
+                ]
+            )
+        )
+        device.scan_response_data = scan_response
         device.on(
             'connection',
             lambda connection: print(f'PERIPHERAL_CONNECTED: {connection}', flush=True),
@@ -78,7 +120,10 @@ async def run_peripheral(transport_name):
         await device.power_on()
         # auto_restart: resume advertising after a central disconnects,
         # so a retried test attempt finds the peripheral again.
-        await device.start_advertising(auto_restart=True)
+        await device.start_advertising(
+            auto_restart=True,
+            scan_response_data=scan_response,
+        )
         print('ADVERTISING_STARTED', flush=True)
         await asyncio.get_running_loop().create_future()
 

--- a/test/ios/ble.sh
+++ b/test/ios/ble.sh
@@ -21,12 +21,22 @@ EXIT_CODE=0
 start_app "$BLE_APP" "ble" --autotest --autotest-ble
 wait_for_render "ble" --autotest
 wait_for_log "$STREAM_LOG" "BLE adapter:" 30 || true
-wait_for_log "$STREAM_LOG" "BLE connection event:" 60 || true
+wait_for_log "$STREAM_LOG" "BLE mtu failed:" 60 || true
 collect_logs "ble"
 
 assert_log "$FULL_LOG" "BLE adapter:" "BLE adapter check logged"
 assert_log "$FULL_LOG" "BLE connection event: BleConnectionFailed" \
     "connect on simulator fails visibly through the bridge"
+assert_log "$FULL_LOG" "BLE discovery failed:" \
+    "discovery on simulator fails visibly through the bridge"
+assert_log "$FULL_LOG" "BLE read failed:" \
+    "read on simulator fails visibly through the bridge"
+assert_log "$FULL_LOG" "BLE write failed:" \
+    "write on simulator fails visibly through the bridge"
+assert_log "$FULL_LOG" "BLE subscribe failed:" \
+    "subscribe on simulator fails visibly through the bridge"
+assert_log "$FULL_LOG" "BLE mtu failed:" \
+    "MTU request on simulator fails visibly through the bridge"
 assert_log "$FULL_LOG" "createNode" "createNode called (app renders)"
 assert_log "$FULL_LOG" "setRoot" "setRoot"
 


### PR DESCRIPTION
## What

The rest of #108, scoped to what the kbeacon-ota-tool needs to fully implement its deferred features ([kbeacon-ota-tool#2](https://github.com/jappeace/kbeacon-ota-tool/pull/2): GATT connect + `modifyConfig` write, beacon battery read, service UUID scan filter). The KKM SDK the original Kotlin app used is, underneath, exactly these primitives: connect (already landed in #234), MTU negotiation, notify subscription, framed characteristic writes answered by notifications, and parameter reads.

### API (`Hatter.Ble`)

- `discoverBleServices`: every service/characteristic pair with its properties, one list on completion
- `readBleCharacteristic` / `writeBleCharacteristic` (`BleWriteWithResponse` / `BleWriteWithoutResponse`, `ByteString` payloads)
- `subscribeBleCharacteristic` / `unsubscribeBleCharacteristic` with streaming per-characteristic notification callbacks
- `requestBleMtu` (Android negotiates; iOS reports the system-negotiated value)
- `startFilteredBleScan` (service-UUID advertisement filter)
- One GATT operation in flight at a time (matching both platform stacks); a second fails immediately with `BleGattBusy`. Every operation completes exactly once with `Either BleGattError`; desktop stubs fail visibly through the real bridge round trip, never hang.
- Notification callbacks are keyed case-insensitively: Android reports UUIDs lowercase, iOS uppercase. Found while reviewing, pinned by a regression test.

Implemented on Android (`BluetoothGatt`, CCCD writes, `ScanFilter`) and iOS (`CBPeripheralDelegate`, with the pending-read bookkeeping CoreBluetooth needs since reads and notifications share one delegate callback).

### Integration test, same rigour as the connect work

The virtual peripheral now advertises its service UUID (the name moved to the scan response, both together exceed the 31-byte legacy advertisement limit) and serves a write+notify **echo characteristic** next to the readable one. `test/android/ble.sh` asserts over the virtual radio, in one connected session:

1. discovery lists both characteristics with their properties
2. MTU negotiation completes
3. subscribe succeeds
4. read returns the bytes of `"hatter"`
5. a write of `"hatter!"` is acknowledged and comes back as a notification, asserted on **both ends**: hatter's Haskell callback log and the peripheral's own `ECHO_WRITE` log
6. after disconnect, a **service-UUID-filtered scan** still finds the peripheral

On the iOS simulator (no CoreBluetooth exists there), `--autotest-ble` now drives every GATT operation and asserts each fails visibly instead of hanging.

## Verification done locally

- `cabal build` clean, full test suite passes (13 new unit tests: operation/property code roundtrips, the busy guard, discovery accumulation order, completion mismatch handling, subscription lifecycle incl. failed-subscribe cleanup and case-insensitive matching, MTU delivery, and the desktop stub failing all five operations through the actual C bridge)
- The BLE APK (new Java GATT code + JNI bridge) cross-compiles
- The extended bumble peripheral runs against a real standalone netsimd (`ADVERTISING_STARTED` with the split advertisement/scan-response layout)
- In-guest GATT behaviour is CI-only as usual (no KVM locally, docs/ble-emulator-simulation.md)

With this merged, the OTA tool can implement `connectEnhanced`-equivalent auth, `modifyConfig` writes and battery reads in Haskell over these primitives. Remaining in #108 beyond OTA needs: nothing that I can see; suggest closing it when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)